### PR TITLE
Update bson dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 url = "2.1"
-bson = "1.2.2"
+bson = { version="2.0", features = ["chrono-0_4"]}
 log = "0.4"
 chrono = "0.4.19"
 sqlx = {version="0.5.1", features = ["sqlite", "macros", "runtime-actix-rustls"] }


### PR DESCRIPTION
We have to specialize the `from_bson_array` macro for `DateTimeArray` because bson has its own datetime type that doesn't support `FromIterator`