### PR TITLE
build: Use SPDX Licence format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "astarte_sdk"
 version = "0.1.0"
 authors = ["Riccardo Binetti"]
 edition = "2018"
-license = "Apache 2.0"
+license = "Apache-2.0"
 repository = "https://github.com/astarte-platform/astarte-device-sdk-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This is useful for cargo-bitbake tool

Relate-to: https://github.com/astarte-platform/astarte-device-sdk-rust/pull/16
Bug: https://github.com/astarte-platform/astarte-device-sdk-rust/issues/20
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>