### PR TITLE
Protocol: fix behavior after device `emptyCache` message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,9 +146,6 @@ impl AstarteSdk {
                             if !p.session_present {
                                 self.send_introspection().await?;
                                 self.send_emptycache().await?;
-                                if let Some(database) = &self.database {
-                                    database.clear().await?;
-                                }
                             }
                         }
                         rumqttc::Packet::Publish(p) => {
@@ -156,6 +153,7 @@ impl AstarteSdk {
 
                             if let Some((_, _, interface, path)) = topic {
                                 if interface == "control" && path == "/consumer/properties" {
+                                    // TODO: implement consumer purge properties
                                     continue;
                                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod types;
 
 use bson::{to_document, Bson};
 use database::AstarteDatabase;
+use database::StoredProp;
 use itertools::Itertools;
 use log::{debug, error, trace};
 use rumqttc::EventLoop;
@@ -146,6 +147,7 @@ impl AstarteSdk {
                             if !p.session_present {
                                 self.send_introspection().await?;
                                 self.send_emptycache().await?;
+                                self.send_device_owned_properties().await?;
                             }
                         }
                         rumqttc::Packet::Publish(p) => {
@@ -248,6 +250,40 @@ impl AstarteSdk {
                 introspection.clone(),
             )
             .await?;
+        Ok(())
+    }
+
+    async fn send_device_owned_properties(&self) -> Result<(), AstarteError> {
+        if let Some(database) = &self.database {
+            let properties = database.load_all_props().await?;
+            // publish only device-owned properties...
+            let device_owned_properties: Vec<StoredProp> = properties
+                .into_iter()
+                .filter(|prop| {
+                    self.interfaces.get_ownership(&prop.interface)
+                        == Some(crate::interface::Ownership::Device)
+                })
+                .collect();
+            for prop in device_owned_properties {
+                let topic = format!("{}/{}{}", self.client_id(), prop.interface, prop.path);
+                if let Some(version_major) = self
+                    .interfaces
+                    .get_property_major(&prop.interface, &prop.path)
+                {
+                    // ..and only if they are up-to-date
+                    if version_major == prop.interface_major {
+                        debug!(
+                            "sending device-owned property = {}{}",
+                            prop.interface, prop.path
+                        );
+                        self.client
+                            .publish(topic, rumqttc::QoS::ExactlyOnce, false, prop.value)
+                            .await?;
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Do not clear the properties database after sending an  `emptyCache` message. This is a bug which may lead to device information loss. Instead, send all device-owned properties, as in e.g. the [Java](https://github.com/astarte-platform/astarte-device-sdk-java/blob/3de54b55d6074d62e468c2cef7030f791426fae3/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java#L466-L474) or [Go](https://github.com/astarte-platform/astarte-device-sdk-go/blob/bf45b7921f32edf371a85f5be5a2bfcf3d6b515c/device/protocol_mqtt_v1.go#L187-L233) SDKs. 

In order to clean (parts) of the properties database, handling of purge properties messages should be implemented, as stated in the [Astarte doc](https://docs.astarte-platform.org/latest/080-mqtt-v1-protocol.html#purge-properties).