### PR TITLE
docker: Add helper recipe

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Copyright 2022 Huawei OSTC
+#
+# SPDX-License-Identifier: CC0-1.0
+
+#.dockerignore
+.git/
+#.gitignore
+/target
+Cargo.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+#!/bin/echo docker build . -f
+# -*- coding: utf-8 -*-
+# Copyright 2022 Huawei OTC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM rust:bullseye
+LABEL maintainer="Philippe Coval (philippe.coval@astrolabe.coop)"
+
+RUN echo "#log: Setup system" \
+  && set -x \
+  && apt-get update \
+  && apt-get install -y \
+      --no-install-recommends \
+     ca-certificates \
+     libssl-dev \
+     pkg-config \
+  && apt-get upgrade -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && date -u
+
+ARG project=astarte-device-sdk-rust
+ARG workdir="/local/src/${project}"
+
+COPY . "${workdir}/"
+WORKDIR "${workdir}"
+RUN echo "#log: ${project}: Building sources" \
+  && set -x \
+  && export OPENSSL_NO_VENDOR=1 \
+  && cargo build  \
+  && cargo install --path . || echo "warning: no default install rule" \
+  && cargo install --examples --path . \
+  && date -u
+
+WORKDIR "${workdir}"
+ENTRYPOINT [ "cargo" ]
+CMD [ "run", "--example", "simple", "--" , "--help" ]


### PR DESCRIPTION
My distro RUST setup is not running it out of the box
so I used a more recent one.

For the record here is is the observed error:

  error[E0599]: no variant or associated item named `OutOfMemory` found for enum `ErrorKind` in the current scope
  -> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/sqlx-core-0.5.10/src/sqlite/connection/establish.rs:107:32

Relate-to: https://github.com/astarte-platform/astarte-device-sdk-rust/issues/20#
Signed-off-by: Philippe Coval <philippe.coval@astrolabe.coop>