### PR TITLE
Update interfaces with the client already connected

### DIFF
--- a/examples/database.rs
+++ b/examples/database.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), AstarteError> {
         .database(db)
         .build();
 
-    let mut device = astarte_sdk::AstarteSdk::new(&sdk_options).await?;
+    let (device, mut eventloop) = astarte_sdk::AstarteSdk::new(sdk_options).await?;
 
     let w = device.clone();
     tokio::task::spawn(async move {
@@ -93,7 +93,7 @@ async fn main() -> Result<(), AstarteError> {
     });
 
     loop {
-        match device.poll().await {
+        match device.poll(&mut eventloop).await {
             Ok(data) => {
                 println!("incoming: {:?}", data);
             }

--- a/examples/datatypes.rs
+++ b/examples/datatypes.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), AstarteError> {
         .interface_directory("./examples/interfaces")?
         .build();
 
-    let mut device = astarte_sdk::AstarteSdk::new(&sdk_options).await?;
+    let (device, mut eventloop) = astarte_sdk::AstarteSdk::new(sdk_options).await?;
 
     let w = device.clone();
 
@@ -115,7 +115,7 @@ async fn main() -> Result<(), AstarteError> {
     });
 
     loop {
-        match device.poll().await {
+        match device.poll(&mut eventloop).await {
             Ok(data) => {
                 println!("incoming: {:?}", data);
             }

--- a/examples/object.rs
+++ b/examples/object.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), AstarteError> {
         .interface_directory("./examples/interfaces")?
         .build();
 
-    let mut device = astarte_sdk::AstarteSdk::new(&sdk_options).await?;
+    let (device, mut eventloop) = astarte_sdk::AstarteSdk::new(sdk_options).await?;
 
     let w = device.clone();
 
@@ -96,7 +96,7 @@ async fn main() -> Result<(), AstarteError> {
     });
 
     loop {
-        match device.poll().await {
+        match device.poll(&mut eventloop).await {
             Ok(data) => {
                 println!("incoming: {:?}", data);
             }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), AstarteError> {
         .database(db)
         .build();
 
-    let mut device = astarte_sdk::AstarteSdk::new(&sdk_options).await?;
+    let (device, mut eventloop) = astarte_sdk::AstarteSdk::new(sdk_options).await?;
 
     let w = device.clone();
     tokio::task::spawn(async move {
@@ -73,7 +73,7 @@ async fn main() -> Result<(), AstarteError> {
     });
 
     loop {
-        match device.poll().await {
+        match device.poll(&mut eventloop).await {
             Ok(data) => {
                 println!("incoming: {:?}", data);
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -165,7 +165,7 @@ impl AstarteDatabase for AstarteSqliteDatabase {
 impl AstarteSqliteDatabase {
     /// Creates an sqlite database for the astarte client
     /// URI should follow sqlite's convention, read [SqliteConnectOptions] for more details
-    pub async fn new(uri: &str) -> Result<Self, crate::builder::AstarteBuilderError> {
+    pub async fn new(uri: &str) -> Result<Self, AstarteError> {
         let options = SqliteConnectOptions::from_str(uri)?.create_if_missing(true);
 
         let conn = SqlitePoolOptions::new().connect_with(options).await?;

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -20,9 +20,11 @@
 
 use std::collections::HashMap;
 
+use log::debug;
+
 use crate::{interface::traits::Mapping, types::AstarteType, AstarteError, Interface};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Interfaces {
     pub interfaces: HashMap<String, Interface>,
 }
@@ -278,21 +280,51 @@ impl Interfaces {
 
         Ok(())
     }
+
+    /// Add an interface from a json file
+    pub fn add_interface_file(&mut self, file_path: &str) -> Result<(), AstarteError> {
+        let interface = Interface::from_file(file_path.as_ref())?;
+        let name = crate::interface::traits::Interface::name(&interface);
+        debug!("Added interface {}", name);
+        self.interfaces.insert(name.to_owned(), interface);
+        Ok(())
+    }
+
+    /// Add all json interface description inside a specified directory
+    pub fn add_interface_directory(
+        &mut self,
+        interfaces_directory: &str,
+    ) -> Result<(), AstarteError> {
+        let interface_files = std::fs::read_dir(std::path::Path::new(interfaces_directory))?;
+        let it = interface_files.filter_map(Result::ok).filter(|f| {
+            if let Some(ext) = f.path().extension() {
+                ext == "json"
+            } else {
+                false
+            }
+        });
+
+        for f in it {
+            self.add_interface_file(&f.path().to_string_lossy())?;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod test {
     use std::{collections::HashMap, convert::TryInto, str::FromStr};
 
-    use crate::{
-        builder::AstarteOptions, interface::traits::Interface, types::AstarteType, AstarteSdk,
-    };
+    use crate::{interface::traits::Interface, types::AstarteType, AstarteSdk};
+
+    use super::Interfaces;
 
     #[test]
     fn test_individual() {
-        let mut options = AstarteOptions::new("test", "test", "test", "test");
-        options.interface_directory("examples/interfaces/").unwrap();
-        let ifa = super::Interfaces::new(options.interfaces);
+        let mut ifa = Interfaces::default();
+        ifa.add_interface_directory(&"examples/interfaces/".to_string())
+            .unwrap();
 
         let buf = AstarteSdk::serialize_individual(AstarteType::Boolean(true), None).unwrap();
 
@@ -341,9 +373,9 @@ mod test {
 
     #[test]
     fn test_object() {
-        let mut options = AstarteOptions::new("test", "test", "test", "test");
-        options.interface_directory("examples/interfaces/").unwrap();
-        let ifa = super::Interfaces::new(options.interfaces);
+        let mut ifa = Interfaces::default();
+        ifa.add_interface_directory(&"examples/interfaces/".to_string())
+            .unwrap();
 
         let mut obj: std::collections::HashMap<&str, AstarteType> =
             std::collections::HashMap::new();
@@ -427,9 +459,9 @@ mod test {
 
     #[test]
     fn test_individual_recv() {
-        let mut options = AstarteOptions::new("test", "test", "test", "test");
-        options.interface_directory("examples/interfaces/").unwrap();
-        let ifa = super::Interfaces::new(options.interfaces);
+        let mut ifa = Interfaces::default();
+        ifa.add_interface_directory(&"examples/interfaces/".to_string())
+            .unwrap();
 
         let boolean_buf =
             AstarteSdk::serialize_individual(AstarteType::Boolean(true), None).unwrap();


### PR DESCRIPTION
Add method to update interfaces with the client already open
A refactoring was needed to add interior mutability to the astarte sdk struct, now the struct AstarteOptions is saved inside AstarteSdk