### PR TITLE
Remove thread::sleep from async code

### DIFF
--- a/examples/database.rs
+++ b/examples/database.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), AstarteError> {
             .await
             .unwrap();
 
-            std::thread::sleep(std::time::Duration::from_millis(100));
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
             w.send(
                 "org.astarte-platform.genericsensors.AvailableSensors",
@@ -78,7 +78,7 @@ async fn main() -> Result<(), AstarteError> {
             .await
             .unwrap();
 
-            std::thread::sleep(std::time::Duration::from_millis(100));
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
             w.send(
                 "org.astarte-platform.genericsensors.AvailableSensors",
@@ -88,7 +88,7 @@ async fn main() -> Result<(), AstarteError> {
             .await
             .unwrap();
 
-            std::thread::sleep(std::time::Duration::from_millis(1000));
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     });
 

--- a/examples/deviceproperties.rs
+++ b/examples/deviceproperties.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<(), AstarteError> {
             .await
             .unwrap();
 
-            std::thread::sleep(std::time::Duration::from_millis(1000));
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
             w.send(
                 "org.astarte-platform.genericsensors.AvailableSensors",
@@ -75,7 +75,7 @@ async fn main() -> Result<(), AstarteError> {
             .await
             .unwrap();
 
-            std::thread::sleep(std::time::Duration::from_millis(1000));
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     });
 

--- a/examples/object.rs
+++ b/examples/object.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<(), AstarteError> {
             .await
             .unwrap();
 
-            tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     });
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), AstarteError> {
 
             i += 11;
 
-            std::thread::sleep(std::time::Duration::from_millis(1000));
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     });
 


### PR DESCRIPTION
It is not optimal to use std::thread in async