### PR TITLE
Replace nightly with beta for the CI

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         toolchain:
         - stable
-        - nightly
+        - beta
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -78,7 +78,7 @@ jobs:
       matrix:
         toolchain:
         - stable
-        - nightly
+        - beta
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
Due to instability, replace nightly with beta for the CI