### PR TITLE
Fix handling of int32 payload on LongInteger mapping

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -517,6 +517,13 @@ mod test {
             &boolean_buf,
         )
         .unwrap();
+
+        ifa.validate_receive(
+            "org.astarte-platform.genericsensors.SamplingRate",
+            "/nope/samplingPeriod",
+            &integer_buf,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,7 +778,8 @@ mod utils {
 mod test {
     use chrono::{TimeZone, Utc};
 
-    use crate::{types::AstarteType, AstarteSdk};
+    use crate::interface::MappingType;
+    use crate::{types::AstarteType, Aggregation, AstarteSdk};
 
     fn do_vecs_match(a: &[u8], b: &[u8]) -> bool {
         let matching = a.iter().zip(b.iter()).filter(|&(a, b)| a == b).count();
@@ -838,5 +839,32 @@ mod test {
         let s = crate::utils::extract_set_properties(&bdata);
 
         assert!(s.join(";").as_bytes() == example);
+    }
+
+    #[test]
+    fn test_integer_longinteger_compatibility() {
+        let integer_buf =
+            AstarteSdk::deserialize(&[12, 0, 0, 0, 16, 118, 0, 16, 14, 0, 0, 0]).unwrap();
+        if let Aggregation::Individual(astarte_type) = integer_buf {
+            assert_eq!(astarte_type, MappingType::LongInteger);
+        } else {
+            panic!("Deserialization in not individual");
+        }
+    }
+
+    #[test]
+    fn test_bson_serialization() {
+        let og_value: i64 = 3600;
+        let buf = AstarteSdk::serialize_individual(og_value, None).unwrap();
+        if let Aggregation::Individual(astarte_type) = AstarteSdk::deserialize(&buf).unwrap() {
+            assert_eq!(astarte_type, AstarteType::LongInteger(3600));
+            if let AstarteType::LongInteger(value) = astarte_type {
+                assert_eq!(value, 3600);
+            } else {
+                panic!("Astarte Type is not LongInteger");
+            }
+        } else {
+            panic!("Deserialization in not individual");
+        }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,6 +22,7 @@ use std::convert::TryInto;
 
 use bson::{Binary, Bson};
 
+use crate::interface::MappingType;
 use crate::AstarteError;
 
 /// Types supported by astarte
@@ -48,8 +49,8 @@ pub enum AstarteType {
     Unset,
 }
 
-impl PartialEq<crate::interface::MappingType> for AstarteType {
-    fn eq(&self, other: &crate::interface::MappingType) -> bool {
+impl PartialEq<MappingType> for AstarteType {
+    fn eq(&self, other: &MappingType) -> bool {
         macro_rules! check_astype_match {
             ( $self:ident, $other:ident, {$( $astartetype:tt ,)*}) => {
                 match $other {
@@ -62,6 +63,12 @@ impl PartialEq<crate::interface::MappingType> for AstarteType {
                     )*
                 }
             };
+        }
+
+        if other == &MappingType::LongInteger {
+            if let AstarteType::Integer(_) = self {
+                return true;
+            }
         }
 
         check_astype_match!(self, other, {


### PR DESCRIPTION
In the case of a server-owned longinteger mapping, Astarte sends an integer number if the value is small enough.
This behavior was not taken into account during the data validation. 
A condition was add in the `eq` function that compares the type of the data received with the mapping type.
Added some tests.