### PR TITLE
API cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,9 @@
 
 
 [package]
-name = "astarte_sdk"
+name = "astarte-device-sdk"
 version = "0.1.0"
-authors = ["Riccardo Binetti"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/astarte-platform/astarte-device-sdk-rust"
 

--- a/examples/database.rs
+++ b/examples/database.rs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_sdk::{builder::AstarteOptions, database::AstarteSqliteDatabase, AstarteError};
+use astarte_device_sdk::{builder::AstarteOptions, database::AstarteSqliteDatabase, AstarteError};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -55,7 +55,7 @@ async fn main() -> Result<(), AstarteError> {
         .database(db)
         .build();
 
-    let mut device = astarte_sdk::AstarteSdk::new(&sdk_options).await?;
+    let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await?;
 
     let w = device.clone();
     tokio::task::spawn(async move {
@@ -93,7 +93,7 @@ async fn main() -> Result<(), AstarteError> {
     });
 
     loop {
-        match device.poll().await {
+        match device.handle_events().await {
             Ok(data) => {
                 println!("incoming: {:?}", data);
             }

--- a/examples/deviceproperties.rs
+++ b/examples/deviceproperties.rs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_sdk::{builder::AstarteOptions, AstarteError};
+use astarte_device_sdk::{builder::AstarteOptions, AstarteError};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -52,7 +52,7 @@ async fn main() -> Result<(), AstarteError> {
         .interface_directory("./examples/interfaces")?
         .build();
 
-    let mut device = astarte_sdk::AstarteSdk::new(&sdk_options).await?;
+    let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await?;
 
     let w = device.clone();
     tokio::task::spawn(async move {
@@ -80,7 +80,7 @@ async fn main() -> Result<(), AstarteError> {
     });
 
     loop {
-        match device.poll().await {
+        match device.handle_events().await {
             Ok(data) => {
                 println!("incoming: {:?}", data);
             }

--- a/examples/object.rs
+++ b/examples/object.rs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_sdk::{builder::AstarteOptions, AstarteError};
+use astarte_device_sdk::{builder::AstarteOptions, AstarteError};
 use structopt::StructOpt;
 
 use serde::Serialize;
@@ -54,7 +54,7 @@ async fn main() -> Result<(), AstarteError> {
         .interface_directory("./examples/interfaces")?
         .build();
 
-    let mut device = astarte_sdk::AstarteSdk::new(&sdk_options).await?;
+    let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await?;
 
     let w = device.clone();
 
@@ -96,7 +96,7 @@ async fn main() -> Result<(), AstarteError> {
     });
 
     loop {
-        match device.poll().await {
+        match device.handle_events().await {
             Ok(data) => {
                 println!("incoming: {:?}", data);
             }

--- a/examples/registration.rs
+++ b/examples/registration.rs
@@ -48,7 +48,7 @@ async fn main() {
     } = Cli::from_args();
 
     let credentials_secret =
-        astarte_sdk::registration::register_device(&token, &pairing_url, &realm, &device_id)
+        astarte_device_sdk::registration::register_device(&token, &pairing_url, &realm, &device_id)
             .await
             .unwrap();
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -37,7 +37,7 @@ use crate::pairing;
 /// Builder for Astarte client
 ///
 /// ```no_run
-/// use astarte_sdk::builder::AstarteOptions;
+/// use astarte_device_sdk::builder::AstarteOptions;
 ///
 /// #[tokio::main]
 /// async fn main(){

--- a/src/database.rs
+++ b/src/database.rs
@@ -25,7 +25,7 @@ use log::{debug, trace};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::FromRow;
 
-use crate::{types::AstarteType, AstarteError, AstarteSdk};
+use crate::{types::AstarteType, AstarteDeviceSdk, AstarteError};
 
 /// Implementation of the [AstarteDatabase] trait for an sqlite database backend
 #[derive(Clone, Debug)]
@@ -122,7 +122,7 @@ impl AstarteDatabase for AstarteSqliteDatabase {
                 return Ok(None);
             }
 
-            let data = AstarteSdk::deserialize(&res.0)?;
+            let data = AstarteDeviceSdk::deserialize(&res.0)?;
 
             match data {
                 crate::Aggregation::Individual(data) => Ok(Some(data)),
@@ -179,7 +179,7 @@ impl AstarteSqliteDatabase {
 #[cfg(test)]
 mod test {
     use crate::database::AstarteDatabase;
-    use crate::AstarteSdk;
+    use crate::AstarteDeviceSdk;
     use crate::{database::AstarteSqliteDatabase, database::StoredProp, types::AstarteType};
 
     #[tokio::test]
@@ -189,7 +189,7 @@ mod test {
             .unwrap();
 
         let ty = AstarteType::Integer(23);
-        let ser = AstarteSdk::serialize_individual(ty.clone(), None).unwrap();
+        let ser = AstarteDeviceSdk::serialize_individual(ty.clone(), None).unwrap();
 
         db.clear().await.unwrap();
 

--- a/src/e2etest/e2etest.rs
+++ b/src/e2etest/e2etest.rs
@@ -24,8 +24,8 @@ use base64::Engine;
 use chrono::{TimeZone, Utc};
 use serde_json::Value;
 
-use astarte_sdk::builder::AstarteOptions;
-use astarte_sdk::types::AstarteType;
+use astarte_device_sdk::builder::AstarteOptions;
+use astarte_device_sdk::types::AstarteType;
 
 fn get_data() -> HashMap<String, AstarteType> {
     let alltypes: Vec<AstarteType> = vec![
@@ -132,7 +132,9 @@ async fn main() {
         .ignore_ssl_errors()
         .build();
 
-    let mut device = astarte_sdk::AstarteSdk::new(&sdk_options).await.unwrap();
+    let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options)
+        .await
+        .unwrap();
 
     let data = get_data();
 
@@ -226,7 +228,7 @@ async fn main() {
     });
 
     loop {
-        match device.poll().await {
+        match device.handle_events().await {
             Ok(data) => {
                 println!("incoming: {:?}", data);
             }

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -122,7 +122,7 @@ impl Interfaces {
         data: &[u8],
         timestamp: &Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<(), AstarteError> {
-        let data_deserialized = crate::AstarteSdk::deserialize(data)?;
+        let data_deserialized = crate::AstarteDeviceSdk::deserialize(data)?;
 
         let interface = self
             .interfaces
@@ -225,7 +225,7 @@ impl Interfaces {
             AstarteError::ReceiveError(format!("Interface '{}' does not exists", interface_name))
         })?;
 
-        let data = crate::AstarteSdk::deserialize(bdata)?;
+        let data = crate::AstarteDeviceSdk::deserialize(bdata)?;
 
         match data {
             crate::Aggregation::Individual(individual) => {
@@ -297,7 +297,7 @@ mod test {
     use chrono::{TimeZone, Utc};
 
     use crate::{
-        builder::AstarteOptions, interface::traits::Interface, types::AstarteType, AstarteSdk,
+        builder::AstarteOptions, interface::traits::Interface, types::AstarteType, AstarteDeviceSdk,
     };
 
     #[test]
@@ -306,7 +306,7 @@ mod test {
         options.interface_directory("examples/interfaces/").unwrap();
         let ifa = super::Interfaces::new(options.interfaces);
 
-        let buf = AstarteSdk::serialize_individual(AstarteType::Boolean(true), None).unwrap();
+        let buf = AstarteDeviceSdk::serialize_individual(AstarteType::Boolean(true), None).unwrap();
 
         ifa.validate_send(
             "org.astarte-platform.test.Everything",
@@ -371,7 +371,8 @@ mod test {
         ifa.validate_send("com.fake.fake", "/boolean", &buf, &timestamp)
             .unwrap_err();
 
-        let buf = AstarteSdk::serialize_individual(AstarteType::Double(f64::NAN), None).unwrap(); // NaN
+        let buf =
+            AstarteDeviceSdk::serialize_individual(AstarteType::Double(f64::NAN), None).unwrap(); // NaN
 
         ifa.validate_send(
             "org.astarte-platform.test.Everything",
@@ -381,7 +382,7 @@ mod test {
         )
         .unwrap_err();
 
-        let buf = AstarteSdk::serialize_individual(
+        let buf = AstarteDeviceSdk::serialize_individual(
             AstarteType::DoubleArray(vec![1.0, 2.0, f64::NAN, 4.0]),
             None,
         )
@@ -412,7 +413,9 @@ mod test {
         obj.insert("heading", 237.0.try_into().unwrap());
         obj.insert("speed", 250.0.try_into().unwrap());
 
-        let buf = AstarteSdk::serialize_object(AstarteSdk::to_bson_map(obj.clone()), None).unwrap();
+        let buf =
+            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(obj.clone()), None)
+                .unwrap();
 
         ifa.validate_send(
             "org.astarte-platform.genericsensors.Geolocation",
@@ -436,7 +439,8 @@ mod test {
         // nonexisting object field
         let mut obj2 = obj.clone();
         obj2.insert("latitudef", 37.534543.try_into().unwrap());
-        let buf = AstarteSdk::serialize_object(AstarteSdk::to_bson_map(obj2), None).unwrap();
+        let buf =
+            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(obj2), None).unwrap();
         ifa.validate_send(
             "org.astarte-platform.genericsensors.Geolocation",
             "/1",
@@ -448,7 +452,8 @@ mod test {
         // wrong type
         let mut obj2 = obj.clone();
         obj2.insert("latitude", AstarteType::Boolean(false));
-        let buf = AstarteSdk::serialize_object(AstarteSdk::to_bson_map(obj2), None).unwrap();
+        let buf =
+            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(obj2), None).unwrap();
         ifa.validate_send(
             "org.astarte-platform.genericsensors.Geolocation",
             "/1",
@@ -460,7 +465,8 @@ mod test {
         // missing object field
         let mut obj2 = obj.clone();
         obj2.remove("latitude");
-        let buf = AstarteSdk::serialize_object(AstarteSdk::to_bson_map(obj2), None).unwrap();
+        let buf =
+            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(obj2), None).unwrap();
         ifa.validate_send(
             "org.astarte-platform.genericsensors.Geolocation",
             "/1",
@@ -472,7 +478,8 @@ mod test {
         // invalid float
         let mut obj2 = obj.clone();
         obj2.insert("latitude", AstarteType::Double(f64::NAN));
-        let buf = AstarteSdk::serialize_object(AstarteSdk::to_bson_map(obj2), None).unwrap();
+        let buf =
+            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(obj2), None).unwrap();
         ifa.validate_send(
             "org.astarte-platform.genericsensors.Geolocation",
             "/1",
@@ -489,8 +496,9 @@ mod test {
         let ifa = super::Interfaces::new(options.interfaces);
 
         let boolean_buf =
-            AstarteSdk::serialize_individual(AstarteType::Boolean(true), None).unwrap();
-        let integer_buf = AstarteSdk::serialize_individual(AstarteType::Integer(23), None).unwrap();
+            AstarteDeviceSdk::serialize_individual(AstarteType::Boolean(true), None).unwrap();
+        let integer_buf =
+            AstarteDeviceSdk::serialize_individual(AstarteType::Integer(23), None).unwrap();
 
         ifa.validate_receive(
             "org.astarte-platform.genericsensors.SamplingRate",
@@ -569,7 +577,9 @@ mod test {
         .iter()
         .cloned()
         .collect();
-        let buf = AstarteSdk::serialize_object(AstarteSdk::to_bson_map(inner_data), None).unwrap();
+        let buf =
+            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(inner_data), None)
+                .unwrap();
 
         ifa.validate_receive("com.test.object", "/", &buf).unwrap();
         ifa.validate_receive("com.test.object", "/no", &buf)
@@ -583,7 +593,9 @@ mod test {
         .iter()
         .cloned()
         .collect();
-        let buf = AstarteSdk::serialize_object(AstarteSdk::to_bson_map(inner_data), None).unwrap();
+        let buf =
+            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(inner_data), None)
+                .unwrap();
 
         ifa.validate_receive("com.test.object", "/", &buf)
             .unwrap_err();
@@ -595,7 +607,9 @@ mod test {
         .iter()
         .cloned()
         .collect();
-        let buf = AstarteSdk::serialize_object(AstarteSdk::to_bson_map(inner_data), None).unwrap();
+        let buf =
+            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(inner_data), None)
+                .unwrap();
 
         ifa.validate_receive("com.test.object", "/", &buf)
             .unwrap_err();

--- a/src/types.rs
+++ b/src/types.rs
@@ -319,7 +319,7 @@ mod test {
 
     use chrono::{DateTime, TimeZone, Utc};
 
-    use crate::{types::AstarteType, Aggregation, AstarteError, AstarteSdk};
+    use crate::{types::AstarteType, Aggregation, AstarteDeviceSdk, AstarteError};
 
     #[test]
     fn test_individual_serialization() {
@@ -349,9 +349,9 @@ mod test {
         for ty in alltypes {
             println!("checking {:?}", ty);
 
-            let buf = AstarteSdk::serialize_individual(ty.clone(), None).unwrap();
+            let buf = AstarteDeviceSdk::serialize_individual(ty.clone(), None).unwrap();
 
-            let ty2 = AstarteSdk::deserialize(&buf).unwrap();
+            let ty2 = AstarteDeviceSdk::deserialize(&buf).unwrap();
 
             if let Aggregation::Individual(data) = ty2 {
                 assert!(ty == data);
@@ -409,9 +409,10 @@ mod test {
         }
 
         let bytes =
-            AstarteSdk::serialize_object(AstarteSdk::to_bson_map(data.clone()), None).unwrap();
+            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(data.clone()), None)
+                .unwrap();
 
-        let data2 = AstarteSdk::deserialize(&bytes).unwrap();
+        let data2 = AstarteDeviceSdk::deserialize(&bytes).unwrap();
 
         fn hashmap_match(
             map1: &HashMap<&str, AstarteType>,


### PR DESCRIPTION
Rename package from `astarte_sdk` to `astarte-device-sdk` (automatically translated to `astarte_device_sdk` inside the code) to better adhere to common RUST naming conventions.
Rename various APIs for better understandability.

Close #57 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>