### PR TITLE
Remove generic type from unset function signature

### DIFF
--- a/src/e2etest/e2etest.rs
+++ b/src/e2etest/e2etest.rs
@@ -122,6 +122,10 @@ async fn main() {
             "./examples/interfaces/org.astarte-platform.genericsensors.Geolocation.json",
         ))
         .unwrap()
+        .interface_file(std::path::Path::new(
+            "./examples/interfaces/org.astarte-platform.genericsensors.SamplingRate.json",
+        ))
+        .unwrap()
         .ignore_ssl_errors()
         .build();
 
@@ -199,6 +203,21 @@ async fn main() {
         println!("----------------\n{:?}", json);
 
         check_json_obj(&data, json);
+
+        w.send(
+            "org.astarte-platform.genericsensors.SamplingRate",
+            "/1/enable",
+            true,
+        )
+        .await
+        .unwrap();
+
+        w.unset(
+            "org.astarte-platform.genericsensors.SamplingRate",
+            "/1/enable",
+        )
+        .await
+        .unwrap();
 
         std::process::exit(0);
     });

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -135,7 +135,7 @@ impl Interfaces {
                     .get_mapping(interface_name, interface_path)
                     .ok_or_else(|| AstarteError::SendError("Mapping doesn't exist".into()))?;
 
-                if individual != mapping.mapping_type() {
+                if individual != AstarteType::Unset && individual != mapping.mapping_type() {
                     return Err(AstarteError::SendError(format!(
                         "You are sending the wrong type for this mapping: got {:?}, expected {:?}",
                         individual,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,14 +389,11 @@ impl AstarteSdk {
     }
 
     /// unset a device property
-    pub async fn unset<D>(
+    pub async fn unset(
         &self,
         interface_name: &str,
         interface_path: &str,
-    ) -> Result<(), AstarteError>
-    where
-        D: Into<AstarteType>,
-    {
+    ) -> Result<(), AstarteError> {
         trace!("unsetting {} {}", interface_name, interface_path);
 
         if cfg!(debug_assertions) {


### PR DESCRIPTION
The unset function definition makes use of an unused generic type definition.
During tests, a bug on validation that prevents the unset functionality emerged.
This commit fixes both issues.

Close #77 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>