### PR TITLE
Fix the magic number in `store_property_on_send`

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -40,6 +40,8 @@ pub enum Error {
     MajorMinorError,
     #[error("interface not found")]
     InterfaceNotFoundError,
+    #[error("mapping not found")]
+    MappingNotFoundError,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]


### PR DESCRIPTION
Replaced `0` magic number in `store_property_on_send` with the actual `version_major` meant to be there.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>