### PR TITLE
Locking CI to v1.59.0

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           profile: minimal
           # No toolchain matrix for fmt checking
-          toolchain: stable
+          toolchain: 1.59.0
           override: true
       - name: Add rustfmt
         run: rustup component add rustfmt
@@ -54,8 +54,8 @@ jobs:
     strategy:
       matrix:
         toolchain:
+        - 1.59.0
         - stable
-        - beta
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -77,8 +77,8 @@ jobs:
     strategy:
       matrix:
         toolchain:
+        - 1.59.0
         - stable
-        - beta
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ flate2 = "1.0"
 
 [dev-dependencies]
 structopt = "0.3"
-env_logger = "0.10.0"
+env_logger = "0.9"
 
 [dev-dependencies.cargo-husky]
 version = "1"


### PR DESCRIPTION
Perform all the operations in the `build-workflow` also for the `v1.59.0` of Rust.
Do not run anything for `beta` versions of Rust.
Roll back `env_logger` to latest version supported by Rust `v1.59.0`
Closes #91 