### PR TITLE
Conversion from astarte type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,9 @@ pub enum AstarteError {
 
     #[error("generic error")]
     Unreported,
+
+    #[error("conversion error")]
+    Conversion,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Implement the `TryFrom` trait for the base types from an `AstarteType`.
Closes #88.