### PR TITLE
Resolve warnings from tests

### DIFF
--- a/src/e2etest/e2etest.rs
+++ b/src/e2etest/e2etest.rs
@@ -20,9 +20,11 @@
 
 use std::{collections::HashMap, panic};
 
+use chrono::{TimeZone, Utc};
+use serde_json::Value;
+
 use astarte_sdk::builder::AstarteOptions;
 use astarte_sdk::types::AstarteType;
-use serde_json::Value;
 
 fn get_data() -> HashMap<String, AstarteType> {
     let alltypes: Vec<AstarteType> = vec![
@@ -32,7 +34,7 @@ fn get_data() -> HashMap<String, AstarteType> {
         45543543534_i64.into(),
         "hello".into(),
         b"hello".to_vec().into(),
-        chrono::TimeZone::timestamp(&chrono::Utc, 1627580808, 0).into(),
+        TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap().into(),
         vec![1.2, 3.4, 5.6, 7.8].into(),
         vec![1, 3, 5, 7].into(),
         vec![true, false, true, true].into(),
@@ -40,9 +42,9 @@ fn get_data() -> HashMap<String, AstarteType> {
         vec!["hello".to_owned(), "world".to_owned()].into(),
         vec![b"hello".to_vec(), b"world".to_vec()].into(),
         vec![
-            chrono::TimeZone::timestamp(&chrono::Utc, 1627580808, 0),
-            chrono::TimeZone::timestamp(&chrono::Utc, 1627580809, 0),
-            chrono::TimeZone::timestamp(&chrono::Utc, 1627580810, 0),
+            TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap(),
+            TimeZone::timestamp_opt(&Utc, 1627580809, 0).unwrap(),
+            TimeZone::timestamp_opt(&Utc, 1627580810, 0).unwrap(),
         ]
         .into(),
     ];

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -294,6 +294,8 @@ impl Interfaces {
 mod test {
     use std::{collections::HashMap, convert::TryInto, str::FromStr};
 
+    use chrono::{TimeZone, Utc};
+
     use crate::{
         builder::AstarteOptions, interface::traits::Interface, types::AstarteType, AstarteSdk,
     };
@@ -334,7 +336,7 @@ mod test {
         ifa.validate_send("com.fake.fake", "/boolean", &buf, &None)
             .unwrap_err();
 
-        let timestamp = Some(chrono::TimeZone::timestamp(&chrono::Utc, 1537449422, 0));
+        let timestamp = Some(TimeZone::timestamp_opt(&Utc, 1537449422, 0).unwrap());
 
         ifa.validate_send(
             "org.astarte-platform.test.Everything",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -948,7 +948,7 @@ mod test {
         assert!(do_vecs_match(
             &AstarteSdk::serialize_individual(
                 AstarteType::Double(16.73),
-                Some(Utc.timestamp(1537449422, 890000000))
+                Some(Utc.timestamp_opt(1537449422, 890000000).unwrap())
             )
             .unwrap(),
             &[

--- a/src/types.rs
+++ b/src/types.rs
@@ -280,6 +280,8 @@ impl AstarteType {
 mod test {
     use std::collections::HashMap;
 
+    use chrono::{TimeZone, Utc};
+
     use crate::{types::AstarteType, Aggregation, AstarteSdk};
 
     #[test]
@@ -291,7 +293,7 @@ mod test {
             45543543534_i64.into(),
             "hello".into(),
             b"hello".to_vec().into(),
-            chrono::TimeZone::timestamp(&chrono::Utc, 1627580808, 0).into(),
+            TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap().into(),
             vec![1.2, 3.4, 5.6, 7.8].into(),
             vec![1, 3, 5, 7].into(),
             vec![true, false, true, true].into(),
@@ -299,9 +301,9 @@ mod test {
             vec!["hello".to_owned(), "world".to_owned()].into(),
             vec![b"hello".to_vec(), b"world".to_vec()].into(),
             vec![
-                chrono::TimeZone::timestamp(&chrono::Utc, 1627580808, 0),
-                chrono::TimeZone::timestamp(&chrono::Utc, 1627580809, 0),
-                chrono::TimeZone::timestamp(&chrono::Utc, 1627580810, 0),
+                TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1627580809, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1627580810, 0).unwrap(),
             ]
             .into(),
             AstarteType::Unset,
@@ -331,7 +333,7 @@ mod test {
             45543543534_i64.into(),
             "hello".into(),
             b"hello".to_vec().into(),
-            chrono::TimeZone::timestamp(&chrono::Utc, 1627580808, 0).into(),
+            TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap().into(),
             vec![1.2, 3.4, 5.6, 7.8].into(),
             vec![1, 3, 5, 7].into(),
             vec![true, false, true, true].into(),
@@ -339,9 +341,9 @@ mod test {
             vec!["hello".to_owned(), "world".to_owned()].into(),
             vec![b"hello".to_vec(), b"world".to_vec()].into(),
             vec![
-                chrono::TimeZone::timestamp(&chrono::Utc, 1627580808, 0),
-                chrono::TimeZone::timestamp(&chrono::Utc, 1627580809, 0),
-                chrono::TimeZone::timestamp(&chrono::Utc, 1627580810, 0),
+                TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1627580809, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1627580810, 0).unwrap(),
             ]
             .into(),
         ];


### PR DESCRIPTION
All the warnings were generated by the deprecated function `timestamp`. They have been solved by replacing it with `timestamp_opt`.
Closes #97 