### PR TITLE
Implement AstarteAggregate trait and macro

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -91,10 +91,12 @@ jobs:
       - name: Add clippy
         run: rustup component add clippy
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -Dwarnings
+        run: |
+          cargo clippy --all-targets --all-features -- -Dwarnings
+      - name: Run clippy in derive macros folder
+        run: |
+          cd ./astarte-device-sdk-derive
+          cargo clippy --all-targets --all-features -- -Dwarnings
 
   test:
     name: cargo test

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: CC0-1.0
 
 /target
+/astarte-device-sdk-derive/target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ uuid = {version="1.2.2", features = ["v5", "v4"] }
 base64 = "0.21.0"
 webpki = "0.22.0"
 flate2 = "1.0"
+astarte-device-sdk-derive = { path = "./astarte-device-sdk-derive" }
 
 [dev-dependencies]
 structopt = "0.3"

--- a/astarte-device-sdk-derive/Cargo.toml
+++ b/astarte-device-sdk-derive/Cargo.toml
@@ -1,0 +1,19 @@
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# SPDX-License-Identifier: CC0-1.0
+
+[package]
+name = "astarte-device-sdk-derive"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = {version = "1.0", features = ["extra-traits"]}
+quote = "1.0"

--- a/astarte-device-sdk-derive/src/lib.rs
+++ b/astarte-device-sdk-derive/src/lib.rs
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse_macro_input;
+
+#[proc_macro_derive(AstarteAggregate)]
+pub fn astarte_aggregate_derive(input: TokenStream) -> TokenStream {
+    // Construct a representation of Rust code as a syntax tree
+    // that we can manipulate
+    let ast = parse_macro_input!(input as syn::DeriveInput);
+
+    // Build the trait implementation
+    impl_astarte_aggregate(ast)
+}
+
+fn impl_astarte_aggregate(ast: syn::DeriveInput) -> TokenStream {
+    if let syn::Data::Struct(st) = ast.data {
+        if let syn::Fields::Named(fields) = st.fields {
+            let mut fields_names = (Vec::new(), Vec::new());
+            for field in fields.named {
+                let ident = field
+                    .ident
+                    .expect("AstarteAggregate is not implementable over this struct");
+                fields_names.0.push(ident.to_string());
+                fields_names.1.push(ident);
+            }
+            let name = &ast.ident;
+            let fields_names_str_iter = fields_names.0.iter();
+            let fields_names_iter = fields_names.1.iter();
+            let gen = quote! {
+                impl AstarteAggregate for #name {
+                    fn astarte_aggregate(
+                        self,
+                    ) -> Result<
+                        std::collections::HashMap<String, astarte_device_sdk::types::AstarteType>,
+                        astarte_device_sdk::AstarteError,
+                    > {
+                        let mut result = std::collections::HashMap::new();
+                        #(
+                            let astype: astarte_device_sdk::types::AstarteType =
+                                std::convert::TryInto::try_into(self.#fields_names_iter)?;
+                            result.insert(#fields_names_str_iter.to_string(), astype);
+                        )*
+                        Ok(result)
+                    }
+                }
+            };
+            gen.into()
+        } else {
+            panic!("AstarteAggregate is only implementable over a named struct.")
+        }
+    } else {
+        panic!("AstarteAggregate is only implementable over a struct.")
+    }
+}

--- a/examples/object.rs
+++ b/examples/object.rs
@@ -21,7 +21,8 @@
 use astarte_device_sdk::{builder::AstarteOptions, AstarteError};
 use structopt::StructOpt;
 
-use serde::Serialize;
+use astarte_device_sdk::AstarteAggregate;
+use astarte_device_sdk_derive::AstarteAggregate;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -60,8 +61,7 @@ async fn main() -> Result<(), AstarteError> {
 
     tokio::task::spawn(async move {
         loop {
-            #[derive(Serialize)]
-            #[serde(rename_all = "camelCase")]
+            #[derive(AstarteAggregate)]
             struct Geolocation {
                 latitude: f64,
                 longitude: f64,

--- a/src/e2etest/e2etest.rs
+++ b/src/e2etest/e2etest.rs
@@ -18,6 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use std::convert::TryInto;
 use std::{collections::HashMap, panic};
 
 use base64::Engine;
@@ -87,15 +88,15 @@ fn get_data() -> HashMap<String, AstarteType> {
     data_map
 }
 
-fn get_data_obj() -> HashMap<String, f64> {
-    let mut data: HashMap<String, f64> = HashMap::new();
-    data.insert("latitude".into(), 1.34);
-    data.insert("longitude".into(), 2.34);
-    data.insert("altitude".into(), 3.34);
-    data.insert("accuracy".into(), 4.34);
-    data.insert("altitudeAccuracy".into(), 5.34);
-    data.insert("heading".into(), 6.34);
-    data.insert("speed".into(), 7.34);
+fn get_data_obj() -> HashMap<String, AstarteType> {
+    let mut data: HashMap<String, AstarteType> = HashMap::new();
+    data.insert("latitude".into(), AstarteType::Double(1.34));
+    data.insert("longitude".into(), AstarteType::Double(2.34));
+    data.insert("altitude".into(), AstarteType::Double(3.34));
+    data.insert("accuracy".into(), AstarteType::Double(4.34));
+    data.insert("altitudeAccuracy".into(), AstarteType::Double(5.34));
+    data.insert("heading".into(), AstarteType::Double(6.34));
+    data.insert("speed".into(), AstarteType::Double(7.34));
 
     data
 }
@@ -341,8 +342,8 @@ fn encode_blob(blob: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(blob)
 }
 
-fn check_json_obj(data: &HashMap<String, f64>, json: String) {
-    fn parse_response_json(json: &str) -> HashMap<String, f64> {
+fn check_json_obj(data: &HashMap<String, AstarteType>, json: String) {
+    fn parse_response_json(json: &str) -> HashMap<String, AstarteType> {
         let mut ret = HashMap::new();
         let v: Value = serde_json::from_str(json).unwrap();
 
@@ -354,7 +355,10 @@ fn check_json_obj(data: &HashMap<String, f64>, json: String) {
                     if let Value::Object(data) = &data[0] {
                         for dat in data {
                             if let Value::Number(dat2) = dat.1 {
-                                ret.insert(dat.0.clone(), dat2.as_f64().unwrap());
+                                ret.insert(
+                                    dat.0.clone(),
+                                    AstarteType::Double(dat2.as_f64().unwrap()),
+                                );
                             }
                         }
                     }
@@ -374,8 +378,10 @@ fn check_json_obj(data: &HashMap<String, f64>, json: String) {
 
         println!("{:?} {:?}", i.1, jtype);
         assert!(compare_json_with_astartetype(
-            &AstarteType::Double(*i.1),
-            &Value::Number(serde_json::Number::from_f64(*jtype).unwrap())
+            i.1,
+            &Value::Number(
+                serde_json::Number::from_f64(jtype.clone().try_into().unwrap()).unwrap()
+            )
         ));
     }
 }

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -291,14 +291,13 @@ impl Interfaces {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
-    use std::{collections::HashMap, convert::TryInto, str::FromStr};
+    use std::{collections::HashMap, str::FromStr};
 
     use chrono::{TimeZone, Utc};
 
     use crate::{
-        builder::AstarteOptions, interface::traits::Interface, types::AstarteType, AstarteDeviceSdk,
+        builder::AstarteOptions, interface::traits::Interface, interfaces::Interfaces,
+        types::AstarteType, AstarteDeviceSdk,
     };
 
     #[test]
@@ -404,19 +403,17 @@ mod test {
         options.interface_directory("examples/interfaces/").unwrap();
         let ifa = Interfaces::new(options.interfaces);
 
-        let mut obj: std::collections::HashMap<&str, AstarteType> =
+        let mut obj: std::collections::HashMap<String, AstarteType> =
             std::collections::HashMap::new();
-        obj.insert("latitude", 37.534543.try_into().unwrap());
-        obj.insert("longitude", 45.543.try_into().unwrap());
-        obj.insert("altitude", 650.6.try_into().unwrap());
-        obj.insert("accuracy", 12.0.try_into().unwrap());
-        obj.insert("altitudeAccuracy", 10.0.try_into().unwrap());
-        obj.insert("heading", 237.0.try_into().unwrap());
-        obj.insert("speed", 250.0.try_into().unwrap());
+        obj.insert("latitude".to_string(), AstarteType::Double(37.534543));
+        obj.insert("longitude".to_string(), AstarteType::Double(45.543));
+        obj.insert("altitude".to_string(), AstarteType::Double(650.6));
+        obj.insert("accuracy".to_string(), AstarteType::Double(12.0));
+        obj.insert("altitudeAccuracy".to_string(), AstarteType::Double(10.0));
+        obj.insert("heading".to_string(), AstarteType::Double(237.0));
+        obj.insert("speed".to_string(), AstarteType::Double(250.0));
 
-        let buf =
-            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(obj.clone()), None)
-                .unwrap();
+        let buf = AstarteDeviceSdk::serialize_object(obj.clone(), None).unwrap();
 
         ifa.validate_send(
             "org.astarte-platform.genericsensors.Geolocation",
@@ -439,9 +436,8 @@ mod test {
 
         // nonexisting object field
         let mut obj2 = obj.clone();
-        obj2.insert("latitudef", 37.534543.try_into().unwrap());
-        let buf =
-            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(obj2), None).unwrap();
+        obj2.insert("latitudef".to_string(), AstarteType::Double(37.534543));
+        let buf = AstarteDeviceSdk::serialize_object(obj2, None).unwrap();
         ifa.validate_send(
             "org.astarte-platform.genericsensors.Geolocation",
             "/1",
@@ -452,9 +448,8 @@ mod test {
 
         // wrong type
         let mut obj2 = obj.clone();
-        obj2.insert("latitude", AstarteType::Boolean(false));
-        let buf =
-            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(obj2), None).unwrap();
+        obj2.insert("latitude".to_string(), AstarteType::Boolean(false));
+        let buf = AstarteDeviceSdk::serialize_object(obj2, None).unwrap();
         ifa.validate_send(
             "org.astarte-platform.genericsensors.Geolocation",
             "/1",
@@ -466,8 +461,7 @@ mod test {
         // missing object field
         let mut obj2 = obj.clone();
         obj2.remove("latitude");
-        let buf =
-            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(obj2), None).unwrap();
+        let buf = AstarteDeviceSdk::serialize_object(obj2, None).unwrap();
         ifa.validate_send(
             "org.astarte-platform.genericsensors.Geolocation",
             "/1",
@@ -478,9 +472,8 @@ mod test {
 
         // invalid float
         let mut obj2 = obj.clone();
-        obj2.insert("latitude", AstarteType::Double(f64::NAN));
-        let buf =
-            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(obj2), None).unwrap();
+        obj2.insert("latitude".to_string(), AstarteType::Double(f64::NAN));
+        let buf = AstarteDeviceSdk::serialize_object(obj2, None).unwrap();
         ifa.validate_send(
             "org.astarte-platform.genericsensors.Geolocation",
             "/1",
@@ -571,46 +564,40 @@ mod test {
 
         let ifa = Interfaces::new(ifa);
 
-        let inner_data: HashMap<&str, AstarteType> = [
-            ("button", AstarteType::Boolean(false)),
-            ("uptimeSeconds", AstarteType::Integer(324)),
+        let inner_data: HashMap<String, AstarteType> = [
+            ("button".to_string(), AstarteType::Boolean(false)),
+            ("uptimeSeconds".to_string(), AstarteType::Integer(324)),
         ]
         .iter()
         .cloned()
         .collect();
-        let buf =
-            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(inner_data), None)
-                .unwrap();
+        let buf = AstarteDeviceSdk::serialize_object(inner_data, None).unwrap();
 
         ifa.validate_receive("com.test.object", "/", &buf).unwrap();
         ifa.validate_receive("com.test.object", "/no", &buf)
             .unwrap_err();
         ifa.validate_receive("com.test.no", "/", &buf).unwrap_err();
 
-        let inner_data: HashMap<&str, AstarteType> = [
-            ("buttonfoo", AstarteType::Boolean(false)),
-            ("uptimeSeconds", AstarteType::Integer(324)),
+        let inner_data: HashMap<String, AstarteType> = [
+            ("buttonfoo".to_string(), AstarteType::Boolean(false)),
+            ("uptimeSeconds".to_string(), AstarteType::Integer(324)),
         ]
         .iter()
         .cloned()
         .collect();
-        let buf =
-            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(inner_data), None)
-                .unwrap();
+        let buf = AstarteDeviceSdk::serialize_object(inner_data, None).unwrap();
 
         ifa.validate_receive("com.test.object", "/", &buf)
             .unwrap_err();
 
-        let inner_data: HashMap<&str, AstarteType> = [
-            ("button", AstarteType::Double(3.3)),
-            ("uptimeSeconds", AstarteType::Integer(324)),
+        let inner_data: HashMap<String, AstarteType> = [
+            ("button".to_string(), AstarteType::Double(3.3)),
+            ("uptimeSeconds".to_string(), AstarteType::Integer(324)),
         ]
         .iter()
         .cloned()
         .collect();
-        let buf =
-            AstarteDeviceSdk::serialize_object(AstarteDeviceSdk::to_bson_map(inner_data), None)
-                .unwrap();
+        let buf = AstarteDeviceSdk::serialize_object(inner_data, None).unwrap();
 
         ifa.validate_receive("com.test.object", "/", &buf)
             .unwrap_err();
@@ -906,9 +893,9 @@ mod test {
             .unwrap_err();
 
         // Test receiving an aggregate
-        let aggr_data: HashMap<&str, bson::Bson> = HashMap::from([
-            ("boolean_endpoint", AstarteType::Boolean(false).into()),
-            ("integer_endpoint", AstarteType::Integer(324).into()),
+        let aggr_data: HashMap<String, AstarteType> = HashMap::from([
+            ("boolean_endpoint".to_string(), AstarteType::Boolean(false)),
+            ("integer_endpoint".to_string(), AstarteType::Integer(324)),
         ]);
         let aggr_data = AstarteDeviceSdk::serialize_object(aggr_data, None).unwrap();
         interfaces
@@ -916,9 +903,9 @@ mod test {
             .unwrap();
 
         // Test receiving an aggregate with wrong type
-        let aggr_data: HashMap<&str, bson::Bson> = HashMap::from([
-            ("boolean_endpoint", AstarteType::Boolean(false).into()),
-            ("integer_endpoint", AstarteType::Boolean(false).into()),
+        let aggr_data: HashMap<String, AstarteType> = HashMap::from([
+            ("boolean_endpoint".to_string(), AstarteType::Boolean(false)),
+            ("integer_endpoint".to_string(), AstarteType::Boolean(false)),
         ]);
         let aggr_data = AstarteDeviceSdk::serialize_object(aggr_data, None).unwrap();
         interfaces
@@ -926,9 +913,9 @@ mod test {
             .unwrap_err();
 
         // Test receiving an aggregate on an property interface
-        let aggr_data: HashMap<&str, bson::Bson> = HashMap::from([
-            ("boolean_endpoint", AstarteType::Boolean(false).into()),
-            ("integer_endpoint", AstarteType::Integer(324).into()),
+        let aggr_data: HashMap<String, AstarteType> = HashMap::from([
+            ("boolean_endpoint".to_string(), AstarteType::Boolean(false)),
+            ("integer_endpoint".to_string(), AstarteType::Integer(324)),
         ]);
         let aggr_data = AstarteDeviceSdk::serialize_object(aggr_data, None).unwrap();
         interfaces


### PR DESCRIPTION
This PR introduces the procedural macro and trait `AstarteAggregate`.
Using this macro with the `derive` function over a compatible struct makes it possible to send it as an aggregate.

Closes #112. Closes #111.