### PR TITLE
Add AstarteAggregate as a crate feature.

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -43,10 +43,8 @@ jobs:
       - name: Add rustfmt
         run: rustup component add rustfmt
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: |
+          cargo fmt --all -- --check
 
   check:
     name: cargo check
@@ -65,11 +63,10 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
-
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: |
+          cargo check --all-targets
+          cargo check --all-features
 
   clippy_check:
     name: cargo clippy
@@ -92,11 +89,13 @@ jobs:
         run: rustup component add clippy
       - name: Run cargo clippy
         run: |
-          cargo clippy --all-targets --all-features -- -Dwarnings
+          cargo clippy --all-targets -- -Dwarnings
+          cargo clippy --all-features -- -Dwarnings
       - name: Run clippy in derive macros folder
         run: |
           cd ./astarte-device-sdk-derive
-          cargo clippy --all-targets --all-features -- -Dwarnings
+          cargo clippy --all-targets -- -Dwarnings
+          cargo clippy --all-features -- -Dwarnings
 
   test:
     name: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/astarte-platform/astarte-device-sdk-rust"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+astarte-device-sdk-derive = {optional = true, path = "./astarte-device-sdk-derive" }
 itertools = "0.10"
 http = "0.2"
 openssl = { version = "0.10", features = ["vendored"] }
@@ -37,9 +38,9 @@ uuid = {version="1.2.2", features = ["v5", "v4"] }
 base64 = "0.21.0"
 webpki = "0.22.0"
 flate2 = "1.0"
-astarte-device-sdk-derive = { path = "./astarte-device-sdk-derive" }
 
 [dev-dependencies]
+astarte-device-sdk-derive = {path = "./astarte-device-sdk-derive" }
 structopt = "0.3"
 env_logger = "0.9"
 
@@ -47,6 +48,9 @@ env_logger = "0.9"
 version = "1"
 default-features = false # Disable features which are enabled by default
 features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"]
+
+[features]
+derive = ["astarte-device-sdk-derive"]
 
 
 [[bin]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,19 @@ impl AstarteAggregate for HashMap<String, AstarteType> {
     }
 }
 
+// Re-export #[derive(AstarteAggregate)].
+//
+// The reason re-exporting is not enabled by default is that disabling it would
+// be annoying for crates that provide handwritten impls or data formats. They
+// would need to disable default features and then explicitly re-enable std.
+#[cfg(feature = "derive")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate astarte_device_sdk_derive;
+#[cfg(feature = "derive")]
+#[doc(hidden)]
+pub use astarte_device_sdk_derive::*;
+
 /// Astarte client
 #[derive(Clone)]
 pub struct AstarteDeviceSdk {


### PR DESCRIPTION
This PR proposes an alternative import structure for  `AstarteAggregate`.
Previously a user of the SDK wanting to use `#[derive(AstarteAggregate)]` would have needed to add as separate dependencies: `astarte-device-sdk` and `astarte-device-sdk-derive`.
And then in the sources add the following double `use`:
```
use astarte_device_sdk::AstarteAggregate;
use astarte_device_sdk_derive::AstarteAggregate;
```
With the changes inculded in this PR a user only needs to specify the feature `astarte-device-sdk-derive` for the crate `astarte-device-sdk` in its `Cargo.toml` file. Avoiding the double dependency.
In addition in the source files only a single `use` is required:
```
use astarte_device_sdk::AstarteAggregate;
```