### PR TITLE
Fix for Rust version v1.67

### DIFF
--- a/examples/database.rs
+++ b/examples/database.rs
@@ -95,9 +95,9 @@ async fn main() -> Result<(), AstarteError> {
     loop {
         match device.handle_events().await {
             Ok(data) => {
-                println!("incoming: {:?}", data);
+                println!("incoming: {data:?}");
             }
-            Err(err) => log::error!("{:?}", err),
+            Err(err) => log::error!("{err:?}"),
         }
     }
 }

--- a/examples/deviceproperties.rs
+++ b/examples/deviceproperties.rs
@@ -82,9 +82,9 @@ async fn main() -> Result<(), AstarteError> {
     loop {
         match device.handle_events().await {
             Ok(data) => {
-                println!("incoming: {:?}", data);
+                println!("incoming: {data:?}");
             }
-            Err(err) => log::error!("{:?}", err),
+            Err(err) => log::error!("{err:?}"),
         }
     }
 }

--- a/examples/object.rs
+++ b/examples/object.rs
@@ -98,9 +98,9 @@ async fn main() -> Result<(), AstarteError> {
     loop {
         match device.handle_events().await {
             Ok(data) => {
-                println!("incoming: {:?}", data);
+                println!("incoming: {data:?}");
             }
-            Err(err) => log::error!("{:?}", err),
+            Err(err) => log::error!("{err:?}"),
         }
     }
 }

--- a/examples/registration.rs
+++ b/examples/registration.rs
@@ -52,5 +52,5 @@ async fn main() {
             .await
             .unwrap();
 
-    println!("{}", credentials_secret);
+    println!("{credentials_secret}");
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), AstarteError> {
             w.send("org.astarte-platform.test.Everything", "/longinteger", i)
                 .await
                 .unwrap();
-            println!("Sent {}", i);
+            println!("Sent {i}");
 
             i += 11;
 
@@ -75,7 +75,7 @@ async fn main() -> Result<(), AstarteError> {
     loop {
         match device.handle_events().await {
             Ok(data) => {
-                println!("incoming: {:?}", data);
+                println!("incoming: {data:?}");
 
                 if let astarte_device_sdk::Aggregation::Individual(var) = data.data {
                     if data.path == "/1/enable" {

--- a/src/e2etest/e2etest.rs
+++ b/src/e2etest/e2etest.rs
@@ -159,8 +159,7 @@ async fn main() {
 
         let json = reqwest::Client::new()
             .get(format!(
-                "https://api.autotest.astarte-platform.org/appengine/v1/{}/devices/{}/interfaces/org.astarte-platform.test.Everything",
-                realm, device_id
+                "https://api.autotest.astarte-platform.org/appengine/v1/{realm}/devices/{device_id}/interfaces/org.astarte-platform.test.Everything"
             ))
             .header(
                 "Authorization",
@@ -191,8 +190,7 @@ async fn main() {
 
         let json = reqwest::Client::new()
         .get(format!(
-            "https://api.autotest.astarte-platform.org/appengine/v1/{}/devices/{}/interfaces/org.astarte-platform.genericsensors.Geolocation",
-            realm, device_id
+            "https://api.autotest.astarte-platform.org/appengine/v1/{realm}/devices/{device_id}/interfaces/org.astarte-platform.genericsensors.Geolocation"
         ))
         .header(
             "Authorization",
@@ -205,8 +203,8 @@ async fn main() {
         .await
         .unwrap();
 
-        println!("----------------\n{:?}", data);
-        println!("----------------\n{:?}", json);
+        println!("----------------\n{data:?}");
+        println!("----------------\n{json:?}");
 
         check_json_obj(&data, json);
 
@@ -231,10 +229,10 @@ async fn main() {
     loop {
         match device.handle_events().await {
             Ok(data) => {
-                println!("incoming: {:?}", data);
+                println!("incoming: {data:?}");
             }
             Err(err) => {
-                println!("poll error {:?}", err);
+                println!("poll error {err:?}");
                 std::process::exit(1);
             }
         }
@@ -246,7 +244,7 @@ fn check_json(data: &HashMap<String, AstarteType>, json: String) {
         let mut ret = HashMap::new();
         let v: Value = serde_json::from_str(json).unwrap();
 
-        println!("{:#?}", v);
+        println!("{v:#?}");
 
         if let Value::Object(data) = v {
             if let Value::Object(data) = &data["data"] {
@@ -269,7 +267,7 @@ fn check_json(data: &HashMap<String, AstarteType>, json: String) {
             .get(i.0)
             .unwrap_or_else(|| panic!("Can't find {} in json {:?}", i.0, json));
 
-        println!("{:?} {:?}", atype, jtype);
+        println!("{atype:?} {jtype:?}");
         assert!(compare_json_with_astartetype(atype, jtype));
     }
 }
@@ -347,7 +345,7 @@ fn check_json_obj(data: &HashMap<String, AstarteType>, json: String) {
         let mut ret = HashMap::new();
         let v: Value = serde_json::from_str(json).unwrap();
 
-        println!("{:#?}", v);
+        println!("{v:#?}");
 
         if let Value::Object(data) = v {
             if let Value::Object(data) = &data["data"] {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -538,7 +538,7 @@ mod tests {
         assert!(deser_interface.is_err());
         assert!(match deser_interface {
             Err(Error::MajorMinor) => true,
-            Err(e) => panic!("expected Error::MajorMinor, got {:?}", e),
+            Err(e) => panic!("expected Error::MajorMinor, got {e:?}"),
             Ok(_) => panic!("Expected Err, got Ok"),
         });
     }

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -172,8 +172,7 @@ impl Interfaces {
                         self.get_mapping(interface_name, &mapping_path)
                             .ok_or_else(|| {
                                 AstarteError::SendError(format!(
-                                    "Mapping '{}' doesn't exist",
-                                    mapping_path
+                                    "Mapping '{mapping_path}' doesn't exist"
                                 ))
                             })?;
 
@@ -222,7 +221,7 @@ impl Interfaces {
         }
 
         self.interfaces.get(interface_name).ok_or_else(|| {
-            AstarteError::ReceiveError(format!("Interface '{}' does not exists", interface_name))
+            AstarteError::ReceiveError(format!("Interface '{interface_name}' does not exists"))
         })?;
 
         let data = crate::AstarteDeviceSdk::deserialize(bdata)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,7 +742,7 @@ impl AstarteDeviceSdk {
             let mapping = interfaces
                 .get_mapping(interface_name, interface_path)
                 .ok_or_else(|| {
-                    AstarteError::SendError(format!("Mapping {} doesn't exist", interface_path))
+                    AstarteError::SendError(format!("Mapping {interface_path} doesn't exist"))
                 })?;
 
             if let crate::interface::Mapping::Properties(_) = mapping {
@@ -1062,7 +1062,7 @@ mod test {
             ),
         ]);
         assert_eq!(expected_res, my_aggregate.astarte_aggregate().unwrap());
-        println!("{:?}", expected_res);
+        println!("{expected_res:?}");
     }
 
     #[test]
@@ -1089,7 +1089,7 @@ mod test {
         ];
 
         for ty in alltypes {
-            println!("checking {:?}", ty);
+            println!("checking {ty:?}");
 
             let buf = AstarteDeviceSdk::serialize_individual(ty.clone(), None).unwrap();
 
@@ -1153,7 +1153,7 @@ mod test {
 
         let data_processed = AstarteDeviceSdk::deserialize(&bytes).unwrap();
 
-        println!("\nComparing {:?}\nto {:?}", data, data_processed);
+        println!("\nComparing {data:?}\nto {data_processed:?}");
 
         if let Aggregation::Object(data_processed) = data_processed {
             assert_eq!(data, data_processed);

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -207,7 +207,7 @@ fn build_mqtt_opts(
         realm, device_id, ..
     } = options;
 
-    let client_id = format!("{}/{}", realm, device_id);
+    let client_id = format!("{realm}/{device_id}");
     let host = broker_url
         .host_str()
         .ok_or_else(|| AstarteBuilderError::ConfigError("bad broker url".into()))?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -311,8 +311,7 @@ impl std::convert::TryFrom<Bson> for AstarteType {
                 Bson::String(_) => from_bson_array!(arr, StringArray, String, String),
                 Bson::Binary(_) => from_bson_array!(arr, BinaryBlobArray, Binary, Vec<u8>),
                 _ => Err(AstarteError::FromBsonError(format!(
-                    "Can't convert array {:?} to astarte",
-                    arr
+                    "Can't convert array {arr:?} to astarte"
                 ))),
             },
             Bson::Boolean(d) => Ok(AstarteType::Boolean(d)),
@@ -321,8 +320,7 @@ impl std::convert::TryFrom<Bson> for AstarteType {
             Bson::Binary(d) => Ok(AstarteType::BinaryBlob(d.bytes)),
             Bson::DateTime(d) => Ok(AstarteType::DateTime(d.into())),
             _ => Err(AstarteError::FromBsonError(format!(
-                "Can't convert {:?} to astarte",
-                d
+                "Can't convert {d:?} to astarte"
             ))),
         }
     }


### PR DESCRIPTION
Rust version [v1.67](https://blog.rust-lang.org/2023/01/26/Rust-1.67.0.html) brings some new/improved linting rules in `clippy`.
This PR fixes complaints from `clippy` for this Rust version.