### PR TITLE
Improved docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ SPDX-License-Identifier: Apache-2.0
 
 *Warning: this SDK is experimental, correctness and API stability are currently not guaranteed*
 
-This package allows you to implement an Astarte Device using Rust.
+The Astarte Device SDK for Rust is a ready to use library that provides communication and
+pairing primitives to an Astarte Cluster.
+
+See the [Astarte documentation](https://docs.astarte-platform.org/latest/001-intro_user.html)
+for more information regarding Astarte and the available SDKs.
 
 ## Building
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -43,10 +43,15 @@ pub enum Error {
     MappingNotFound,
 }
 
+/// Astarte interface implementation.
+///
+/// Should be used only through its methods, not instantiated directly.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum Interface {
+    #[doc(hidden)]
     Datastream(DatastreamInterface),
+    #[doc(hidden)]
     Properties(PropertiesInterface),
 }
 
@@ -219,6 +224,7 @@ fn is_default<T: Default + PartialEq>(t: &T) -> bool {
 }
 
 impl Interface {
+    /// Instantiate a new `Interface` from a file.
     pub fn from_file(path: &Path) -> Result<Self, Error> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
@@ -227,6 +233,7 @@ impl Interface {
         Ok(interface)
     }
 
+    /// Getter function for the aggregation type of the interface.
     pub fn aggregation(&self) -> Aggregation {
         match &self {
             Self::Datastream(d) => d.aggregation,
@@ -278,6 +285,10 @@ impl Interface {
         }
     }
 
+    /// Getter function for the the endpoint paths for each property contained in the interface.
+    ///
+    /// Return a vector of touples. Each touple contains the endpoint as a `String` and the
+    /// major version of the interface as a `i32`.
     pub fn get_properties_paths(&self) -> Vec<(String, i32)> {
         if let Interface::Properties(iface) = self {
             let name = iface.base.interface_name.clone();
@@ -294,6 +305,7 @@ impl Interface {
         Vec::new()
     }
 
+    /// Getter function for the interface name.
     pub fn get_name(&self) -> String {
         match &self {
             Interface::Datastream(iface) => iface.base.interface_name.clone(),
@@ -301,6 +313,7 @@ impl Interface {
         }
     }
 
+    /// Getter function for the interface major version.
     pub fn get_version_major(&self) -> i32 {
         match &self {
             Interface::Datastream(iface) => iface.base.version_major,
@@ -308,6 +321,7 @@ impl Interface {
         }
     }
 
+    /// Getter function for the interface minor version.
     pub fn get_version_minor(&self) -> i32 {
         match &self {
             Interface::Datastream(iface) => iface.base.version_minor,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -242,7 +242,7 @@ impl Interface {
         }
     }
 
-    pub fn mapping(&self, path: &str) -> Option<Mapping> {
+    pub(crate) fn mapping(&self, path: &str) -> Option<Mapping> {
         match &self {
             Self::Datastream(d) => {
                 for mapping in d.mappings.iter() {
@@ -264,21 +264,21 @@ impl Interface {
         None
     }
 
-    pub fn mappings(&self) -> Vec<Mapping> {
+    pub(crate) fn mappings(&self) -> Vec<Mapping> {
         return match &self {
             Self::Datastream(d) => d.mappings.iter().map(Mapping::Datastream).collect(),
             Self::Properties(p) => p.mappings.iter().map(Mapping::Properties).collect(),
         };
     }
 
-    pub fn mappings_len(&self) -> usize {
+    pub(crate) fn mappings_len(&self) -> usize {
         match &self {
             Self::Datastream(d) => d.mappings.len(),
             Self::Properties(p) => p.mappings.len(),
         }
     }
 
-    pub fn get_ownership(&self) -> Ownership {
+    pub(crate) fn get_ownership(&self) -> Ownership {
         match &self {
             Interface::Datastream(iface) => iface.base.ownership,
             Interface::Properties(iface) => iface.base.ownership,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
 #![doc = include_str!("../README.md")]
 
 mod crypto;
@@ -50,7 +49,43 @@ use types::AstarteType;
 use crate::interface::traits::{Interface as iface, Mapping};
 pub use interface::Interface;
 
+/// A **trait** required by all data to be sent using
+/// [send_object()][crate::AstarteDeviceSdk::send_object] and
+/// [send_object_with_timestamp()][crate::AstarteDeviceSdk::send_object_with_timestamp].
+/// It ensures correct parsing of the data.
+///
+/// The returned hash map should have as values the data to transmit for each
+/// object endpoint and as keys the endpoints themselves.
+///
+/// The Astarte Device SDK provides a procedural macro that can be used to automatically
+/// generate `AstarteAggregate` implementations for Structs.
+/// To use the procedual macro enable the feature `derive`.
 pub trait AstarteAggregate {
+    /// Parse this data structure into a `HashMap` compatible with transmission of Astarte objects.
+    /// ```
+    /// use std::collections::HashMap;
+    /// use std::convert::TryInto;
+    ///
+    /// use astarte_device_sdk::{types::AstarteType, AstarteError, AstarteAggregate};
+    ///
+    /// struct Person {
+    ///     name: String,
+    ///     age: i32,
+    ///     phones: Vec<String>,
+    /// }
+    ///
+    /// // This is what #[derive(AstarteAggregate)] would generate.
+    /// impl AstarteAggregate for Person {
+    ///     fn astarte_aggregate(self) -> Result<HashMap<String, AstarteType>, AstarteError>
+    ///     {
+    ///         let mut r = HashMap::new();
+    ///         r.insert("name".to_string(), self.name.try_into()?);
+    ///         r.insert("age".to_string(), self.age.try_into()?);
+    ///         r.insert("phones".to_string(), self.phones.try_into()?);
+    ///         Ok(r)
+    ///     }
+    /// }
+    /// ```
     fn astarte_aggregate(self) -> Result<HashMap<String, AstarteType>, AstarteError>;
 }
 
@@ -70,10 +105,12 @@ impl AstarteAggregate for HashMap<String, AstarteType> {
 #[macro_use]
 extern crate astarte_device_sdk_derive;
 #[cfg(feature = "derive")]
-#[doc(hidden)]
 pub use astarte_device_sdk_derive::*;
 
-/// Astarte client
+/// Astarte device implementation.
+///
+/// Provides functionality to transmit and receive individual and object datastreams as well
+/// as properties.
 #[derive(Clone)]
 pub struct AstarteDeviceSdk {
     realm: String,
@@ -85,6 +122,9 @@ pub struct AstarteDeviceSdk {
     database: Option<Arc<dyn AstarteDatabase + Sync + Send>>,
 }
 
+/// Astarte error.
+///
+/// Possible errors returned by functions of the Astarte device SDK.
 #[derive(thiserror::Error, Debug)]
 pub enum AstarteError {
     #[error("bson serialize error")]
@@ -136,17 +176,25 @@ pub enum AstarteError {
     Infallible(#[from] Infallible),
 }
 
+/// Payload format for an Astarte device event data.
 #[derive(Debug, Clone)]
 pub enum Aggregation {
+    /// Individual data, can be both from a datastream or property.
     Individual(AstarteType),
+    /// Object data, also called aggregate. Can only be from a datastream.
     Object(HashMap<String, AstarteType>),
 }
 
-/// data from astarte to device
+/// Astarte device event data structure.
+///
+/// Data structure returned when an instance of [`AstarteDeviceSdk`] polls a valid event.
 #[derive(Debug, Clone)]
 pub struct AstarteDeviceDataEvent {
+    /// Interface on which the event has been triggered
     pub interface: String,
+    /// Path to the endpoint for which the event has been triggered
     pub path: String,
+    /// Payload of the event
     pub data: Aggregation,
 }
 
@@ -161,6 +209,21 @@ fn parse_topic(topic: &str) -> Option<(String, String, String, String)> {
 }
 
 impl AstarteDeviceSdk {
+    /// Create a new instance of the Astarte Device SDK.
+    ///
+    /// ```no_run
+    /// use astarte_device_sdk::{AstarteDeviceSdk, options::AstarteOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let sdk_options = AstarteOptions::new("", "", "", "")
+    ///     .interface_directory("")
+    ///     .unwrap()
+    ///     .ignore_ssl_errors();
+    ///
+    ///     let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
+    /// }
+    /// ```
     pub async fn new(opts: &AstarteOptions) -> Result<AstarteDeviceSdk, AstarteError> {
         let mqtt_options = pairing::get_transport_config(opts).await?;
 
@@ -183,6 +246,38 @@ impl AstarteDeviceSdk {
         device.wait_for_connack().await?;
 
         Ok(device)
+    }
+
+    async fn wait_for_connack(&mut self) -> Result<(), AstarteError> {
+        loop {
+            // keep consuming and processing packets until we have data for the user
+            match self.eventloop.lock().await.poll().await? {
+                Event::Incoming(i) => {
+                    trace!("MQTT Incoming = {i:?}");
+
+                    if let rumqttc::Packet::ConnAck(p) = i {
+                        return self.connack(p).await;
+                    } else {
+                        error!("BUG: not connack inside poll_connack {i:?}");
+                    }
+                }
+                Event::Outgoing(i) => {
+                    error!("BUG: not connack inside poll_connack {i:?}");
+                }
+            }
+        }
+    }
+
+    async fn connack(&self, p: rumqttc::ConnAck) -> Result<(), AstarteError> {
+        if !p.session_present {
+            self.subscribe().await?;
+            self.send_introspection().await?;
+            self.send_emptycache().await?;
+            self.send_device_owned_properties().await?;
+            info!("connack done");
+        }
+
+        Ok(())
     }
 
     async fn subscribe(&self) -> Result<(), AstarteError> {
@@ -241,49 +336,21 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    async fn wait_for_connack(&mut self) -> Result<(), AstarteError> {
-        loop {
-            // keep consuming and processing packets until we have data for the user
-            match self.eventloop.lock().await.poll().await? {
-                Event::Incoming(i) => {
-                    trace!("MQTT Incoming = {i:?}");
-
-                    if let rumqttc::Packet::ConnAck(p) = i {
-                        return self.connack(p).await;
-                    } else {
-                        error!("BUG: not connack inside poll_connack {i:?}");
-                    }
-                }
-                Event::Outgoing(i) => {
-                    error!("BUG: not connack inside poll_connack {i:?}");
-                }
-            }
-        }
-    }
-
-    async fn connack(&self, p: rumqttc::ConnAck) -> Result<(), AstarteError> {
-        if !p.session_present {
-            self.subscribe().await?;
-            self.send_introspection().await?;
-            self.send_emptycache().await?;
-            self.send_device_owned_properties().await?;
-            info!("connack done");
-        }
-
-        Ok(())
-    }
-
+    /// Add a new interface from the provided file.
     pub async fn add_interface_from_file(&self, file_path: &str) -> Result<(), AstarteError> {
         let path = Path::new(file_path);
         let interface = Interface::from_file(path)?;
         self.add_interface(interface).await
     }
 
+    /// Add a new interface from a string. The string should contain a valid json formatted
+    /// interface.
     pub async fn add_interface_from_str(&self, json_str: &str) -> Result<(), AstarteError> {
         let interface: Interface = Interface::from_str(json_str)?;
         self.add_interface(interface).await
     }
 
+    /// Add a new [`Interface`] to the device interfaces.
     pub async fn add_interface(&self, interface: Interface) -> Result<(), AstarteError> {
         if interface.get_ownership() == interface::Ownership::Server {
             self.subscribe_server_owned_interface(&interface).await?;
@@ -300,6 +367,7 @@ impl AstarteDeviceSdk {
         interfaces_map.insert(interface.name().to_string(), interface);
     }
 
+    /// Remove the interface with the name specified as argument.
     pub async fn remove_interface(&self, interface_name: &str) -> Result<(), AstarteError> {
         let interface = self.remove_interface_from_map(interface_name).await?;
         self.remove_properties_from_store(interface_name).await?;
@@ -324,16 +392,26 @@ impl AstarteDeviceSdk {
             ))
     }
 
-    /// Poll updates from mqtt, this is where you receive data
+    /// Poll updates from mqtt, can be placed in a loop to receive data.
+    ///
+    /// This is a blocking function. It should be placed on a dedicated thread/task.
+    ///
     /// ```no_run
+    /// use astarte_device_sdk::{AstarteDeviceSdk, options::AstarteOptions};
+    ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut sdk_options = astarte_device_sdk::options::AstarteOptions::new("_","_","_","_");
-    ///     let mut d = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await.unwrap();
+    ///     let mut sdk_options = AstarteOptions::new("_","_","_","_");
+    ///     let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
     ///
     ///     loop {
-    ///         if let Ok(data) = d.handle_events().await {
-    ///             println!("incoming: {:?}", data);
+    ///         match device.handle_events().await {
+    ///             Ok(data) => {
+    ///                 // React to received data
+    ///             }
+    ///             Err(err) => {
+    ///                 // React to reception error
+    ///             }
     ///         }
     ///     }
     /// }
@@ -515,7 +593,22 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    /// unset a device property
+    /// Unset a device property.
+    ///
+    /// ```no_run
+    /// use astarte_device_sdk::{AstarteDeviceSdk, options::AstarteOptions};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut sdk_options = AstarteOptions::new("_","_","_","_");
+    ///     let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
+    ///
+    ///     device
+    ///         .unset("my.interface.name", "/endpoint/path",)
+    ///         .await
+    ///         .unwrap();
+    /// }
+    /// ```
     pub async fn unset(
         &self,
         interface_name: &str,
@@ -538,7 +631,6 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    /// Serialize data directly from Bson
     fn serialize(
         data: Bson,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
@@ -594,7 +686,28 @@ impl AstarteDeviceSdk {
         }
     }
 
-    /// get property from database, if present
+    /// When present get property from the allocated database (if allocated).
+    ///
+    /// ```no_run
+    /// use astarte_device_sdk::{
+    ///     AstarteDeviceSdk, database::AstarteSqliteDatabase, options::AstarteOptions,
+    ///     types::AstarteType
+    /// };
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let database = AstarteSqliteDatabase::new("path/to/database/file.sqlite")
+    ///         .await
+    ///         .unwrap();
+    ///     let mut sdk_options = AstarteOptions::new("_","_","_","_").database(database);
+    ///     let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
+    ///
+    ///     let property_value: Option<AstarteType> = device
+    ///         .get_property("my.interface.name", "/endpoint/path",)
+    ///         .await
+    ///         .unwrap();
+    /// }
+    /// ```
     pub async fn get_property(
         &self,
         interface: &str,
@@ -619,16 +732,11 @@ impl AstarteDeviceSdk {
     // individual types
     // ------------------------------------------------------------------------
 
-    /// Send data to an astarte interface
-    /// ```no_run
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let mut sdk_options = astarte_device_sdk::options::AstarteOptions::new("_","_","_","_");
-    ///     let mut d = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await.unwrap();
+    /// Send an individual datastream/property on an interface.
     ///
-    ///     d.send("com.test.interface", "/data", 45).await.unwrap();
-    /// }
-    /// ```
+    /// The usage is the same of
+    /// [send_with_timestamp()][crate::AstarteDeviceSdk::send_with_timestamp],
+    /// without the timestamp.
     pub async fn send<D>(
         &self,
         interface_name: &str,
@@ -642,16 +750,22 @@ impl AstarteDeviceSdk {
             .await
     }
 
-    /// Send data to an astarte interface, with timestamp
+    /// Send an individual datastream/property on an interface, with an explicit timestamp.
+    ///
     /// ```no_run
+    /// use astarte_device_sdk::{AstarteDeviceSdk, options::AstarteOptions};
+    /// use chrono::{TimeZone, Utc};
+    ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     use chrono::Utc;
-    ///     use chrono::TimeZone;
-    ///     let mut sdk_options = astarte_device_sdk::options::AstarteOptions::new("_","_","_","_");
-    ///     let mut d = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await.unwrap();
+    ///     let mut sdk_options = AstarteOptions::new("_","_","_","_");
+    ///     let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
     ///
-    ///     d.send_with_timestamp("com.test.interface", "/data", 45, Utc.timestamp(1537449422, 0) ).await.unwrap();
+    ///     let value: i32 = 42;
+    ///     let timestamp = Utc.timestamp(1537449422, 0);
+    ///     device.send_with_timestamp("my.interface.name", "/endpoint/path", value, timestamp)
+    ///         .await
+    ///         .unwrap();
     /// }
     /// ```
     pub async fn send_with_timestamp<D>(
@@ -719,8 +833,8 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    /// checks if a property mapping has alredy been sent, so we don't have to send the same thing again
-    /// returns true if property was already sent
+    /// Check if a property is already stored in the database with the same value.
+    /// Useful to prevent sending a property twice with the same value.
     async fn check_property_on_send<D>(
         &self,
         interface_name: &str,
@@ -821,7 +935,6 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    /// Serialize an astarte type into a vec of bytes
     fn serialize_individual<D>(
         data: D,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
@@ -837,7 +950,6 @@ impl AstarteDeviceSdk {
     // object types
     // ------------------------------------------------------------------------
 
-    /// Serialize a group of astarte types to a vec of bytes, representing an object
     fn serialize_object<T>(
         data: T,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
@@ -890,7 +1002,34 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    /// Send data to an object interface. with timestamp
+    /// Send an object datastreamy on an interface, with an explicit timestamp.
+    ///
+    /// ```no_run
+    /// # use astarte_device_sdk::{AstarteDeviceSdk, options::AstarteOptions, AstarteAggregate};
+    /// use astarte_device_sdk_derive::AstarteAggregate;
+    /// use chrono::{TimeZone, Utc};
+    ///
+    /// #[derive(AstarteAggregate)]
+    /// struct TestObject {
+    ///     endpoint1: f64,
+    ///     endpoint2: bool,
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut sdk_options = AstarteOptions::new("_","_","_","_");
+    ///     let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
+    ///
+    ///     let data = TestObject {
+    ///         endpoint1: 1.34,
+    ///         endpoint2: false
+    ///     };
+    ///     let timestamp = Utc.timestamp(1537449422, 0);
+    ///     device.send_object_with_timestamp("my.interface.name", "/endpoint/path", data, timestamp)
+    ///         .await
+    ///         .unwrap();
+    /// }
+    /// ```
     pub async fn send_object_with_timestamp<T>(
         &self,
         interface_name: &str,
@@ -905,7 +1044,11 @@ impl AstarteDeviceSdk {
             .await
     }
 
-    /// Send data to an object interface. with timestamp
+    /// Send an object datastreamy on an interface.
+    ///
+    /// The usage is the same of
+    /// [send_object_with_timestamp()][crate::AstarteDeviceSdk::send_object_with_timestamp],
+    /// without the timestamp.
     pub async fn send_object<T>(
         &self,
         interface_name: &str,

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -17,6 +17,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+//! Provides static functions for registering a new device to an Astarte Cluster.
 
 use base64::Engine;
 use http::StatusCode;

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,6 +17,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+//! Provides Astarte specific types to be used by the
+//! [AstarteDeviceSdk][crate::AstarteDeviceSdk] to transmit/receivedata to/from the Astarte cluster.
+
 use std::convert::TryInto;
 
 use bson::{Binary, Bson};
@@ -25,9 +28,27 @@ use chrono::{DateTime, Utc};
 use crate::interface::MappingType;
 use crate::AstarteError;
 
-/// Types supported by astarte
+/// Types supported by the Astarte device.
 ///
-/// <https://docs.astarte-platform.org/latest/080-mqtt-v1-protocol.html#astarte-data-types-to-bson-types>
+/// An implementation of the [From] or [TryFrom] trait is provided for the encapsulated base types.
+///
+/// ```
+/// use astarte_device_sdk::types::AstarteType;
+/// use std::convert::TryInto;
+///
+/// let btype: bool = true;
+/// let astype: AstarteType = AstarteType::from(btype);
+/// assert_eq!(AstarteType::Boolean(true), astype);
+/// let btype: bool = astype.try_into().unwrap();
+///
+/// let dtype: f64 = 42.4;
+/// let astype: AstarteType = AstarteType::try_from(dtype).unwrap();
+/// assert_eq!(AstarteType::Double(42.4), astype);
+/// let dtype: f64 = astype.try_into().unwrap();
+/// ```
+///
+/// For more information about the types supported by Astarte see the
+/// [documentation](https://docs.astarte-platform.org/latest/080-mqtt-v1-protocol.html#astarte-data-types-to-bson-types)
 #[derive(Debug, Clone, PartialEq)]
 pub enum AstarteType {
     Double(f64),


### PR DESCRIPTION
Adds docstrings to all the methods and data structures visible outside the crate.
Two other changes come bundled in this PR:
- Some of the methods of the `Interface` enumerator have been made public only inside of the crate. 
- The `handle_events()` has been splitted in two. This eases readability and prevents eccessive indentation.

Preparation for #70.
Closes #129.