### PR TITLE
Remove AstarteOptions build method

### DIFF
--- a/examples/database.rs
+++ b/examples/database.rs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_device_sdk::{builder::AstarteOptions, database::AstarteSqliteDatabase, AstarteError};
+use astarte_device_sdk::{database::AstarteSqliteDatabase, options::AstarteOptions, AstarteError};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -52,8 +52,7 @@ async fn main() -> Result<(), AstarteError> {
 
     let sdk_options = AstarteOptions::new(&realm, &device_id, &credentials_secret, &pairing_url)
         .interface_directory("./examples/interfaces")?
-        .database(db)
-        .build();
+        .database(db);
 
     let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await?;
 

--- a/examples/deviceproperties.rs
+++ b/examples/deviceproperties.rs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_device_sdk::{builder::AstarteOptions, AstarteError};
+use astarte_device_sdk::{options::AstarteOptions, AstarteError};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -49,8 +49,7 @@ async fn main() -> Result<(), AstarteError> {
     } = Cli::from_args();
 
     let sdk_options = AstarteOptions::new(&realm, &device_id, &credentials_secret, &pairing_url)
-        .interface_directory("./examples/interfaces")?
-        .build();
+        .interface_directory("./examples/interfaces")?;
 
     let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await?;
 

--- a/examples/object.rs
+++ b/examples/object.rs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_device_sdk::{builder::AstarteOptions, AstarteError};
+use astarte_device_sdk::{options::AstarteOptions, AstarteError};
 use structopt::StructOpt;
 
 use astarte_device_sdk::AstarteAggregate;
@@ -52,8 +52,7 @@ async fn main() -> Result<(), AstarteError> {
     } = Cli::from_args();
 
     let sdk_options = AstarteOptions::new(&realm, &device_id, &credentials_secret, &pairing_url)
-        .interface_directory("./examples/interfaces")?
-        .build();
+        .interface_directory("./examples/interfaces")?;
 
     let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await?;
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_device_sdk::{builder::AstarteOptions, AstarteError};
+use astarte_device_sdk::{options::AstarteOptions, AstarteError};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -52,8 +52,7 @@ async fn main() -> Result<(), AstarteError> {
 
     let sdk_options = AstarteOptions::new(&realm, &device_id, &credentials_secret, &pairing_url)
         .interface_directory("./examples/interfaces")?
-        .database(db)
-        .build();
+        .database(db);
 
     let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await?;
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -165,7 +165,7 @@ impl AstarteDatabase for AstarteSqliteDatabase {
 impl AstarteSqliteDatabase {
     /// Creates an sqlite database for the astarte client
     /// URI should follow sqlite's convention, read [SqliteConnectOptions] for more details
-    pub async fn new(uri: &str) -> Result<Self, crate::builder::AstarteBuilderError> {
+    pub async fn new(uri: &str) -> Result<Self, crate::options::AstarteOptionsError> {
         let options = SqliteConnectOptions::from_str(uri)?.create_if_missing(true);
 
         let conn = SqlitePoolOptions::new().connect_with(options).await?;

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -295,14 +295,14 @@ mod test {
     use chrono::{TimeZone, Utc};
 
     use crate::{
-        builder::AstarteOptions, interface::traits::Interface, interfaces::Interfaces,
+        interface::traits::Interface, interfaces::Interfaces, options::AstarteOptions,
         types::AstarteType, AstarteDeviceSdk,
     };
 
     #[test]
     fn test_individual() {
         let mut options = AstarteOptions::new("test", "test", "test", "test");
-        options.interface_directory("examples/interfaces/").unwrap();
+        options = options.interface_directory("examples/interfaces/").unwrap();
         let ifa = Interfaces::new(options.interfaces);
 
         let buf = AstarteDeviceSdk::serialize_individual(AstarteType::Boolean(true), None).unwrap();
@@ -399,7 +399,7 @@ mod test {
     #[test]
     fn test_object() {
         let mut options = AstarteOptions::new("test", "test", "test", "test");
-        options.interface_directory("examples/interfaces/").unwrap();
+        options = options.interface_directory("examples/interfaces/").unwrap();
         let ifa = Interfaces::new(options.interfaces);
 
         let mut obj: std::collections::HashMap<String, AstarteType> =
@@ -485,7 +485,7 @@ mod test {
     #[test]
     fn test_individual_recv() {
         let mut options = AstarteOptions::new("test", "test", "test", "test");
-        options.interface_directory("examples/interfaces/").unwrap();
+        options = options.interface_directory("examples/interfaces/").unwrap();
         let ifa = Interfaces::new(options.interfaces);
 
         let boolean_buf =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,21 +20,21 @@
 
 #![doc = include_str!("../README.md")]
 
-pub mod builder;
 mod crypto;
 pub mod database;
 mod interface;
 mod interfaces;
+pub mod options;
 mod pairing;
 pub mod registration;
 pub mod types;
 
 use bson::Bson;
-use builder::AstarteOptions;
 use database::AstarteDatabase;
 use database::StoredProp;
 use itertools::Itertools;
 use log::{debug, error, info, trace};
+use options::AstarteOptions;
 use rumqttc::{AsyncClient, Event};
 use rumqttc::{EventLoop, MqttOptions};
 use std::collections::HashMap;
@@ -118,7 +118,7 @@ pub enum AstarteError {
     DbError(#[from] sqlx::Error),
 
     #[error("builder error")]
-    BuilderError(#[from] builder::AstarteBuilderError),
+    BuilderError(#[from] options::AstarteOptionsError),
 
     #[error(transparent)]
     InterfaceError(#[from] interface::Error),
@@ -328,8 +328,7 @@ impl AstarteDeviceSdk {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut sdk_options = astarte_device_sdk::builder::AstarteOptions::new("_","_","_","_")
-    ///                           .build();
+    ///     let mut sdk_options = astarte_device_sdk::options::AstarteOptions::new("_","_","_","_");
     ///     let mut d = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await.unwrap();
     ///
     ///     loop {
@@ -624,8 +623,7 @@ impl AstarteDeviceSdk {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut sdk_options = astarte_device_sdk::builder::AstarteOptions::new("_","_","_","_")
-    ///                           .build();
+    ///     let mut sdk_options = astarte_device_sdk::options::AstarteOptions::new("_","_","_","_");
     ///     let mut d = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await.unwrap();
     ///
     ///     d.send("com.test.interface", "/data", 45).await.unwrap();
@@ -650,8 +648,7 @@ impl AstarteDeviceSdk {
     /// async fn main() {
     ///     use chrono::Utc;
     ///     use chrono::TimeZone;
-    ///     let mut sdk_options = astarte_device_sdk::builder::AstarteOptions::new("_","_","_","_")
-    ///                           .build();
+    ///     let mut sdk_options = astarte_device_sdk::options::AstarteOptions::new("_","_","_","_");
     ///     let mut d = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await.unwrap();
     ///
     ///     d.send_with_timestamp("com.test.interface", "/data", 45, Utc.timestamp(1537449422, 0) ).await.unwrap();

--- a/tests/e2etest/main.rs
+++ b/tests/e2etest/main.rs
@@ -34,7 +34,7 @@ use colored::Colorize;
 use serde_json::Value;
 use tokio::{task, time};
 
-use astarte_device_sdk::builder::AstarteOptions;
+use astarte_device_sdk::options::AstarteOptions;
 use astarte_device_sdk::types::AstarteType;
 use astarte_device_sdk::AstarteDeviceSdk;
 
@@ -128,8 +128,7 @@ async fn e2etest_impl() {
     )
     .interface_directory(&test_cfg.interfaces_fld.to_string_lossy())
     .unwrap()
-    .ignore_ssl_errors()
-    .build();
+    .ignore_ssl_errors();
 
     let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
     let rx_data_ind_datastream = Arc::new(Mutex::new(HashMap::new()));


### PR DESCRIPTION
AstarteOptions does not follow the builder pattern, and a `build()` method that only clones the original object is superflous. Change the name and methods to better reflect the actual behavior of the AstarteOptions struct.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>