### PR TITLE
Rename BuilderError to OptionsError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,8 +117,8 @@ pub enum AstarteError {
     #[error("database error")]
     DbError(#[from] sqlx::Error),
 
-    #[error("builder error")]
-    BuilderError(#[from] options::AstarteOptionsError),
+    #[error("options error")]
+    OptionsError(#[from] options::AstarteOptionsError),
 
     #[error(transparent)]
     InterfaceError(#[from] interface::Error),


### PR DESCRIPTION
Rename BuilderError to OptionsError to reflect the change in terminology

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>