### PR TITLE
README: Fix syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,49 +23,61 @@ for more information regarding Astarte and the available SDKs.
 
 ## Basic usage
 
-### Create a device
-Initializing an instance of a device can be performed in three steps, as seen below.
-```Rust
+```rust
 use astarte_device_sdk::{
     database::AstarteSqliteDatabase,
     options::AstarteOptions,
-    AstarteDeviceSdk};
+    AstarteDeviceSdk,
+    AstarteError
+};
 
-// (optional) Initialize a database to store the properties
-let db = AstarteSqliteDatabase::new("sqlite::memory:").await.unwrap();
+async fn run_astarte_device() -> Result<(), AstarteError> {
+    
+    let realm = "realm_name";
+    let device_id = "device_id";
+    let credentials_secret = "device_credentials_secret";
+    let pairing_url = "astarte_cluster_pairing_url";
 
-// Initialize device options
-let sdk_options = AstarteOptions::new(&realm, &device_id, &credentials_secret, &pairing_url)
-    .interface_directory("./examples/interfaces")
-    .unwrap()
-    .database(db);
-
-// Create the device instance
-let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
-```
-### Publish data from device
-Publishing new values can be performed using the `send` and `send_object` functions.
-```Rust
-// Send individual datastream or set individual property
-let data: i32 = 12;
-device.send("interface.name", "/endpoint/path", data).await.unwrap();
-
-// Send aggregated object datastream
-#[derive(Debug, AstarteAggregate)]
-struct MyAggObj {
-    endpoint1: f64,
-    endpoint2: i32
-}
-let data = MyAggObj {endpoint1: 1.34, endpoint2: 22};
-device.send_object("interface.name", "/common/endpoint/path", data).await.unwrap();
-```
-### Receive a server publish
-Polling for new data can be performed using the function `handle_events`.
-```Rust
- loop {
-    match device.handle_events().await {
-        Ok(data) => (), // Handle data
-        Err(err) => (), // Handle errors
+    // Initializing an instance of a device can be performed as shown in the following three steps.
+    
+    // 1. (optional) Initialize a database to store the properties
+    let db = AstarteSqliteDatabase::new("sqlite::memory:").await?;
+    
+    // 2. Initialize device options (the ".database(db)" is not needed if 1 was skipped)
+    let sdk_options = AstarteOptions::new(&realm, &device_id, &credentials_secret, &pairing_url)
+        .interface_directory("./examples/interfaces")?
+        .database(db);
+    
+    // 3. Create the device instance
+    let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
+    
+    // Publishing new values can be performed using the send and send_object functions.
+    
+    // Send individual datastream or set individual property
+    let data: i32 = 12;
+    device.send("interface.name", "/endpoint/path", data).await.unwrap();
+    
+    // Send aggregated object datastream
+    use astarte_device_sdk::AstarteAggregate;
+    use astarte_device_sdk_derive::AstarteAggregate; 
+    
+    #[derive(Debug, AstarteAggregate)]
+    struct MyAggObj {
+        endpoint1: f64,
+        endpoint2: i32
+    }
+    
+    let data = MyAggObj {endpoint1: 1.34, endpoint2: 22};
+    device.send_object("interface.name", "/common/endpoint/path", data).await.unwrap();
+    
+    // Polling for new data can be performed using the function handle_events.
+    
+    // Receive a server publish
+    loop {
+        match device.handle_events().await {
+            Ok(data) => (), // Handle data
+            Err(err) => (), // Handle errors
+        }
     }
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use interface::Interface;
 ///
 /// The Astarte Device SDK provides a procedural macro that can be used to automatically
 /// generate `AstarteAggregate` implementations for Structs.
-/// To use the procedual macro enable the feature `derive`.
+/// To use the procedural macro enable the feature `derive`.
 pub trait AstarteAggregate {
     /// Parse this data structure into a `HashMap` compatible with transmission of Astarte objects.
     /// ```
@@ -1049,7 +1049,7 @@ impl AstarteDeviceSdk {
             .await
     }
 
-    /// Send an object datastreamy on an interface.
+    /// Send an object datastream on an interface.
     ///
     /// The usage is the same of
     /// [send_object_with_timestamp()][crate::AstarteDeviceSdk::send_object_with_timestamp],


### PR DESCRIPTION
Change to `rust` syntax highlighting.
In order to pass the validation of the example provided with the Readme, a full example was provided.