### PR TITLE
e2e tests: bump up version of Astarte Cluster action and fix a related issue.

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -32,6 +32,8 @@ jobs:
       - name: Create Astarte Cluster
         id: astarte
         uses: astarte-platform/astarte-cluster-action@v1
+        with:
+          astarte_version: "1.0.4"
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Install interface


### PR DESCRIPTION
Some fixes for the end to end tests:
- Handle correctly a failure of `POST` or `DELETE` HTTPS requests.
- Bump up version of Astarte in CI to `1.0.4`
- Removes the not necessary `ignore_ssl_errors` flag in the device initialization.

Closes #142 