### PR TITLE
refactor(interface): clean up and clarify the visibility of types

### DIFF
--- a/astarte-device-sdk-derive/Cargo.lock
+++ b/astarte-device-sdk-derive/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.1.0"
+version = "0.5.1"
 dependencies = [
  "quote",
  "syn",

--- a/examples/object.rs
+++ b/examples/object.rs
@@ -22,6 +22,8 @@ use astarte_device_sdk::{options::AstarteOptions, AstarteError};
 use structopt::StructOpt;
 
 use astarte_device_sdk::AstarteAggregate;
+// This is needed for the example to compile the astarte_device_sdk `feature = ["derive"]` is enabled
+#[cfg(not(feature = "derive"))]
 use astarte_device_sdk_derive::AstarteAggregate;
 
 #[derive(Debug, StructOpt)]

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -238,15 +238,6 @@ impl Interface {
         Ok(interface)
     }
 
-    /// Getter function for the aggregation type of the interface.
-    pub(crate) fn aggregation(&self) -> Aggregation {
-        match &self {
-            Self::Datastream(d) => d.aggregation,
-            // Properties are always individual
-            Self::Properties(_) => Aggregation::Individual,
-        }
-    }
-
     pub(crate) fn mapping(&self, path: &str) -> Option<Mapping> {
         match &self {
             Self::Datastream(d) => {

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -18,6 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+//! Provides the functionalities to parse and validate an Astarte interface.
+
 pub(crate) mod traits;
 
 use serde::{Deserialize, Serialize};
@@ -29,6 +31,7 @@ use std::path::Path;
 use traits::Interface as InterfaceTrait;
 use traits::Mapping as MappingTrait;
 
+/// Error for parsing and validating an interface.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("cannot parse interface JSON")]
@@ -68,6 +71,7 @@ pub(crate) struct BaseInterface {
     doc: Option<String>,
 }
 
+#[doc(hidden)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct DatastreamInterface {
     #[serde(flatten)]
@@ -77,6 +81,7 @@ pub struct DatastreamInterface {
     mappings: Vec<DatastreamMapping>,
 }
 
+#[doc(hidden)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct PropertiesInterface {
     #[serde(flatten)]
@@ -86,27 +91,27 @@ pub struct PropertiesInterface {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
-pub enum InterfaceType {
+pub(crate) enum InterfaceType {
     Datastream,
     Properties,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
-pub enum Ownership {
+pub(crate) enum Ownership {
     Device,
     Server,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
-pub enum Aggregation {
+pub(crate) enum Aggregation {
     Individual,
     Object,
 }
 
 #[derive(Debug)]
-pub enum Mapping<'a> {
+pub(crate) enum Mapping<'a> {
     Datastream(&'a DatastreamMapping),
     Properties(&'a PropertiesMapping),
 }
@@ -123,7 +128,7 @@ pub(crate) struct BaseMapping {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct DatastreamMapping {
+pub(crate) struct DatastreamMapping {
     #[serde(flatten)]
     base: BaseMapping,
     #[serde(default, skip_serializing_if = "is_default")]
@@ -144,7 +149,7 @@ pub struct DatastreamMapping {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct PropertiesMapping {
+pub(crate) struct PropertiesMapping {
     #[serde(flatten)]
     base: BaseMapping,
     #[serde(default, skip_serializing_if = "is_default")]
@@ -155,7 +160,7 @@ pub struct PropertiesMapping {
 // Scalar(InnerType)/Array(InnerType)
 #[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 #[serde(rename_all = "lowercase")]
-pub enum MappingType {
+pub(crate) enum MappingType {
     Double,
     Integer,
     Boolean,
@@ -174,7 +179,7 @@ pub enum MappingType {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
-pub enum Reliability {
+pub(crate) enum Reliability {
     Unreliable,
     Guaranteed,
     Unique,
@@ -182,7 +187,7 @@ pub enum Reliability {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
-pub enum Retention {
+pub(crate) enum Retention {
     Discard,
     Volatile,
     Stored,
@@ -190,7 +195,7 @@ pub enum Retention {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
-pub enum DatabaseRetentionPolicy {
+pub(crate) enum DatabaseRetentionPolicy {
     NoTtl,
     UseTtl,
 }
@@ -234,7 +239,7 @@ impl Interface {
     }
 
     /// Getter function for the aggregation type of the interface.
-    pub fn aggregation(&self) -> Aggregation {
+    pub(crate) fn aggregation(&self) -> Aggregation {
         match &self {
             Self::Datastream(d) => d.aggregation,
             // Properties are always individual

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -45,7 +45,7 @@ impl Interfaces {
     }
 
     /// gets mapping from the json description, given the path
-    pub fn get_mapping(
+    pub(crate) fn get_mapping(
         &self,
         interface_name: &str,
         interface_path: &str,
@@ -84,7 +84,7 @@ impl Interfaces {
     }
 
     /// returns ownership if the interface is present in device introspection, None otherwise
-    pub fn get_ownership(&self, interface: &str) -> Option<crate::interface::Ownership> {
+    pub(crate) fn get_ownership(&self, interface: &str) -> Option<crate::interface::Ownership> {
         let iface = self.interfaces.get(interface)?;
         Some(iface.get_ownership())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,10 @@ impl AstarteAggregate for HashMap<String, AstarteType> {
 #[allow(unused_imports)]
 #[macro_use]
 extern crate astarte_device_sdk_derive;
+
+/// Derive macro to implement `AstarteAggregate` trait with `feature = ["derive"]`.
 #[cfg(feature = "derive")]
-pub use astarte_device_sdk_derive::*;
+pub use astarte_device_sdk_derive::AstarteAggregate;
 
 /// Astarte device implementation.
 ///
@@ -1101,6 +1103,7 @@ mod test {
     use astarte_device_sdk::interface::MappingType;
     use astarte_device_sdk::AstarteAggregate;
     use astarte_device_sdk::{types::AstarteType, Aggregation, AstarteDeviceSdk};
+    #[cfg(not(feature = "derive"))]
     use astarte_device_sdk_derive::AstarteAggregate;
 
     #[derive(AstarteAggregate)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,10 @@
 
 mod crypto;
 pub mod database;
-mod interface;
+pub mod interface;
 mod interfaces;
 pub mod options;
-mod pairing;
+pub mod pairing;
 pub mod registration;
 pub mod types;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -29,11 +29,11 @@ use openssl::error::ErrorStack;
 use pairing::PairingError;
 
 use crate::database::AstarteDatabase;
-use crate::interface::{self};
+use crate::interface;
 use crate::pairing;
 
 use interface::traits::Interface as InterfaceTrait;
-pub use interface::Interface;
+use interface::Interface;
 
 /// Astarte options error.
 ///

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -18,6 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+//! Provides the functionalities to pair a device with the Astarte Cluster.
+
 use std::sync::Arc;
 
 use http::StatusCode;
@@ -62,6 +64,7 @@ struct AstarteMqttV1Info {
     broker_url: String,
 }
 
+/// Error returned during pairing.
 #[derive(thiserror::Error, Debug)]
 pub enum PairingError {
     #[error("invalid credentials secret")]
@@ -80,7 +83,7 @@ pub enum PairingError {
     ConfigError(String),
 }
 
-pub async fn fetch_credentials(opts: &AstarteOptions, csr: &str) -> Result<String, PairingError> {
+async fn fetch_credentials(opts: &AstarteOptions, csr: &str) -> Result<String, PairingError> {
     let mut url = Url::parse(&opts.pairing_url)?;
     // We have to do this this way to avoid unconsistent behaviour depending
     // on the user putting the trailing slash or not
@@ -126,7 +129,7 @@ pub async fn fetch_credentials(opts: &AstarteOptions, csr: &str) -> Result<Strin
     }
 }
 
-pub async fn fetch_broker_url(opts: &AstarteOptions) -> Result<String, PairingError> {
+async fn fetch_broker_url(opts: &AstarteOptions) -> Result<String, PairingError> {
     let mut url = Url::parse(&opts.pairing_url)?;
     // We have to do this this way to avoid unconsistent behaviour depending
     // on the user putting the trailing slash or not
@@ -268,7 +271,8 @@ fn build_mqtt_opts(
     Ok(mqtt_opts)
 }
 
-pub async fn get_transport_config(
+/// Returns a MqttOptions struct that can be used to connect to the broker.
+pub(crate) async fn get_transport_config(
     opts: &AstarteOptions,
 ) -> Result<MqttOptions, AstarteOptionsError> {
     let (certificate_pem, private_key) = populate_credentials(opts).await?;

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -95,7 +95,6 @@ pub fn generate_uuid(namespace: uuid::Uuid, unique_data: &str) -> String {
 }
 
 #[cfg(test)]
-
 mod test {
     use crate::registration::generate_random_uuid;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -390,7 +390,6 @@ impl AstarteType {
 }
 
 #[cfg(test)]
-
 mod test {
     use std::convert::TryFrom;
     use std::convert::TryInto;

--- a/tests/e2etest/mock_data_aggregate.rs
+++ b/tests/e2etest/mock_data_aggregate.rs
@@ -25,6 +25,7 @@ use chrono::{DateTime, Utc};
 
 use astarte_device_sdk::types::AstarteType;
 use astarte_device_sdk::AstarteAggregate;
+#[cfg(not(feature = "derive"))]
 use astarte_device_sdk_derive::AstarteAggregate;
 
 use crate::utils;


### PR DESCRIPTION
Make the types and functions pub only when they are returned or used outside the crate.

Closes #165