### PR TITLE
 test(mock): introduce mocking for the AstarteSDK

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,8 @@ concurrency:
   cancel-in-progress: true
 env:
   CARGO_TERM_COLOR: always
+  # Enable logging otherwise the logging lines will count as not covered in the test coverage
+  RUST_LOG: trace
 jobs:
   required:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "http",
  "itertools 0.11.0",
  "log",
+ "mockall",
  "openssl",
  "p384",
  "rand_core",
@@ -424,6 +425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +447,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "ecdsa"
@@ -574,6 +587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +637,12 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "funty"
@@ -1165,6 +1193,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1255,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-traits"
@@ -1404,6 +1465,36 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools 0.10.5",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "primeorder"
@@ -2082,6 +2173,12 @@ checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ x509-cert = { version = "0.2.3", features = ["builder"] }
 astarte-device-sdk-derive = { path = "./astarte-device-sdk-derive" }
 colored = "2.0.0"
 env_logger = "0.10.0"
+mockall = "0.11.4"
 structopt = "0.3.26"
 tempfile = "3.6.0"
 

--- a/examples/individual_properties/interfaces/org.astarte-platform.rust.examples.individual-properties.DeviceProperties.json
+++ b/examples/individual_properties/interfaces/org.astarte-platform.rust.examples.individual-properties.DeviceProperties.json
@@ -9,6 +9,7 @@
     "mappings": [
         {
             "endpoint": "/%{sensor_id}/name",
+            "allow_unset": true,
             "type": "string",
             "description": "Sensor name.",
             "doc": "An arbitrary sensor name."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ pub mod crypto;
 pub mod database;
 pub mod interface;
 mod interfaces;
+#[cfg(test)]
+mod mock;
 pub mod options;
 pub mod pairing;
 pub mod registration;
@@ -35,13 +37,17 @@ pub use chrono;
 use interface::error::ValidationError;
 pub use rumqttc;
 
+#[cfg(test)]
+use mock::{MockAsyncClient as AsyncClient, MockEventLoop as EventLoop};
+#[cfg(not(test))]
+use rumqttc::{AsyncClient, EventLoop};
+
 use bson::Bson;
 use database::AstarteDatabase;
 use database::StoredProp;
 use log::{debug, error, info, trace};
 use options::AstarteOptions;
-use rumqttc::{AsyncClient, Event};
-use rumqttc::{EventLoop, MqttOptions};
+use rumqttc::{Event, MqttOptions};
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::convert::TryInto;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,10 @@ impl AstarteDeviceSdk {
                             let bdata = publish.payload;
 
                             if interface == "control" && path == "/consumer/properties" {
+                                debug!("Purging properties");
+
                                 self.purge_properties(&bdata).await?;
+
                                 continue;
                             }
 
@@ -1603,6 +1606,18 @@ mod test {
             "v": true
         };
 
+        // Purge properties
+        eventloope.expect_poll().once().returning(|| {
+            Ok(Event::Incoming(rumqttc::Packet::Publish(
+                rumqttc::Publish::new(
+                    "realm/device_id/control/consumer/properties",
+                    rumqttc::QoS::AtLeastOnce,
+                    vec![],
+                ),
+            )))
+        });
+
+        // Send properties
         eventloope.expect_poll().returning(move || {
             Ok(Event::Incoming(rumqttc::Packet::Publish(
                 rumqttc::Publish::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub enum AstarteError {
     #[error("malformed input from Astarte backend")]
     DeserializationError(#[from] bson::de::Error),
 
-    #[error("malformed input from Astarte backend, missinv value 'v' in document: {0}")]
+    #[error("malformed input from Astarte backend, missing value 'v' in document: {0}")]
     DeserializationMissingValue(bson::Document),
 
     #[error("error converting from Bson to AstarteType ({0})")]
@@ -1143,7 +1143,11 @@ mod test {
 
     use super::{AsyncClient, EventLoop};
 
-    fn mock_astarte<I>(client: AsyncClient, eventloop: EventLoop, interfaces: I) -> AstarteDeviceSdk
+    fn mock_astarte_device<I>(
+        client: AsyncClient,
+        eventloop: EventLoop,
+        interfaces: I,
+    ) -> AstarteDeviceSdk
     where
         I: IntoIterator<Item = Interface>,
     {
@@ -1461,7 +1465,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn wait_for_connack() {
+    async fn test_wait_for_connack() {
         let mut eventloope = EventLoop::default();
 
         eventloope.expect_poll().once().returning(|| {
@@ -1511,7 +1515,7 @@ mod test {
             Interface::from_str(include_str!("../examples/individual_datastream/interfaces/org.astarte-platform.rust.examples.individual-datastream.ServerDatastream.json")).unwrap()
         ];
 
-        let mut astarte = mock_astarte(client, eventloope, interfaces);
+        let mut astarte = mock_astarte_device(client, eventloope, interfaces);
 
         astarte.wait_for_connack().await.unwrap();
     }
@@ -1561,7 +1565,7 @@ mod test {
 
         let interface = include_str!("../examples/individual_datastream/interfaces/org.astarte-platform.rust.examples.individual-datastream.ServerDatastream.json");
 
-        let astarte = mock_astarte(client, eventloope, []);
+        let astarte = mock_astarte_device(client, eventloope, []);
 
         astarte.add_interface_from_str(interface).await.unwrap();
 
@@ -1609,7 +1613,7 @@ mod test {
             )))
         });
 
-        let mut astarte = mock_astarte(client, eventloope, [
+        let mut astarte = mock_astarte_device(client, eventloope, [
             Interface::from_str(include_str!("../examples/individual_properties/interfaces/org.astarte-platform.rust.examples.individual-properties.DeviceProperties.json")).unwrap(),
             Interface::from_str(include_str!("../examples/individual_properties/interfaces/org.astarte-platform.rust.examples.individual-properties.ServerProperties.json")).unwrap(),
         ]);

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -23,7 +23,6 @@ use rumqttc::{ClientError, ConnectionError, Event, MqttOptions, QoS};
 
 mock!(
     pub AsyncClient {
-        // NOTE: This is mocked for compatibility, but it will be hard to test
         pub fn new(options: MqttOptions, cap: usize) -> (MockAsyncClient, MockEventLoop);
         pub async fn subscribe<S: Into<String> + 'static>(&self, topic: S, qos: QoS) -> Result<(), ClientError>;
         pub async fn publish<S, V>(&self, topic: S, qos: QoS, retain: bool, payload: V,) -> Result<(), ClientError> where S: Into<String> + 'static, V: Into<Vec<u8>> + 'static;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,0 +1,41 @@
+// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Mocks for the Astarte Device SDK.
+
+use mockall::mock;
+use rumqttc::{ClientError, ConnectionError, Event, MqttOptions, QoS};
+
+mock!(
+    pub AsyncClient {
+        // NOTE: This is mocked for compatibility, but it will be hard to test
+        pub fn new(options: MqttOptions, cap: usize) -> (MockAsyncClient, MockEventLoop);
+        pub async fn subscribe<S: Into<String> + 'static>(&self, topic: S, qos: QoS) -> Result<(), ClientError>;
+        pub async fn publish<S, V>(&self, topic: S, qos: QoS, retain: bool, payload: V,) -> Result<(), ClientError> where S: Into<String> + 'static, V: Into<Vec<u8>> + 'static;
+        pub async fn unsubscribe<S: Into<String> + 'static>(&self, topic: S) -> Result<(), ClientError>;
+    }
+    impl Clone for AsyncClient {
+        fn clone(&self) -> Self;
+    }
+);
+
+mock! {
+    pub EventLoop{
+        pub async fn poll(&mut self) -> Result<Event, ConnectionError>;
+    }
+}


### PR DESCRIPTION
Mock the AsyncClient and EventLoop of the SDK, so we can unit test the
SDK without having to connect to a broker.

Closes #180