### PR TITLE
refactor(deps): update dependencies and clean up features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -82,7 +82,7 @@ dependencies = [
  "openssl",
  "reqwest",
  "rumqttc",
- "rustls",
+ "rustls 0.20.8",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -776,6 +776,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.21.1",
+ "tokio",
+ "tokio-rustls 0.24.0",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,9 +914,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -924,9 +937,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1034,15 +1047,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1081,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
@@ -1110,7 +1123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -1129,15 +1142,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1222,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -1294,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1324,6 +1337,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1333,16 +1347,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.1",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.24.0",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -1375,7 +1393,7 @@ dependencies = [
  "rustls-pemfile",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -1405,10 +1423,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.6.2"
+name = "rustls"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -1423,6 +1453,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1550,15 +1590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,7 +1683,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "sha2",
  "smallvec",
@@ -1692,7 +1723,7 @@ checksum = "804d3f245f894e61b1e6263c84b23ca675d96753b5abfd5cc8597d86806e8024"
 dependencies = [
  "once_cell",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -1881,7 +1912,6 @@ dependencies = [
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -1914,9 +1944,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio",
 ]
 
 [[package]]
@@ -2040,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
  "getrandom",
  "serde",
@@ -2221,7 +2261,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2241,35 +2281,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,12 +74,15 @@ dependencies = [
  "cargo-husky",
  "chrono",
  "colored",
+ "ecdsa",
  "env_logger",
  "flate2",
  "http",
  "itertools",
  "log",
  "openssl",
+ "p384",
+ "rand_core",
  "reqwest",
  "rumqttc",
  "rustls 0.20.8",
@@ -95,6 +98,7 @@ dependencies = [
  "url",
  "uuid",
  "webpki",
+ "x509-cert",
 ]
 
 [[package]]
@@ -143,6 +147,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +163,12 @@ name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
@@ -281,6 +297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,13 +393,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114792ba6b7545d3f3dd693794aed3a312a67795cd577fcc725c148d84fabe32"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -375,10 +436,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "sha2",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -437,6 +534,22 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "flagset"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
 
 [[package]]
 name = "flate2"
@@ -605,6 +718,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -618,6 +732,17 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -710,6 +835,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1084,15 +1227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "111.26.0+1.1.1u"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,9 +1234,20 @@ checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -1160,6 +1305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1352,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1372,15 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "primeorder"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2fcef82c0ec6eefcc179b978446c399b3cdf73c392c35604e399eee6df1ee3"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -1365,6 +1538,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1680,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1770,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1795,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1627,6 +1845,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -1765,6 +1993,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -2404,3 +2638,22 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077a1672d8ecfa5c1fe69fa7c5d043962e4e32866d4375495536261c0b4781f5"
+dependencies = [
+ "const-oid",
+ "der",
+ "sha1",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,14 @@ async-trait = "0.1.68"
 base64 = "0.21.2"
 bson = { version = "2.6.1", features = ["chrono-0_4"] }
 chrono = "0.4.26"
+ecdsa = { version = "0.16.7", features = ["sha2"] }
 flate2 = "1.0.26"
 http = "0.2.9"
 itertools = "0.10.5"
 log = "0.4.19"
-openssl = { version = "0.10.55", features = ["vendored"] }
+openssl = { version = "0.10.55", optional = true }
+p384 = "0.13.0"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 reqwest = { version = "0.11.18", features = ["json", "rustls-tls"] }
 rumqttc = "0.21.0"
 rustls = { version = "0.20.8", features = ["dangerous_configuration"] }
@@ -43,6 +46,7 @@ tokio = { version = "1.28.2", features = ["parking_lot", "macros"] }
 url = "2.4.0"
 uuid = { version = "1.3.4", features = ["v5", "v4"] }
 webpki = "0.22.0"
+x509-cert = { version = "0.2.3", features = ["builder"] }
 
 [dev-dependencies]
 astarte-device-sdk-derive = { path = "./astarte-device-sdk-derive" }
@@ -58,3 +62,4 @@ features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-f
 
 [features]
 derive = ["astarte-device-sdk-derive"]
+openssl = ["dep:openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,19 +29,19 @@ flate2 = "1.0.26"
 http = "0.2.9"
 itertools = "0.10.5"
 log = "0.4.19"
-openssl = { version = "0.10.54", features = ["vendored"] }
-reqwest = { version = "0.11.18", features = ["json"] }
+openssl = { version = "0.10.55", features = ["vendored"] }
+reqwest = { version = "0.11.18", features = ["json", "rustls-tls"] }
 rumqttc = "0.21.0"
 rustls = { version = "0.20.8", features = ["dangerous_configuration"] }
-rustls-native-certs = "0.6.2"
+rustls-native-certs = "0.6.3"
 rustls-pemfile = "1.0.2"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.97"
-sqlx = { version = "0.6.3", features = ["sqlite", "macros", "runtime-actix-rustls"] }
+sqlx = { version = "0.6.3", features = ["sqlite", "macros", "runtime-tokio-rustls"] }
 thiserror = "1.0.40"
-tokio = { version = "1.28.2", features = ["full"] }
+tokio = { version = "1.28.2", features = ["parking_lot", "macros"] }
 url = "2.4.0"
-uuid = { version = "1.3.3", features = ["v5", "v4"] }
+uuid = { version = "1.3.4", features = ["v5", "v4"] }
 webpki = "0.22.0"
 
 [dev-dependencies]

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -18,28 +18,103 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use openssl::{
-    ec::{EcGroup, EcKey},
-    error::ErrorStack,
-    hash::MessageDigest,
-    nid::Nid,
-    pkey::PKey,
-    x509::{X509NameBuilder, X509ReqBuilder},
+use std::str::FromStr;
+
+use p384::{
+    ecdsa::{DerSignature, SigningKey},
+    pkcs8::{EncodePrivateKey, LineEnding},
+    SecretKey,
+};
+use rustls::PrivateKey;
+use x509_cert::{
+    builder::{Builder, RequestBuilder},
+    der::EncodePem,
+    name::Name,
 };
 
-/// A bundle containing a private key and a CSR.
+/// Errors that can occur while generating the Certificate and CSR.
+#[non_exhaustive]
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[cfg(feature = "openssl")]
+    #[error("Openssl error")]
+    Openssl(#[from] openssl::error::ErrorStack),
+
+    #[error("Invalid COMMONNAME")]
+    InvalidCn(#[from] x509_cert::der::Error),
+
+    #[error("Failed to create Certificate and CSR")]
+    Certificate(#[from] x509_cert::builder::Error),
+
+    #[error("Failed to encode key to PKCS8 pem")]
+    Pem(#[from] p384::pkcs8::Error),
+
+    #[error("Invalid UTF-8 encoded PEM")]
+    Utf8(#[from] std::string::FromUtf8Error),
+}
+
+#[cfg(windows)]
+const LINE_ENDING: LineEnding = LineEnding::CRLF;
+
+#[cfg(not(windows))]
+const LINE_ENDING: LineEnding = LineEnding::LF;
+
+/// Generate a Certificate and CSR bundle in PEM format.
+#[derive(Debug)]
 pub struct Bundle {
-    pub private_key: Vec<u8>,
-    pub csr: Vec<u8>,
+    pub private_key: PrivateKey,
+    /// PEM encoded CSR
+    pub csr: String,
 }
 
 impl Bundle {
-    pub fn new(cn: &str) -> Result<Bundle, ErrorStack> {
+    pub fn new(realm: &str, device_id: &str) -> Result<Bundle, Error> {
+        if cfg!(feature = "openssl") {
+            #[cfg(feature = "openssl")]
+            return Self::openssl_key(realm, device_id);
+        }
+
+        Self::generate_key(realm, device_id)
+    }
+
+    pub fn generate_key(realm: &str, device_id: &str) -> Result<Bundle, Error> {
+        // The realm/device_id for the certificate
+        let subject = Name::from_str(&format!("CN={}/{}", realm, device_id))?;
+
+        // Generate a random private key
+        let private_key = SecretKey::random(&mut rand_core::OsRng);
+
+        // This need to define the signer key type
+        let signer = SigningKey::from(&private_key);
+
+        let csr = RequestBuilder::new(subject, &signer)?
+            .build::<DerSignature>()?
+            .to_pem(LINE_ENDING)?;
+
+        // The private_key is held into a Zeroing wrapper as a security measure so that the key is
+        // note kept in memory. We nee to extract the key from the wrapper to use it normally.
+        let mut z_private_key = private_key.to_pkcs8_der()?.to_bytes();
+        // Replace the private_key with an empty string to take it out without cloning it.
+        let private_key = PrivateKey(std::mem::take(&mut z_private_key));
+
+        Ok(Bundle { private_key, csr })
+    }
+
+    #[cfg(feature = "openssl")]
+    pub fn openssl_key(realm: &str, device_id: &str) -> Result<Bundle, Error> {
+        use openssl::{
+            ec::{EcGroup, EcKey},
+            hash::MessageDigest,
+            nid::Nid,
+            pkey::PKey,
+            x509::{X509NameBuilder, X509ReqBuilder},
+        };
+
         let group = EcGroup::from_curve_name(Nid::SECP384R1)?;
         let ec_key = EcKey::generate(&group)?;
 
         let mut subject_builder = X509NameBuilder::new()?;
-        subject_builder.append_entry_by_nid(Nid::COMMONNAME, cn)?;
+        subject_builder.append_entry_by_nid(Nid::COMMONNAME, &format!("{realm}/{device_id}"))?;
 
         let subject_name = subject_builder.build();
 
@@ -48,34 +123,117 @@ impl Bundle {
         req_builder.set_pubkey(&pkey)?;
         req_builder.set_subject_name(&subject_name)?;
         req_builder.sign(&pkey, MessageDigest::sha512())?;
-        let pkey_bytes = pkey.private_key_to_pem_pkcs8()?;
+        let pkey_bytes = pkey.private_key_to_pkcs8()?;
 
         let csr_bytes = req_builder.build().to_pem()?;
 
         Ok(Bundle {
-            private_key: pkey_bytes,
-            csr: csr_bytes,
+            private_key: PrivateKey(pkey_bytes),
+            csr: String::from_utf8(csr_bytes)?,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use p384::{
+        ecdsa::{signature::Verifier, Signature, VerifyingKey},
+        pkcs8::DecodePrivateKey,
+    };
+    use x509_cert::{
+        der::{DecodePem, Encode},
+        request::CertReq,
+    };
+
     use super::*;
 
     #[test]
-    fn test_bundle() {
-        let bundle = Bundle::new("test").unwrap();
-        assert!(!bundle.private_key.is_empty());
+    fn test_new_cert() {
+        let bundle = Bundle::new("realm", "device_id");
+
+        assert!(
+            bundle.is_ok(),
+            "Failed to generate certificate: {}",
+            bundle.unwrap_err()
+        );
+
+        let bundle = bundle.unwrap();
+
+        assert!(!bundle.private_key.0.is_empty());
         assert!(!bundle.csr.is_empty());
+    }
 
-        let pkey = PKey::private_key_from_pem(&bundle.private_key).unwrap();
-        let csr = openssl::x509::X509Req::from_pem(&bundle.csr).unwrap();
+    #[test]
+    fn test_bundle() {
+        let Bundle {
+            private_key: PrivateKey(private_key),
+            csr,
+        } = Bundle::generate_key("realm", "device_id").unwrap();
+        assert!(!private_key.is_empty());
+        assert!(!csr.is_empty());
 
-        assert!(csr.verify(&pkey).unwrap());
+        let csr = CertReq::from_pem(csr.as_bytes()).unwrap();
+        assert_eq!(csr.info.subject.to_string(), "CN=realm/device_id");
+
+        let private_key = SecretKey::from_pkcs8_der(&private_key).unwrap();
+        let signer = SigningKey::from(&private_key);
+        let verifier = VerifyingKey::from(signer);
+
+        let sign_bytes = csr
+            .signature
+            .as_bytes()
+            .expect("Failed to get signature bytes");
+        let signature: Signature = Signature::from_der(sign_bytes).expect("Failed to decode DER");
+
+        let info = csr.info.to_der().expect("Failed to encode CSR info");
+
+        assert!(verifier.verify(&info, &signature).is_ok());
+    }
+
+    #[cfg(feature = "openssl")]
+    #[test]
+    fn test_bundle_sanity_test() {
+        // This will check both implementation are compatible
+        let Bundle {
+            private_key: PrivateKey(private_key),
+            csr,
+        } = Bundle::generate_key("realm", "device_id").unwrap();
+        assert!(!private_key.is_empty());
+        assert!(!csr.is_empty());
+
+        let private_key = openssl::pkey::PKey::private_key_from_der(&private_key).unwrap();
+        let csr = openssl::x509::X509Req::from_pem(csr.as_bytes()).unwrap();
+
+        assert!(csr.verify(&private_key).unwrap());
 
         let subject_name = csr.subject_name();
-        let cn = subject_name.entries_by_nid(Nid::COMMONNAME).next().unwrap();
-        assert_eq!(cn.data().as_slice(), b"test");
+        let cn = subject_name
+            .entries_by_nid(openssl::nid::Nid::COMMONNAME)
+            .next()
+            .unwrap();
+        assert_eq!(cn.data().as_slice(), b"realm/device_id");
+    }
+
+    #[cfg(feature = "openssl")]
+    #[test]
+    fn test_bundle_openssl() {
+        let Bundle {
+            private_key: PrivateKey(private_key),
+            csr,
+        } = Bundle::openssl_key("realm", "device_id").unwrap();
+        assert!(!private_key.is_empty());
+        assert!(!csr.is_empty());
+
+        let private_key = openssl::pkey::PKey::private_key_from_der(&private_key).unwrap();
+        let csr = openssl::x509::X509Req::from_pem(csr.as_bytes()).unwrap();
+
+        assert!(csr.verify(&private_key).unwrap());
+
+        let subject_name = csr.subject_name();
+        let cn = subject_name
+            .entries_by_nid(openssl::nid::Nid::COMMONNAME)
+            .next()
+            .unwrap();
+        assert_eq!(cn.data().as_slice(), b"realm/device_id");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
  */
 #![doc = include_str!("../README.md")]
 
-mod crypto;
+pub mod crypto;
 pub mod database;
 pub mod interface;
 mod interfaces;

--- a/src/options.rs
+++ b/src/options.rs
@@ -27,9 +27,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use log::debug;
-use openssl::error::ErrorStack;
 use pairing::PairingError;
 
+use crate::crypto::Error as CryptoError;
 use crate::database::AstarteDatabase;
 use crate::interface;
 use crate::interfaces::Interfaces;
@@ -43,7 +43,7 @@ use interface::Interface;
 #[derive(thiserror::Error, Debug)]
 pub enum AstarteOptionsError {
     #[error("private key or CSR creation failed")]
-    CryptoGeneration(#[from] ErrorStack),
+    CryptoGeneration(#[from] CryptoError),
 
     #[error("device must have at least an interface")]
     MissingInterfaces,


### PR DESCRIPTION
Make all the dependencies use rustls for TLS, still using openssl to generate the keys. Remove unused features from tokio to slim down the crate.

Closes #191