### PR TITLE
ci(e2e): make the e2e test runnable locally

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -57,7 +57,8 @@ jobs:
           echo "RUST_LOG=debug" >> $GITHUB_ENV
           TOKEN=$(astartectl utils gen-jwt appengine)
           echo "E2E_TOKEN=$TOKEN" >> $GITHUB_ENV
-          echo "E2E_API_URL=https://api.autotest.astarte-platform.org" >> $GITHUB_ENV
+          echo "E2E_API_URL=https://api.autotest.astarte-platform.org/appengine" >> $GITHUB_ENV
+          echo "E2E_PAIRING_URL=https://api.autotest.astarte-platform.org/pairing" >> $GITHUB_ENV
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,8 +75,8 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
       - name: Set VCPKG_ROOT
         run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-      - name: Install openssl
-        run: vcpkg install --binarysource="clear;x-gha,readwrite" openssl:x64-windows-static-md
+      - name: Install dependencies
+        run: vcpkg install --binarysource="clear;x-gha,readwrite" openssl:x64-windows-static-md sqlite3
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile


### PR DESCRIPTION
Add an environment variable for the pairing URL, and make the API URL variable include the appengine path.