### PR TITLE
 refactor(options): require ownership of the options 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Expose `pairing::PairingError` to public visibility.
 - Bump `MSRV` to 1.66.1.
+- The `AstartDeviceSdk` now requires an owned `AstarteOptions` instance.
 
 ## [0.5.1] - 2023-02-06
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ async fn run_astarte_device() -> Result<(), AstarteError> {
         .database(db);
 
     // 3. Create the device instance
-    let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
+    let mut device = AstarteDeviceSdk::new(sdk_options).await.unwrap();
 
     // Publishing new values can be performed using the send and send_object functions.
 

--- a/examples/individual_datastream/main.rs
+++ b/examples/individual_datastream/main.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), AstarteError> {
     .ignore_ssl_errors();
 
     // Create an Astarte Device (also performs the connection)
-    let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await?;
+    let mut device = astarte_device_sdk::AstarteDeviceSdk::new(sdk_options).await?;
     println!("Connection to Astarte established.");
 
     // Create an thread to transmit

--- a/examples/individual_properties/main.rs
+++ b/examples/individual_properties/main.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<(), AstarteError> {
     .ignore_ssl_errors();
 
     // Create an Astarte Device (also performs the connection)
-    let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await?;
+    let mut device = astarte_device_sdk::AstarteDeviceSdk::new(sdk_options).await?;
     println!("Connection to Astarte established.");
 
     // Create an thread to transmit

--- a/examples/object_datastream/main.rs
+++ b/examples/object_datastream/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), AstarteError> {
     .ignore_ssl_errors();
 
     // Create an Astarte Device (also performs the connection)
-    let mut device = astarte_device_sdk::AstarteDeviceSdk::new(&sdk_options).await?;
+    let mut device = astarte_device_sdk::AstarteDeviceSdk::new(sdk_options).await?;
     println!("Connection to Astarte established.");
 
     // Create an thread to transmit

--- a/tests/e2etest/main.rs
+++ b/tests/e2etest/main.rs
@@ -143,7 +143,7 @@ async fn e2etest_impl() {
         sdk_options = sdk_options.ignore_ssl_errors();
     }
 
-    let mut device = AstarteDeviceSdk::new(&sdk_options).await.unwrap();
+    let mut device = AstarteDeviceSdk::new(sdk_options).await.unwrap();
     let rx_data_ind_datastream = Arc::new(Mutex::new(HashMap::new()));
     let rx_data_agg_datastream = Arc::new(Mutex::new((String::new(), HashMap::new())));
     let rx_data_ind_prop = Arc::new(Mutex::new((String::new(), HashMap::new())));


### PR DESCRIPTION
This prevents some clones while creating the AstarteSdk object. Since
the AstarteOptions can be cloned outside of the new function, or usually
the entire SDK object is cloned. This also removes the mqtt_options from
the SDK, because it's never used and it's a fair large object (circa
300 bytes).
