### PR TITLE
refactor(error): rename error, make them non exaustive and give them specific names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `pairing::PairingError` to public visibility.
 - Bump `MSRV` to 1.66.1.
 - The `AstartDeviceSdk` now requires an owned `AstarteOptions` instance.
+- Rename the main error in `Error` and give the other errors more specific names.
+- Mark all errors as `#[non_exhaustive]`.
 
 ## [0.5.1] - 2023-02-06
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ for more information regarding Astarte and the available SDKs.
 use astarte_device_sdk::{
     database::AstarteSqliteDatabase,
     options::AstarteOptions,
-    AstarteDeviceSdk,
-    AstarteError
+    error::AstarteError,
+    AstarteDeviceSdk
 };
 
 async fn run_astarte_device() -> Result<(), AstarteError> {

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ for more information regarding Astarte and the available SDKs.
 use astarte_device_sdk::{
     database::AstarteSqliteDatabase,
     options::AstarteOptions,
-    error::AstarteError,
+    error::Error,
     AstarteDeviceSdk
 };
 
-async fn run_astarte_device() -> Result<(), AstarteError> {
+async fn run_astarte_device() -> Result<(), Error> {
 
     let realm = "realm_name";
     let device_id = "device_id";

--- a/astarte-device-sdk-derive/src/lib.rs
+++ b/astarte-device-sdk-derive/src/lib.rs
@@ -85,7 +85,7 @@ fn impl_astarte_aggregate_derive(ast: syn::DeriveInput) -> TokenStream {
                         self,
                     ) -> Result<
                         std::collections::HashMap<String, astarte_device_sdk::types::AstarteType>,
-                        astarte_device_sdk::AstarteError,
+                        astarte_device_sdk::error::AstarteError,
                     > {
                         let mut result = std::collections::HashMap::new();
                         #(

--- a/astarte-device-sdk-derive/src/lib.rs
+++ b/astarte-device-sdk-derive/src/lib.rs
@@ -85,7 +85,7 @@ fn impl_astarte_aggregate_derive(ast: syn::DeriveInput) -> TokenStream {
                         self,
                     ) -> Result<
                         std::collections::HashMap<String, astarte_device_sdk::types::AstarteType>,
-                        astarte_device_sdk::error::AstarteError,
+                        astarte_device_sdk::error::Error,
                     > {
                         let mut result = std::collections::HashMap::new();
                         #(

--- a/examples/individual_datastream/main.rs
+++ b/examples/individual_datastream/main.rs
@@ -21,7 +21,7 @@ use std::time::SystemTime;
 
 use serde::Deserialize;
 
-use astarte_device_sdk::{error::AstarteError, options::AstarteOptions};
+use astarte_device_sdk::{error::Error, options::AstarteOptions};
 
 #[derive(Deserialize)]
 struct Config {
@@ -32,7 +32,7 @@ struct Config {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), AstarteError> {
+async fn main() -> Result<(), Error> {
     env_logger::init();
     let now = SystemTime::now();
 
@@ -98,7 +98,7 @@ async fn main() -> Result<(), AstarteError> {
                         .next()
                         .and_then(|id| id.parse::<u16>().ok())
                         .ok_or_else(|| {
-                            AstarteError::ReceiveError("Incorrect error received.".to_string())
+                            Error::ReceiveError("Incorrect error received.".to_string())
                         })?;
 
                     match iter.next() {

--- a/examples/individual_datastream/main.rs
+++ b/examples/individual_datastream/main.rs
@@ -21,7 +21,7 @@ use std::time::SystemTime;
 
 use serde::Deserialize;
 
-use astarte_device_sdk::{options::AstarteOptions, AstarteError};
+use astarte_device_sdk::{error::AstarteError, options::AstarteOptions};
 
 #[derive(Deserialize)]
 struct Config {

--- a/examples/individual_properties/main.rs
+++ b/examples/individual_properties/main.rs
@@ -21,8 +21,8 @@
 use serde::{Deserialize, Serialize};
 
 use astarte_device_sdk::{
-    database::AstarteSqliteDatabase, error::AstarteError, options::AstarteOptions,
-    types::AstarteType, AstarteDeviceSdk,
+    database::AstarteSqliteDatabase, error::Error, options::AstarteOptions, types::AstarteType,
+    AstarteDeviceSdk,
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -54,7 +54,7 @@ async fn get_name_for_sensor(device: &AstarteDeviceSdk, sensor_n: i32) -> Result
 }
 
 #[tokio::main]
-async fn main() -> Result<(), AstarteError> {
+async fn main() -> Result<(), Error> {
     env_logger::init();
 
     // Load configuration
@@ -129,7 +129,7 @@ async fn main() -> Result<(), AstarteError> {
                         .next()
                         .and_then(|id| id.parse::<u16>().ok())
                         .ok_or_else(|| {
-                            AstarteError::ReceiveError("Incorrect error received.".to_string())
+                            Error::ReceiveError("Incorrect error received.".to_string())
                         })?;
 
                     match iter.next() {

--- a/examples/individual_properties/main.rs
+++ b/examples/individual_properties/main.rs
@@ -21,8 +21,8 @@
 use serde::{Deserialize, Serialize};
 
 use astarte_device_sdk::{
-    database::AstarteSqliteDatabase, options::AstarteOptions, types::AstarteType, AstarteDeviceSdk,
-    AstarteError,
+    database::AstarteSqliteDatabase, error::AstarteError, options::AstarteOptions,
+    types::AstarteType, AstarteDeviceSdk,
 };
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/examples/object_datastream/main.rs
+++ b/examples/object_datastream/main.rs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_device_sdk::{error::AstarteError, options::AstarteOptions, AstarteAggregate};
+use astarte_device_sdk::{error::Error, options::AstarteOptions, AstarteAggregate};
 #[cfg(not(feature = "derive"))]
 use astarte_device_sdk_derive::AstarteAggregate;
 
@@ -40,7 +40,7 @@ struct DataObject {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), AstarteError> {
+async fn main() -> Result<(), Error> {
     env_logger::init();
 
     // Load configuration

--- a/examples/object_datastream/main.rs
+++ b/examples/object_datastream/main.rs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_device_sdk::{options::AstarteOptions, AstarteAggregate, AstarteError};
+use astarte_device_sdk::{error::AstarteError, options::AstarteOptions, AstarteAggregate};
 #[cfg(not(feature = "derive"))]
 use astarte_device_sdk_derive::AstarteAggregate;
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -45,7 +45,7 @@ use x509_cert::{
 /// Errors that can occur while generating the Certificate and CSR.
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+pub enum CryptoError {
     #[cfg(feature = "openssl")]
     #[error("Openssl error")]
     Openssl(#[from] openssl::error::ErrorStack),
@@ -72,7 +72,7 @@ pub(crate) struct Bundle {
 }
 
 impl Bundle {
-    pub(crate) fn new(realm: &str, device_id: &str) -> Result<Bundle, Error> {
+    pub(crate) fn new(realm: &str, device_id: &str) -> Result<Bundle, CryptoError> {
         // This is written this way so when all features are enable, the generate_key function is
         // not marked as unused. The if will be optimized out by the compiler in release.
         if cfg!(feature = "openssl") {
@@ -83,7 +83,7 @@ impl Bundle {
         Self::generate_key(realm, device_id)
     }
 
-    pub(crate) fn generate_key(realm: &str, device_id: &str) -> Result<Bundle, Error> {
+    pub(crate) fn generate_key(realm: &str, device_id: &str) -> Result<Bundle, CryptoError> {
         // The realm/device_id for the certificate
         let subject = Name::from_str(&format!("CN={}/{}", realm, device_id))?;
 
@@ -108,7 +108,7 @@ impl Bundle {
     }
 
     #[cfg(feature = "openssl")]
-    pub(crate) fn openssl_key(realm: &str, device_id: &str) -> Result<Bundle, Error> {
+    pub(crate) fn openssl_key(realm: &str, device_id: &str) -> Result<Bundle, CryptoError> {
         let group = EcGroup::from_curve_name(Nid::SECP384R1)?;
         let ec_key = EcKey::generate(&group)?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,17 +20,16 @@
 
 use std::convert::Infallible;
 
-use crate::interface::error::ValidationError;
-use crate::interface::mapping::path::Error as MappingError;
-use crate::interface::Error as InterfaceError;
-use crate::options::AstarteOptionsError;
+use crate::interface::mapping::path::MappingError;
+use crate::interface::InterfaceError;
+use crate::options::OptionsError;
 use crate::topic::TopicError;
 
 /// Astarte error.
 ///
 /// Possible errors returned by functions of the Astarte device SDK.
 #[derive(thiserror::Error, Debug)]
-pub enum AstarteError {
+pub enum Error {
     #[error("bson serialize error")]
     BsonSerError(#[from] bson::ser::Error),
 
@@ -65,10 +64,10 @@ pub enum AstarteError {
     DbError(#[from] sqlx::Error),
 
     #[error("options error")]
-    OptionsError(#[from] AstarteOptionsError),
+    OptionsError(#[from] OptionsError),
 
-    #[error(transparent)]
-    InterfaceError(#[from] InterfaceError),
+    #[error("invalid interface")]
+    Interface(#[from] InterfaceError),
 
     #[error("generic error ({0})")]
     Reported(String),
@@ -87,7 +86,4 @@ pub enum AstarteError {
 
     #[error("invalid mapping path '{}'", .0.path())]
     InvalidEndpoint(#[from] MappingError),
-
-    #[error("invalid interface added")]
-    InvalidInterface(#[from] ValidationError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,93 @@
+// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Error types for the Astarte SDK.
+
+use std::convert::Infallible;
+
+use crate::interface::error::ValidationError;
+use crate::interface::mapping::path::Error as MappingError;
+use crate::interface::Error as InterfaceError;
+use crate::options::AstarteOptionsError;
+use crate::topic::TopicError;
+
+/// Astarte error.
+///
+/// Possible errors returned by functions of the Astarte device SDK.
+#[derive(thiserror::Error, Debug)]
+pub enum AstarteError {
+    #[error("bson serialize error")]
+    BsonSerError(#[from] bson::ser::Error),
+
+    #[error("bson client error")]
+    BsonClientError(#[from] rumqttc::ClientError),
+
+    #[error("mqtt connection error")]
+    ConnectionError(#[from] rumqttc::ConnectionError),
+
+    #[error("malformed input from Astarte backend")]
+    DeserializationError(#[from] bson::de::Error),
+
+    #[error("malformed input from Astarte backend, missing value 'v' in document: {0}")]
+    DeserializationMissingValue(bson::Document),
+
+    #[error("error converting from Bson to AstarteType ({0})")]
+    FromBsonError(String),
+
+    #[error("type mismatch in bson array from astarte, something has gone very wrong here")]
+    FromBsonArrayError,
+
+    #[error("forbidden floating point number")]
+    FloatError,
+
+    #[error("send error ({0})")]
+    SendError(String),
+
+    #[error("receive error ({0})")]
+    ReceiveError(String),
+
+    #[error("database error")]
+    DbError(#[from] sqlx::Error),
+
+    #[error("options error")]
+    OptionsError(#[from] AstarteOptionsError),
+
+    #[error(transparent)]
+    InterfaceError(#[from] InterfaceError),
+
+    #[error("generic error ({0})")]
+    Reported(String),
+
+    #[error("generic error")]
+    Unreported,
+
+    #[error("conversion error")]
+    Conversion,
+
+    #[error("infallible error")]
+    Infallible(#[from] Infallible),
+
+    #[error("invalid topic {}",.0.topic())]
+    InvalidTopic(#[from] TopicError),
+
+    #[error("invalid mapping path '{}'", .0.path())]
+    InvalidEndpoint(#[from] MappingError),
+
+    #[error("invalid interface added")]
+    InvalidInterface(#[from] ValidationError),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,7 @@ use crate::topic::TopicError;
 /// Astarte error.
 ///
 /// Possible errors returned by functions of the Astarte device SDK.
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("bson serialize error")]

--- a/src/interface/def.rs
+++ b/src/interface/def.rs
@@ -33,7 +33,7 @@ use crate::{
     Interface,
 };
 
-use super::{DatabaseRetention, Error, InterfaceType, Retention};
+use super::{DatabaseRetention, InterfaceError, InterfaceType, Retention};
 
 /// Utility to skip default value
 fn is_default<T: Default + PartialEq>(value: &T) -> bool {
@@ -232,7 +232,7 @@ impl<'a> From<&'a Interface> for InterfaceDef<'a> {
 }
 
 impl<'a> TryFrom<InterfaceDef<'a>> for Interface {
-    type Error = Error;
+    type Error = InterfaceError;
 
     fn try_from(def: InterfaceDef<'a>) -> Result<Self, Self::Error> {
         let inner = match def.interface_type {

--- a/src/interface/error.rs
+++ b/src/interface/error.rs
@@ -22,6 +22,7 @@ use std::io;
 use super::{mapping::endpoint::EndpointError, validation::VersionChangeError};
 
 /// Error for parsing and validating an interface.
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum InterfaceError {
     #[error("cannot parse interface JSON")]

--- a/src/interface/error.rs
+++ b/src/interface/error.rs
@@ -19,11 +19,11 @@
 
 use std::io;
 
-use super::{mapping::endpoint::Error as EndpointError, validation::VersionChange};
+use super::{mapping::endpoint::EndpointError, validation::VersionChangeError};
 
 /// Error for parsing and validating an interface.
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+pub enum InterfaceError {
     #[error("cannot parse interface JSON")]
     Parse(#[from] serde_json::Error),
     #[error("cannot read interface file")]
@@ -48,11 +48,6 @@ pub enum Error {
     DuplicateMapping { endpoint: String, duplicate: String },
     #[error("object endpoint should have at least 2 levels: '{0}'")]
     ObjectEndpointTooShort(String),
-}
-
-/// Error for an interface validation.
-#[derive(thiserror::Error, Debug)]
-pub enum ValidationError {
     /// The name of the interface was changed.
     #[error(
         r#"this version has a different name than the previous version
@@ -63,18 +58,4 @@ pub enum ValidationError {
     /// Invalid version change.
     #[error("invalid version: {0}")]
     Version(VersionChangeError),
-}
-
-/// Error for changing the version of an interface.
-#[derive(thiserror::Error, Debug, Clone, Copy)]
-pub enum VersionChangeError {
-    /// The major version cannot be decreased.
-    #[error("the major version decreased: {0}")]
-    MajorDecresed(VersionChange),
-    /// The minor version cannot be decreased.
-    #[error("the minor version decreased: {0}")]
-    MinorDecresed(VersionChange),
-    // The interface is different but the version did not change.
-    #[error("the version did not change: {0}")]
-    SameVersion(VersionChange),
 }

--- a/src/interface/mapping/endpoint.rs
+++ b/src/interface/mapping/endpoint.rs
@@ -223,6 +223,8 @@ impl<'a> Ord for Level<'a> {
     }
 }
 
+/// Error that can happen when parsing an endpoint.
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum EndpointError {
     #[error("endpoint must start with a slash, got instead: {0}")]
@@ -247,6 +249,8 @@ impl EndpointError {
     }
 }
 
+/// Error that can happen when parsing a level.
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum LevelError {
     #[error("levels must not be empty")]

--- a/src/interface/mapping/mod.rs
+++ b/src/interface/mapping/mod.rs
@@ -20,7 +20,7 @@ use std::{borrow::Borrow, ops::Deref};
 
 use self::endpoint::Endpoint;
 
-use super::{DatabaseRetention, Error, Mapping, MappingType, Reliability, Retention};
+use super::{DatabaseRetention, InterfaceError, Mapping, MappingType, Reliability, Retention};
 
 pub mod endpoint;
 pub mod iter;
@@ -62,7 +62,7 @@ impl<'a> From<&'a DatastreamIndividualMapping> for Mapping<'a> {
 }
 
 impl TryFrom<&Mapping<'_>> for DatastreamIndividualMapping {
-    type Error = Error;
+    type Error = InterfaceError;
 
     fn try_from(value: &Mapping<'_>) -> Result<Self, Self::Error> {
         let base_mapping = BaseMapping::try_from(value)?;
@@ -126,7 +126,7 @@ impl<'a> From<&'a PropertiesMapping> for Mapping<'a> {
 }
 
 impl TryFrom<&Mapping<'_>> for PropertiesMapping {
-    type Error = Error;
+    type Error = InterfaceError;
 
     fn try_from(value: &Mapping<'_>) -> Result<Self, Self::Error> {
         let base_mapping = BaseMapping::try_from(value)?;
@@ -211,7 +211,7 @@ impl<'a> From<&'a BaseMapping> for Mapping<'a> {
 }
 
 impl<'a> TryFrom<&Mapping<'a>> for BaseMapping {
-    type Error = Error;
+    type Error = InterfaceError;
 
     fn try_from(value: &Mapping<'a>) -> Result<Self, Self::Error> {
         let endpoint = Endpoint::try_from(value.endpoint())?.into_owned();

--- a/src/interface/mapping/path.rs
+++ b/src/interface/mapping/path.rs
@@ -126,6 +126,8 @@ impl PartialEq<&str> for MappingPath<'_> {
     }
 }
 
+/// Error that can happen while parsing the MQTT levels structure of the topic received.
+#[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]
 pub enum MappingError {
     #[error("path missing prefix: {0}")]

--- a/src/interface/validation.rs
+++ b/src/interface/validation.rs
@@ -22,6 +22,7 @@ use std::{cmp::Ordering, fmt::Display};
 use super::Interface;
 
 /// Error for changing the version of an interface.
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug, Clone, Copy)]
 pub enum VersionChangeError {
     /// The major version cannot be decreased.

--- a/src/interface/validation.rs
+++ b/src/interface/validation.rs
@@ -19,7 +19,21 @@
 
 use std::{cmp::Ordering, fmt::Display};
 
-use super::{error::VersionChangeError, Interface};
+use super::Interface;
+
+/// Error for changing the version of an interface.
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+pub enum VersionChangeError {
+    /// The major version cannot be decreased.
+    #[error("the major version decreased: {0}")]
+    MajorDecresed(VersionChange),
+    /// The minor version cannot be decreased.
+    #[error("the minor version decreased: {0}")]
+    MinorDecresed(VersionChange),
+    // The interface is different but the version did not change.
+    #[error("the version did not change: {0}")]
+    SameVersion(VersionChange),
+}
 
 /// A change in version of an interface.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,9 @@ pub use crate::interface::Interface;
 
 use crate::database::AstarteDatabase;
 use crate::database::StoredProp;
-use crate::error::AstarteError;
+use crate::error::Error;
 use crate::interface::mapping::path::MappingPath;
+use crate::interface::InterfaceError;
 use crate::options::AstarteOptions;
 use crate::topic::parse_topic;
 use crate::types::AstarteType;
@@ -81,7 +82,7 @@ pub trait AstarteAggregate {
     /// use std::collections::HashMap;
     /// use std::convert::TryInto;
     ///
-    /// use astarte_device_sdk::{types::AstarteType, error::AstarteError, AstarteAggregate};
+    /// use astarte_device_sdk::{types::AstarteType, error::Error, AstarteAggregate};
     ///
     /// struct Person {
     ///     name: String,
@@ -91,7 +92,7 @@ pub trait AstarteAggregate {
     ///
     /// // This is what #[derive(AstarteAggregate)] would generate.
     /// impl AstarteAggregate for Person {
-    ///     fn astarte_aggregate(self) -> Result<HashMap<String, AstarteType>, AstarteError>
+    ///     fn astarte_aggregate(self) -> Result<HashMap<String, AstarteType>, Error>
     ///     {
     ///         let mut r = HashMap::new();
     ///         r.insert("name".to_string(), self.name.try_into()?);
@@ -101,11 +102,11 @@ pub trait AstarteAggregate {
     ///     }
     /// }
     /// ```
-    fn astarte_aggregate(self) -> Result<HashMap<String, AstarteType>, AstarteError>;
+    fn astarte_aggregate(self) -> Result<HashMap<String, AstarteType>, Error>;
 }
 
 impl AstarteAggregate for HashMap<String, AstarteType> {
-    fn astarte_aggregate(self) -> Result<HashMap<String, AstarteType>, AstarteError> {
+    fn astarte_aggregate(self) -> Result<HashMap<String, AstarteType>, Error> {
         Ok(self)
     }
 }
@@ -176,7 +177,7 @@ impl AstarteDeviceSdk {
     ///     let mut device = AstarteDeviceSdk::new(sdk_options).await.unwrap();
     /// }
     /// ```
-    pub async fn new(opts: AstarteOptions) -> Result<AstarteDeviceSdk, AstarteError> {
+    pub async fn new(opts: AstarteOptions) -> Result<AstarteDeviceSdk, Error> {
         let mqtt_options = pairing::get_transport_config(&opts).await?;
 
         debug!("{:#?}", mqtt_options);
@@ -197,7 +198,7 @@ impl AstarteDeviceSdk {
         Ok(device)
     }
 
-    async fn wait_for_connack(&mut self) -> Result<(), AstarteError> {
+    async fn wait_for_connack(&mut self) -> Result<(), Error> {
         loop {
             // keep consuming and processing packets until we have data for the user
             match self.eventloop.lock().await.poll().await? {
@@ -217,7 +218,7 @@ impl AstarteDeviceSdk {
         }
     }
 
-    async fn connack(&self, p: rumqttc::ConnAck) -> Result<(), AstarteError> {
+    async fn connack(&self, p: rumqttc::ConnAck) -> Result<(), Error> {
         if !p.session_present {
             self.subscribe().await?;
             self.send_introspection().await?;
@@ -229,7 +230,7 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    async fn subscribe(&self) -> Result<(), AstarteError> {
+    async fn subscribe(&self) -> Result<(), Error> {
         let ifaces = &self.interfaces.read().await;
         let server_owned_ifaces = ifaces
             .iter_interfaces()
@@ -249,10 +250,7 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    async fn subscribe_server_owned_interface(
-        &self,
-        iface: &Interface,
-    ) -> Result<(), AstarteError> {
+    async fn subscribe_server_owned_interface(&self, iface: &Interface) -> Result<(), Error> {
         if iface.ownership() != interface::Ownership::Server {
             warn!("Unable to subscribe to {} as it is not server owned", iface);
         } else {
@@ -266,10 +264,7 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    async fn unsubscribe_server_owned_interface(
-        &self,
-        iface: &Interface,
-    ) -> Result<(), AstarteError> {
+    async fn unsubscribe_server_owned_interface(&self, iface: &Interface) -> Result<(), Error> {
         if iface.ownership() != interface::Ownership::Server {
             warn!(
                 "Unable to unsubscribe to {} as it is not server owned",
@@ -284,7 +279,7 @@ impl AstarteDeviceSdk {
     }
 
     /// Add a new interface from the provided file.
-    pub async fn add_interface_from_file(&self, file_path: &str) -> Result<(), AstarteError> {
+    pub async fn add_interface_from_file(&self, file_path: &str) -> Result<(), Error> {
         let path = Path::new(file_path);
         let interface = Interface::from_file(path)?;
         self.add_interface(interface).await
@@ -292,13 +287,13 @@ impl AstarteDeviceSdk {
 
     /// Add a new interface from a string. The string should contain a valid json formatted
     /// interface.
-    pub async fn add_interface_from_str(&self, json_str: &str) -> Result<(), AstarteError> {
+    pub async fn add_interface_from_str(&self, json_str: &str) -> Result<(), Error> {
         let interface: Interface = Interface::from_str(json_str)?;
         self.add_interface(interface).await
     }
 
     /// Add a new [`Interface`] to the device interfaces.
-    pub async fn add_interface(&self, interface: Interface) -> Result<(), AstarteError> {
+    pub async fn add_interface(&self, interface: Interface) -> Result<(), Error> {
         if interface.ownership() == interface::Ownership::Server {
             self.subscribe_server_owned_interface(&interface).await?;
         }
@@ -307,17 +302,14 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    async fn add_interface_to_introspection(
-        &self,
-        interface: Interface,
-    ) -> Result<(), AstarteError> {
+    async fn add_interface_to_introspection(&self, interface: Interface) -> Result<(), Error> {
         self.interfaces.write().await.add(interface)?;
 
         Ok(())
     }
 
     /// Remove the interface with the name specified as argument.
-    pub async fn remove_interface(&self, interface_name: &str) -> Result<(), AstarteError> {
+    pub async fn remove_interface(&self, interface_name: &str) -> Result<(), Error> {
         let interface = self.remove_interface_from_map(interface_name).await?;
         self.remove_properties_from_store(interface_name).await?;
         self.send_introspection().await?;
@@ -327,17 +319,12 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    async fn remove_interface_from_map(
-        &self,
-        interface_name: &str,
-    ) -> Result<Interface, AstarteError> {
+    async fn remove_interface_from_map(&self, interface_name: &str) -> Result<Interface, Error> {
         self.interfaces
             .write()
             .await
             .remove(interface_name)
-            .ok_or(AstarteError::InterfaceError(
-                interface::Error::InterfaceNotFound,
-            ))
+            .ok_or(Error::Interface(InterfaceError::InterfaceNotFound))
     }
 
     /// Poll updates from mqtt, can be placed in a loop to receive data.
@@ -364,7 +351,7 @@ impl AstarteDeviceSdk {
     ///     }
     /// }
     /// ```
-    pub async fn handle_events(&mut self) -> Result<AstarteDeviceDataEvent, AstarteError> {
+    pub async fn handle_events(&mut self) -> Result<AstarteDeviceDataEvent, Error> {
         loop {
             // keep consuming and processing packets until we have data for the user
             match self.eventloop.lock().await.poll().await? {
@@ -422,7 +409,7 @@ impl AstarteDeviceSdk {
         interface: &str,
         path: &MappingPath<'a>,
         bdata: &[u8],
-    ) -> Result<(), AstarteError> {
+    ) -> Result<(), Error> {
         //if database is loaded
         if let Some(database) = &self.database {
             //if it's a property
@@ -465,7 +452,7 @@ impl AstarteDeviceSdk {
         format!("{}/{}", self.realm, self.device_id)
     }
 
-    async fn purge_properties(&self, bdata: &[u8]) -> Result<(), AstarteError> {
+    async fn purge_properties(&self, bdata: &[u8]) -> Result<(), Error> {
         if let Some(db) = &self.database {
             let stored_props = db.load_all_props().await?;
 
@@ -484,7 +471,7 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    async fn send_emptycache(&self) -> Result<(), AstarteError> {
+    async fn send_emptycache(&self) -> Result<(), Error> {
         let url = self.client_id() + "/control/emptyCache";
         debug!("sending emptyCache to {}", url);
 
@@ -495,7 +482,7 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    async fn send_introspection(&self) -> Result<(), AstarteError> {
+    async fn send_introspection(&self) -> Result<(), Error> {
         let interfaces = self.interfaces.read().await;
         let introspection = interfaces.get_introspection_string();
 
@@ -512,7 +499,7 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    async fn send_device_owned_properties(&self) -> Result<(), AstarteError> {
+    async fn send_device_owned_properties(&self) -> Result<(), Error> {
         if let Some(database) = &self.database {
             let properties = database.load_all_props().await?;
             // publish only device-owned properties...
@@ -563,11 +550,7 @@ impl AstarteDeviceSdk {
     ///         .unwrap();
     /// }
     /// ```
-    pub async fn unset(
-        &self,
-        interface_name: &str,
-        interface_path: &str,
-    ) -> Result<(), AstarteError> {
+    pub async fn unset(&self, interface_name: &str, interface_path: &str) -> Result<(), Error> {
         trace!("unsetting {} {}", interface_name, interface_path);
 
         if cfg!(debug_assertions) {
@@ -588,7 +571,7 @@ impl AstarteDeviceSdk {
     fn serialize(
         data: Bson,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<Vec<u8>, AstarteError> {
+    ) -> Result<Vec<u8>, Error> {
         if let Bson::Null = data {
             return Ok(Vec::new());
         }
@@ -609,7 +592,7 @@ impl AstarteDeviceSdk {
         Ok(buf)
     }
 
-    fn deserialize(bdata: &[u8]) -> Result<Aggregation, AstarteError> {
+    fn deserialize(bdata: &[u8]) -> Result<Aggregation, Error> {
         if bdata.is_empty() {
             return Ok(Aggregation::Individual(AstarteType::Unset));
         }
@@ -621,14 +604,14 @@ impl AstarteDeviceSdk {
         // Take the value without cloning
         let value = document
             .remove("v")
-            .ok_or_else(|| AstarteError::DeserializationMissingValue(document))?;
+            .ok_or_else(|| Error::DeserializationMissingValue(document))?;
 
         match value {
             Bson::Document(doc) => {
                 let hmap = doc
                     .into_iter()
                     .map(|(name, value)| AstarteType::try_from(value).map(|v| (name, v)))
-                    .collect::<Result<HashMap<String, AstarteType>, AstarteError>>()?;
+                    .collect::<Result<HashMap<String, AstarteType>, Error>>()?;
 
                 Ok(Aggregation::Object(hmap))
             }
@@ -666,7 +649,7 @@ impl AstarteDeviceSdk {
         &self,
         interface: &str,
         path: &str,
-    ) -> Result<Option<AstarteType>, AstarteError> {
+    ) -> Result<Option<AstarteType>, Error> {
         let path_mappings = MappingPath::try_from(path)?;
 
         self.property(interface, &path_mappings).await
@@ -679,7 +662,7 @@ impl AstarteDeviceSdk {
         &self,
         interface: &str,
         path: &MappingPath<'a>,
-    ) -> Result<Option<AstarteType>, AstarteError> {
+    ) -> Result<Option<AstarteType>, Error> {
         let db = match &self.database {
             Some(db) => db,
             None => return Ok(None),
@@ -711,7 +694,7 @@ impl AstarteDeviceSdk {
         interface_name: &str,
         interface_path: &str,
         data: D,
-    ) -> Result<(), AstarteError>
+    ) -> Result<(), Error>
     where
         D: TryInto<AstarteType>,
     {
@@ -743,7 +726,7 @@ impl AstarteDeviceSdk {
         interface_path: &str,
         data: D,
         timestamp: chrono::DateTime<chrono::Utc>,
-    ) -> Result<(), AstarteError>
+    ) -> Result<(), Error>
     where
         D: TryInto<AstarteType>,
     {
@@ -757,13 +740,13 @@ impl AstarteDeviceSdk {
         interface_path: &str,
         data: D,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<(), AstarteError>
+    ) -> Result<(), Error>
     where
         D: TryInto<AstarteType>,
     {
         debug!("sending {} {}", interface_name, interface_path);
 
-        let data = data.try_into().map_err(|_| AstarteError::Conversion)?;
+        let data = data.try_into().map_err(|_| Error::Conversion)?;
 
         let buf = AstarteDeviceSdk::serialize_individual(data.clone(), timestamp)?;
 
@@ -809,7 +792,7 @@ impl AstarteDeviceSdk {
         interface_name: &str,
         interface_path: &str,
         data: D,
-    ) -> Result<bool, AstarteError>
+    ) -> Result<bool, Error>
     where
         D: TryInto<AstarteType>,
     {
@@ -819,15 +802,13 @@ impl AstarteDeviceSdk {
         };
         //if database is present
 
-        let data: AstarteType = data.try_into().map_err(|_| AstarteError::Conversion)?;
+        let data: AstarteType = data.try_into().map_err(|_| Error::Conversion)?;
 
         let interfaces = self.interfaces.read().await;
 
         interfaces
             .get_propertiy_mapping(interface_name, &interface_path.try_into()?)
-            .ok_or_else(|| {
-                AstarteError::SendError(format!("Mapping {interface_path} doesn't exist"))
-            })?;
+            .ok_or_else(|| Error::SendError(format!("Mapping {interface_path} doesn't exist")))?;
 
         // Check if already in db
         let is_present = db
@@ -844,7 +825,7 @@ impl AstarteDeviceSdk {
         interface_name: &str,
         interface_path: &str,
         data: D,
-    ) -> Result<(), AstarteError>
+    ) -> Result<(), Error>
     where
         D: TryInto<AstarteType>,
     {
@@ -854,15 +835,13 @@ impl AstarteDeviceSdk {
         };
         //if database is present
 
-        let data: AstarteType = data.try_into().map_err(|_| AstarteError::Conversion)?;
+        let data: AstarteType = data.try_into().map_err(|_| Error::Conversion)?;
 
         let interfaces = self.interfaces.read().await;
 
         let interface = interfaces
             .get(interface_name)
-            .ok_or(AstarteError::InterfaceError(
-                interface::Error::InterfaceNotFound,
-            ))?;
+            .ok_or(Error::Interface(InterfaceError::InterfaceNotFound))?;
 
         let interface_major = interface.version_major();
 
@@ -871,9 +850,7 @@ impl AstarteDeviceSdk {
         interface
             .properties()
             .and_then(|properties| properties.mapping(&path))
-            .ok_or(AstarteError::InterfaceError(
-                interface::Error::MappingNotFound,
-            ))?;
+            .ok_or(Error::Interface(InterfaceError::MappingNotFound))?;
 
         let bin = AstarteDeviceSdk::serialize_individual(data, None)?;
 
@@ -885,7 +862,7 @@ impl AstarteDeviceSdk {
         Ok(())
     }
 
-    async fn remove_properties_from_store(&self, interface_name: &str) -> Result<(), AstarteError> {
+    async fn remove_properties_from_store(&self, interface_name: &str) -> Result<(), Error> {
         let db = match self.database {
             Some(ref db) => db,
             None => return Ok(()),
@@ -914,11 +891,11 @@ impl AstarteDeviceSdk {
     fn serialize_individual<D>(
         data: D,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<Vec<u8>, AstarteError>
+    ) -> Result<Vec<u8>, Error>
     where
         D: TryInto<AstarteType>,
     {
-        let data: AstarteType = data.try_into().map_err(|_| AstarteError::Conversion)?;
+        let data: AstarteType = data.try_into().map_err(|_| Error::Conversion)?;
         AstarteDeviceSdk::serialize(data.into(), timestamp)
     }
 
@@ -929,7 +906,7 @@ impl AstarteDeviceSdk {
     fn serialize_object<T>(
         data: T,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<Vec<u8>, AstarteError>
+    ) -> Result<Vec<u8>, Error>
     where
         T: AstarteAggregate,
     {
@@ -948,7 +925,7 @@ impl AstarteDeviceSdk {
         interface_path: &str,
         data: T,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<(), AstarteError>
+    ) -> Result<(), Error>
     where
         T: AstarteAggregate,
     {
@@ -1010,7 +987,7 @@ impl AstarteDeviceSdk {
         interface_path: &str,
         data: T,
         timestamp: chrono::DateTime<chrono::Utc>,
-    ) -> Result<(), AstarteError>
+    ) -> Result<(), Error>
     where
         T: AstarteAggregate,
     {
@@ -1028,7 +1005,7 @@ impl AstarteDeviceSdk {
         interface_name: &str,
         interface_path: &str,
         data: T,
-    ) -> Result<(), AstarteError>
+    ) -> Result<(), Error>
     where
         T: AstarteAggregate,
     {

--- a/src/options.rs
+++ b/src/options.rs
@@ -38,6 +38,7 @@ use crate::pairing;
 /// Astarte options error.
 ///
 /// Possible errors used by the Astarte options module.
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum OptionsError {
     #[error("private key or CSR creation failed")]

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -63,6 +63,7 @@ struct AstarteMqttV1Info {
 }
 
 /// Error returned during pairing.
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum PairingError {
     #[error("invalid credentials secret")]

--- a/src/topic.rs
+++ b/src/topic.rs
@@ -25,6 +25,7 @@ use crate::interface::mapping::path::{MappingError, MappingPath};
 /// Error returned when parsing a topic.
 ///
 /// We expect the topic to be in the form `<realm>/<device_id>/<interface>/<path>`.
+#[non_exhaustive]
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum TopicError {
     #[error("topic is empty")]


### PR DESCRIPTION
- Rename the main error `Error`
- Make the other errors names more clear
- Make all errors non-exhaustive