### PR TITLE
feat(serialize/payload): improve ser/de and control payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,13 +140,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -165,6 +174,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base16ct"
@@ -195,6 +219,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitvec"
@@ -291,6 +321,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
@@ -331,7 +362,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -340,21 +371,20 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.5"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2686c4115cb0810d9a984776e197823d08ec94f176549a89a9efded477c456dc"
+checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.5"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
+checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
 dependencies = [
  "anstyle",
- "bitflags",
  "clap_lex",
 ]
 
@@ -377,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
 
 [[package]]
 name = "core-foundation"
@@ -439,10 +469,10 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.3.5",
+ "clap 4.3.10",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -463,7 +493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -543,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
+checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -563,7 +593,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -859,7 +889,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -915,6 +945,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "group"
@@ -1000,15 +1036,6 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1214,13 +1241,12 @@ checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
+ "rustix 0.38.2",
  "windows-sys 0.48.0",
 ]
 
@@ -1244,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "c0aa48fab2893d8a49caa94082ae8488f4e1050d73b367881dcd2198f4199fd8"
 
 [[package]]
 name = "js-sys"
@@ -1285,6 +1311,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -1430,12 +1462,21 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1456,7 +1497,7 @@ version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1473,7 +1514,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1577,29 +1618,29 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -1731,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -1802,7 +1843,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1811,7 +1852,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1916,16 +1957,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.37.20"
+name = "rustc-demangle"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.37.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8818fa822adcc98b18fedbb3632a6a33213c070556b5aa7c4c8cc21cff565c4c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
 ]
 
@@ -1967,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
 ]
@@ -2044,7 +2104,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2087,7 +2147,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2231,7 +2291,7 @@ checksum = "fa8241483a83a3f33aa5fff7e7d9def398ff9990b2752b6c6112b83c6d246029"
 dependencies = [
  "ahash 0.7.6",
  "atoi",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "bytes",
  "crc",
@@ -2358,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2383,7 +2443,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.22",
  "windows-sys 0.48.0",
 ]
 
@@ -2428,7 +2488,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2496,11 +2556,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2520,7 +2581,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2754,7 +2815,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
@@ -2788,7 +2849,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2894,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ astarte-device-sdk-derive = { optional = true, path = "./astarte-device-sdk-deri
 async-trait = "0.1.68"
 base64 = "0.21.2"
 bson = { version = "2.6.1", features = ["chrono-0_4"] }
-chrono = "0.4.26"
+chrono = { version = "0.4.26", features = ["serde"] }
 ecdsa = { version = "0.16.7", features = ["sha2"] }
 flate2 = "1.0.26"
 http = "0.2.9"

--- a/src/database.rs
+++ b/src/database.rs
@@ -26,7 +26,8 @@ use log::{debug, trace};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::FromRow;
 
-use crate::{types::AstarteType, AstarteDeviceSdk, Error};
+use crate::payload;
+use crate::{types::AstarteType, Error};
 
 /// Data structure providing an implementation of a sqlite database.
 ///
@@ -134,7 +135,7 @@ impl AstarteDatabase for AstarteSqliteDatabase {
                 return Ok(None);
             }
 
-            let data = AstarteDeviceSdk::deserialize(&res.0)?;
+            let data = payload::deserialize(&res.0)?;
 
             match data {
                 crate::Aggregation::Individual(data) => Ok(Some(data)),
@@ -203,7 +204,7 @@ impl AstarteSqliteDatabase {
 #[cfg(test)]
 mod test {
     use crate::database::AstarteDatabase;
-    use crate::AstarteDeviceSdk;
+    use crate::payload;
     use crate::{database::AstarteSqliteDatabase, database::StoredProp, types::AstarteType};
 
     #[tokio::test]
@@ -215,7 +216,7 @@ mod test {
         let db = AstarteSqliteDatabase::new(path).await.unwrap();
 
         let ty = AstarteType::Integer(23);
-        let ser = AstarteDeviceSdk::serialize_individual(ty.clone(), None).unwrap();
+        let ser = payload::serialize_individual(&ty, None).unwrap();
 
         db.clear().await.unwrap();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,10 @@ use std::convert::Infallible;
 use crate::interface::mapping::path::MappingError;
 use crate::interface::InterfaceError;
 use crate::options::OptionsError;
+use crate::payload::PayloadError;
+use crate::properties::PropertiesError;
 use crate::topic::TopicError;
+use crate::types::TypeError;
 
 /// Astarte error.
 ///
@@ -31,29 +34,11 @@ use crate::topic::TopicError;
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("bson serialize error")]
-    BsonSerError(#[from] bson::ser::Error),
-
     #[error("bson client error")]
     BsonClientError(#[from] rumqttc::ClientError),
 
     #[error("mqtt connection error")]
     ConnectionError(#[from] rumqttc::ConnectionError),
-
-    #[error("malformed input from Astarte backend")]
-    DeserializationError(#[from] bson::de::Error),
-
-    #[error("malformed input from Astarte backend, missing value 'v' in document: {0}")]
-    DeserializationMissingValue(bson::Document),
-
-    #[error("error converting from Bson to AstarteType ({0})")]
-    FromBsonError(String),
-
-    #[error("type mismatch in bson array from astarte, something has gone very wrong here")]
-    FromBsonArrayError,
-
-    #[error("forbidden floating point number")]
-    FloatError,
 
     #[error("send error ({0})")]
     SendError(String),
@@ -76,9 +61,6 @@ pub enum Error {
     #[error("generic error")]
     Unreported,
 
-    #[error("conversion error")]
-    Conversion,
-
     #[error("infallible error")]
     Infallible(#[from] Infallible),
 
@@ -87,4 +69,15 @@ pub enum Error {
 
     #[error("invalid mapping path '{}'", .0.path())]
     InvalidEndpoint(#[from] MappingError),
+
+    /// Errors when converting between Astarte types.
+    #[error("couldn't process payload")]
+    Types(#[from] TypeError),
+
+    /// Errors that can occur handling the payload.
+    #[error("couldn't process payload")]
+    Payload(#[from] PayloadError),
+
+    #[error("couldn't handle properties")]
+    Properties(#[from] PropertiesError),
 }

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -25,6 +25,7 @@ use log::debug;
 
 use crate::{
     interface::{mapping::path::MappingPath, InterfaceError, Mapping, Ownership},
+    payload,
     types::AstarteType,
     Aggregation, Error, Interface,
 };
@@ -202,7 +203,7 @@ impl Interfaces {
         data: &[u8],
         timestamp: &Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<(), Error> {
-        let data_deserialized = crate::AstarteDeviceSdk::deserialize(data)?;
+        let data_deserialized = payload::deserialize(data)?;
 
         let interface = self
             .interfaces
@@ -286,7 +287,7 @@ impl Interfaces {
             Error::ReceiveError(format!("Interface '{interface_name}' does not exists"))
         })?;
 
-        let data = crate::AstarteDeviceSdk::deserialize(bdata)?;
+        let data = payload::deserialize(bdata)?;
 
         match data {
             Aggregation::Individual(individual) => {
@@ -346,8 +347,8 @@ mod test {
     use std::{collections::HashMap, str::FromStr};
 
     use crate::{
-        interfaces::Interfaces, mapping, options::AstarteOptions, types::AstarteType,
-        AstarteDeviceSdk, Interface,
+        interfaces::Interfaces, mapping, options::AstarteOptions, payload, types::AstarteType,
+        Interface,
     };
 
     #[test]
@@ -554,7 +555,7 @@ mod test {
             .unwrap_err();
 
         // Test non existant endpoint
-        let aggregate_data = AstarteDeviceSdk::serialize_object(aggregate.clone(), None).unwrap();
+        let aggregate_data = payload::serialize_object(&aggregate, None).unwrap();
         interfaces
             .validate_send(&interface_name, "/1/25", &aggregate_data, &None)
             .unwrap_err();
@@ -570,7 +571,7 @@ mod test {
 
         // Test sending an aggregate with an object field with incorrect type
         aggregate.insert("integer_endpoint".to_string(), AstarteType::Boolean(false));
-        let aggregate_data = AstarteDeviceSdk::serialize_object(aggregate.clone(), None).unwrap();
+        let aggregate_data = payload::serialize_object(&aggregate, None).unwrap();
         interfaces
             .validate_send(&interface_name, "/1", &aggregate_data, &None)
             .unwrap_err();
@@ -578,7 +579,7 @@ mod test {
 
         // Test sending an aggregate with an non existing object field
         aggregate.insert("gibberish".to_string(), AstarteType::Boolean(false));
-        let aggregate_data = AstarteDeviceSdk::serialize_object(aggregate.clone(), None).unwrap();
+        let aggregate_data = payload::serialize_object(&aggregate, None).unwrap();
         interfaces
             .validate_send(&interface_name, "/1", &aggregate_data, &None)
             .unwrap_err();
@@ -586,7 +587,7 @@ mod test {
 
         // Test sending an aggregate with a missing object field
         aggregate.remove("integer_endpoint");
-        let aggregate_data = AstarteDeviceSdk::serialize_object(aggregate.clone(), None).unwrap();
+        let aggregate_data = payload::serialize_object(&aggregate, None).unwrap();
         interfaces
             .validate_send(&interface_name, "/1", &aggregate_data, &None)
             .unwrap_err();
@@ -608,12 +609,12 @@ mod test {
 
         // Test sending a value (with and without timestamp)
         let boolean_endpoint_data =
-            AstarteDeviceSdk::serialize_individual(AstarteType::Boolean(true), None).unwrap();
+            payload::serialize_individual(&AstarteType::Boolean(true), None).unwrap();
         interfaces
             .validate_send(&interface_name, "/boolean", &boolean_endpoint_data, &None)
             .unwrap();
         let double_endpoint_data =
-            AstarteDeviceSdk::serialize_individual(AstarteType::Double(23.2), None).unwrap();
+            payload::serialize_individual(&AstarteType::Double(23.2), None).unwrap();
         let timestamp = Some(TimeZone::timestamp_opt(&Utc, 1537449422, 0).unwrap());
         interfaces
             .validate_send(
@@ -654,7 +655,7 @@ mod test {
 
         // Test receiving a new value
         let boolean_endpoint_data =
-            AstarteDeviceSdk::serialize_individual(AstarteType::Boolean(true), None).unwrap();
+            payload::serialize_individual(&AstarteType::Boolean(true), None).unwrap();
         interfaces
             .validate_receive(
                 &interface_name,
@@ -665,7 +666,7 @@ mod test {
 
         // Test receiving a new value with the wrong type
         let integer_endpoint_data =
-            AstarteDeviceSdk::serialize_individual(AstarteType::Integer(23), None).unwrap();
+            payload::serialize_individual(&AstarteType::Integer(23), None).unwrap();
         interfaces
             .validate_receive(
                 &interface_name,
@@ -699,7 +700,7 @@ mod test {
             ("boolean_endpoint".to_string(), AstarteType::Boolean(false)),
             ("integer_endpoint".to_string(), AstarteType::Integer(324)),
         ]);
-        let aggr_data = AstarteDeviceSdk::serialize_object(aggr_data, None).unwrap();
+        let aggr_data = payload::serialize_object(&aggr_data, None).unwrap();
         interfaces
             .validate_receive(&interface_name, mapping!("/obj"), &aggr_data)
             .unwrap();
@@ -709,7 +710,7 @@ mod test {
             ("boolean_endpoint".to_string(), AstarteType::Boolean(false)),
             ("integer_endpoint".to_string(), AstarteType::Boolean(false)),
         ]);
-        let aggr_data = AstarteDeviceSdk::serialize_object(aggr_data, None).unwrap();
+        let aggr_data = payload::serialize_object(&aggr_data, None).unwrap();
         interfaces
             .validate_receive(&interface_name, mapping!("/foo"), &aggr_data)
             .unwrap_err();
@@ -731,7 +732,7 @@ mod test {
 
         // Test receiving a set property
         let boolean_endpoint_data =
-            AstarteDeviceSdk::serialize_individual(AstarteType::Boolean(true), None).unwrap();
+            payload::serialize_individual(&AstarteType::Boolean(true), None).unwrap();
         interfaces
             .validate_receive(
                 &interface_name,
@@ -752,7 +753,7 @@ mod test {
 
         // Test receiving a set property with the wrong type
         let integer_endpoint_data =
-            AstarteDeviceSdk::serialize_individual(AstarteType::Integer(23), None).unwrap();
+            payload::serialize_individual(&AstarteType::Integer(23), None).unwrap();
         interfaces
             .validate_receive(
                 &interface_name,
@@ -766,7 +767,7 @@ mod test {
             ("boolean_endpoint".to_string(), AstarteType::Boolean(false)),
             ("integer_endpoint".to_string(), AstarteType::Integer(324)),
         ]);
-        let aggr_data = AstarteDeviceSdk::serialize_object(aggr_data, None).unwrap();
+        let aggr_data = payload::serialize_object(&aggr_data, None).unwrap();
         interfaces
             .validate_receive(&interface_name, mapping!("/obj"), &aggr_data)
             .unwrap_err();

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,0 +1,272 @@
+// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides the structs for the Astarte MQTT Protocol.
+//!
+//! You can find more information about the protocol v1 in the [Astarte MQTT v1 Protocol](https://docs.astarte-platform.org/astarte/latest/080-mqtt-v1-protocol.html).
+
+use std::collections::HashMap;
+
+use bson::Bson;
+use chrono::{DateTime, Utc};
+use log::trace;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    types::{AstarteType, TypeError},
+    Aggregation,
+};
+
+/// Errors that can occur handling the payload.
+#[non_exhaustive]
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum PayloadError {
+    /// Couldn't serialize the payload to bson.
+    #[error("couldn't serialize the payload")]
+    Serialize(#[from] bson::ser::Error),
+    /// Couldn't deserialize the payload to bson.
+    #[error("couldn't deserialize the payload")]
+    Deserialize(#[from] bson::de::Error),
+
+    /// Couldn't convert the value to [`AstarteType`]
+    #[error("couldn't convert the value to AstarteType")]
+    AstarteType(#[from] TypeError),
+}
+
+/// The payload of an MQTT message.
+///
+/// It is serialized as a BSON object when sent over the wire.
+///
+/// The payload BSON specification can be found here: [BSON](https://docs.astarte-platform.org/astarte/latest/080-mqtt-v1-protocol.html#bson)
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub(crate) struct Payload<T> {
+    #[serde(rename = "v")]
+    pub(crate) value: T,
+    #[serde(rename = "t", default, skip_serializing_if = "Option::is_none")]
+    pub(crate) timestamp: Option<DateTime<Utc>>,
+}
+
+impl<T> Payload<T>
+where
+    T: serde::Serialize,
+{
+    pub(crate) fn to_vec(&self) -> Result<Vec<u8>, PayloadError> {
+        let res = bson::to_vec(self)?;
+
+        Ok(res)
+    }
+
+    pub(crate) fn from_slice<'a>(buf: &'a [u8]) -> Result<Payload<T>, PayloadError>
+    where
+        T: serde::de::Deserialize<'a>,
+    {
+        let res = bson::from_slice(buf)?;
+
+        Ok(res)
+    }
+}
+
+/// Serialize an [`AstarteType`] to bson payload.
+pub(crate) fn serialize_individual(
+    data: &AstarteType,
+    timestamp: Option<DateTime<Utc>>,
+) -> Result<Vec<u8>, PayloadError> {
+    let payload = Payload {
+        value: data,
+        timestamp,
+    };
+
+    payload.to_vec()
+}
+
+/// Serialize an Object passed as an [`HashMap`] of [`AstarteType`] to bson payload.
+pub(crate) fn serialize_object(
+    data: &HashMap<String, AstarteType>,
+    timestamp: Option<DateTime<Utc>>,
+) -> Result<Vec<u8>, PayloadError> {
+    let payload = Payload {
+        value: data,
+        timestamp,
+    };
+
+    payload.to_vec()
+}
+
+/// Deserialize a bson payload to an individual [`AstarteType`] or an object as an [`HashMap`].
+pub(crate) fn deserialize(bdata: &[u8]) -> Result<Aggregation, PayloadError> {
+    if bdata.is_empty() {
+        return Ok(Aggregation::Individual(AstarteType::Unset));
+    }
+
+    let payload = Payload::<Bson>::from_slice(bdata)?;
+
+    trace!("{:?}", payload);
+
+    match payload.value {
+        Bson::Document(doc) => {
+            let hmap = doc
+                .into_iter()
+                .map(|(name, value)| {
+                    let v = AstarteType::try_from(value)?;
+
+                    Ok((name, v))
+                })
+                .collect::<Result<HashMap<String, AstarteType>, PayloadError>>()?;
+
+            Ok(Aggregation::Object(hmap))
+        }
+        value => {
+            let individual = AstarteType::try_from(value)?;
+
+            Ok(Aggregation::Individual(individual))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use chrono::TimeZone;
+
+    use crate::interface::MappingType;
+
+    use super::*;
+
+    #[test]
+    fn test_individual_serialization() {
+        let alltypes: Vec<AstarteType> = vec![
+            AstarteType::Double(4.5),
+            AstarteType::Integer(-4),
+            AstarteType::Boolean(true),
+            AstarteType::LongInteger(45543543534_i64),
+            AstarteType::String("hello".into()),
+            AstarteType::BinaryBlob(b"hello".to_vec()),
+            AstarteType::DateTime(TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap()),
+            AstarteType::DoubleArray(vec![1.2, 3.4, 5.6, 7.8]),
+            AstarteType::IntegerArray(vec![1, 3, 5, 7]),
+            AstarteType::BooleanArray(vec![true, false, true, true]),
+            AstarteType::LongIntegerArray(vec![45543543534_i64, 45543543535_i64, 45543543536_i64]),
+            AstarteType::StringArray(vec!["hello".to_owned(), "world".to_owned()]),
+            AstarteType::BinaryBlobArray(vec![b"hello".to_vec(), b"world".to_vec()]),
+            AstarteType::DateTimeArray(vec![
+                TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1627580809, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1627580810, 0).unwrap(),
+            ]),
+        ];
+
+        for ty in alltypes {
+            println!("checking {ty:?}");
+
+            let buf = serialize_individual(&ty, None).unwrap();
+
+            let ty2 = deserialize(&buf).unwrap();
+
+            if let Aggregation::Individual(data) = ty2 {
+                assert!(ty == data);
+            } else {
+                panic!();
+            }
+        }
+    }
+
+    #[test]
+    fn test_serialize_object() {
+        let alltypes: Vec<AstarteType> = vec![
+            AstarteType::Double(4.5),
+            AstarteType::Integer(-4),
+            AstarteType::Boolean(true),
+            AstarteType::LongInteger(45543543534_i64),
+            AstarteType::String("hello".into()),
+            AstarteType::BinaryBlob(b"hello".to_vec()),
+            AstarteType::DateTime(TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap()),
+            AstarteType::DoubleArray(vec![1.2, 3.4, 5.6, 7.8]),
+            AstarteType::IntegerArray(vec![1, 3, 5, 7]),
+            AstarteType::BooleanArray(vec![true, false, true, true]),
+            AstarteType::LongIntegerArray(vec![45543543534_i64, 45543543535_i64, 45543543536_i64]),
+            AstarteType::StringArray(vec!["hello".to_owned(), "world".to_owned()]),
+            AstarteType::BinaryBlobArray(vec![b"hello".to_vec(), b"world".to_vec()]),
+            AstarteType::DateTimeArray(vec![
+                TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1627580809, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1627580810, 0).unwrap(),
+            ]),
+        ];
+
+        let allendpoints = vec![
+            "double".to_string(),
+            "integer".to_string(),
+            "boolean".to_string(),
+            "longinteger".to_string(),
+            "string".to_string(),
+            "binaryblob".to_string(),
+            "datetime".to_string(),
+            "doublearray".to_string(),
+            "integerarray".to_string(),
+            "booleanarray".to_string(),
+            "longintegerarray".to_string(),
+            "stringarray".to_string(),
+            "binaryblobarray".to_string(),
+            "datetimearray".to_string(),
+        ];
+
+        let mut data = std::collections::HashMap::new();
+
+        for i in allendpoints.iter().zip(alltypes.iter()) {
+            data.insert(i.0.clone(), i.1.clone());
+        }
+
+        let bytes = serialize_object(&data, None).unwrap();
+
+        let data_processed = deserialize(&bytes).unwrap();
+
+        println!("\nComparing {data:?}\nto {data_processed:?}");
+
+        if let Aggregation::Object(data_processed) = data_processed {
+            assert_eq!(data, data_processed);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn test_integer_longinteger_compatibility() {
+        let longinteger_b = [12, 0, 0, 0, 16, 118, 0, 16, 14, 0, 0, 0];
+        let integer_buf = deserialize(&longinteger_b).unwrap();
+        if let Aggregation::Individual(astarte_type) = integer_buf {
+            assert_eq!(astarte_type, MappingType::LongInteger);
+        } else {
+            panic!("Deserialization in not individual");
+        }
+    }
+
+    #[test]
+    fn test_bson_serialization() {
+        let og_value = AstarteType::LongInteger(3600);
+        let buf = serialize_individual(&og_value, None).unwrap();
+        if let Aggregation::Individual(astarte_type) = deserialize(&buf).unwrap() {
+            assert_eq!(astarte_type, AstarteType::LongInteger(3600));
+            if let AstarteType::LongInteger(value) = astarte_type {
+                assert_eq!(value, 3600);
+            } else {
+                panic!("Astarte Type is not LongInteger");
+            }
+        } else {
+            panic!("Deserialization in not individual");
+        }
+    }
+}

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,0 +1,91 @@
+// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Handles the properties for the device.
+
+use flate2::bufread::ZlibDecoder;
+use log::error;
+
+/// Error handling the properties.
+#[non_exhaustive]
+#[derive(thiserror::Error, Debug)]
+pub enum PropertiesError {
+    /// The payload is too short, it should be at least 4 bytes long.
+    #[error("the payload should at least 4 bytes long, got {0}")]
+    PayloadTooShort(usize),
+    /// Couldn't convert the size from u32 to usize.
+    #[error("error converting the size from u32 to usize")]
+    Conversion(#[from] std::num::TryFromIntError),
+    /// Error decoding the zlib compressed payload.
+    #[error("error decoding the zlib compressed payload")]
+    Decode(#[from] std::io::Error),
+}
+
+/// Extracts the properties from a set payload.
+///
+/// See https://docs.astarte-platform.org/astarte/latest/080-mqtt-v1-protocol.html#purge-properties
+pub(crate) fn extract_set_properties(bdata: &[u8]) -> Result<Vec<String>, PropertiesError> {
+    use std::io::Read;
+
+    if bdata.len() < 4 {
+        return Err(PropertiesError::PayloadTooShort(bdata.len()));
+    }
+
+    let (size, data) = bdata.split_at(4);
+    // The size is a u32 in big endian, so we need to convert it to usize
+    let size: u32 = u32::from_be_bytes([size[0], size[1], size[2], size[3]]);
+    let size: usize = size.try_into()?;
+
+    let mut d = ZlibDecoder::new(data);
+    let mut s = String::new();
+    let bytes_read = d.read_to_string(&mut s)?;
+
+    debug_assert_eq!(
+        bytes_read, size,
+        "Byte red and size mismatch: {} != {}",
+        bytes_read, size
+    );
+    // Signal the error in production
+    if bytes_read != size {
+        error!("Byte red and size mismatch: {} != {}", bytes_read, size);
+    }
+
+    Ok(s.split(';').map(|x| x.to_string()).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub(crate) const PROPERTIES_PAYLOAD: [u8; 66] = [
+        0x00, 0x00, 0x00, 0x46, 0x78, 0x9c, 0x4b, 0xce, 0xcf, 0xd5, 0x4b, 0xad, 0x48, 0xcc, 0x2d,
+        0xc8, 0x49, 0xd5, 0xf3, 0xad, 0xf4, 0xcc, 0x2b, 0x49, 0x2d, 0x4a, 0x4b, 0x4c, 0x4e, 0xd5,
+        0x2f, 0xce, 0xcf, 0x4d, 0xd5, 0x2f, 0x48, 0x2c, 0xc9, 0xb0, 0xce, 0x2f, 0x4a, 0x87, 0xab,
+        0x70, 0x29, 0x4a, 0x4c, 0x2b, 0x41, 0x28, 0xca, 0x2f, 0xc9, 0x48, 0x2d, 0x0a, 0x00, 0x2a,
+        0x02, 0x00, 0xb2, 0x0c, 0x1a, 0xc9,
+    ];
+
+    #[test]
+    fn test_deflate() {
+        let example = b"com.example.MyInterface/some/path;org.example.DraftInterface/otherPath";
+
+        let s = extract_set_properties(&PROPERTIES_PAYLOAD).unwrap();
+
+        assert_eq!(s.join(";").as_bytes(), example);
+    }
+}


### PR DESCRIPTION
Use Serialize and Deserialize to not allocate an additional HashMap when working with the payload. Separate the types errors int the specific module. Check the length of the control payload after deflating it and remove the unwraps.