### PR TITLE
ci(dependabot): ignore patch and minor updates for libraries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,10 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
+      ignore:
+        - dependency-name: "*"
+          # patch and minor updates don't matter for libraries
+          # remove this ignore rule if your package has binaries
+          update-types:
+            - "version-update:semver-patch"
+            - "version-update:semver-minor"


### PR DESCRIPTION
The consumer of a library will have a different minor/patch version of the dependency, this way we are not flooded by dependabot PRs.