### PR TITLE
Prepare release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0] - Unreleased
+## [0.6.0] - 2023-07-05
 ### Added
 - Support for different case conventions on `AstarteAggregate` derive macro
   ([#126](https://github.com/astarte-platform/astarte-device-sdk-rust/issues/126)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "astarte-device-sdk"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "astarte-device-sdk-derive",
  "async-trait",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "astarte-device-sdk"
-version = "0.5.1"
+version = "0.6.0"
 documentation = "https://docs.rs/astarte-device-sdk"
 edition = "2021"
 homepage = "https://astarte.cloud/"
@@ -24,7 +24,7 @@ name = "benchmark"
 harness = false
 
 [dependencies]
-astarte-device-sdk-derive = { optional = true, path = "./astarte-device-sdk-derive" }
+astarte-device-sdk-derive = { version = "=0.6.0", optional = true, path = "./astarte-device-sdk-derive" }
 async-trait = "0.1.68"
 base64 = "0.21.2"
 bson = { version = "2.6.1", features = ["chrono-0_4"] }

--- a/astarte-device-sdk-derive/CHANGELOG.md
+++ b/astarte-device-sdk-derive/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2023-07-05
+
 ## [0.5.1] - 2023-02-06
 
 ## [0.5.0] - 2023-02-01

--- a/astarte-device-sdk-derive/Cargo.lock
+++ b/astarte-device-sdk-derive/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "quote",
  "syn",

--- a/astarte-device-sdk-derive/Cargo.toml
+++ b/astarte-device-sdk-derive/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "astarte-device-sdk-derive"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/astarte-platform/astarte-device-sdk-rust"

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,6 +81,6 @@ pub enum Error {
     Properties(#[from] PropertiesError),
 
     /// Error returned by a store operation.
-    #[error("could't complete store operation")]
+    #[error("couldn't complete store operation")]
     Database(#[from] StoreError),
 }

--- a/src/store/error.rs
+++ b/src/store/error.rs
@@ -21,7 +21,7 @@
 /// Dynamic error type of an [`super::PropertyStore`].
 type DynError = Box<dyn std::error::Error>;
 
-/// Error type returned by the [`AstarteDatabase`] trait.
+/// Error type returned by the [`super::PropertyStore`] trait.
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {


### PR DESCRIPTION
 - Fix documentation building.
 
Specify a version on `astarte-device-sdk-derive` because all dependencies must have a version specified when publishing.

Note: The published dependency will use the version from crates.io, the `path` specification will be removed from the dependency declaration.