### PR TITLE
feat(derive):  implement the FromEvent trait and derive macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make the reconnection attempt wait with an exponential back-off.
 - Trait `PropAccess` to access the stored properties from the
   `AstarteDeviceSdk`.
+- Trait `FromEvent` to convert a generic object aggregate into a Rust struct.
 
 ### Changed
 - Return a channel for the events when creating a device SDK.

--- a/astarte-device-sdk-derive/CHANGELOG.md
+++ b/astarte-device-sdk-derive/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Macro to implement the `FromEvent` trait on a generic struct.
+
 ### Changed
 - Update the `AstarteAggregate` derive macro to syn `2`, see
   [#236](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/236).

--- a/astarte-device-sdk-derive/src/lib.rs
+++ b/astarte-device-sdk-derive/src/lib.rs
@@ -18,21 +18,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+//! Proc macro helpers for the [Astarte Device SDK](https://crates.io/crates/astarte-device-sdk)
+
 mod case;
 
 use std::collections::HashMap;
+use std::fmt::Debug;
 
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
 use quote::quote;
 use quote::quote_spanned;
+use syn::parse::Parse;
+use syn::parse::ParseStream;
 use syn::parse_macro_input;
 use syn::Attribute;
+use syn::Expr;
 use syn::GenericParam;
 use syn::Generics;
+use syn::MetaNameValue;
+use syn::Token;
 
 use case::RenameRule;
 use syn::parse_quote;
+use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 
 /// Handle for the `#[astarte_aggregate(..)]` attribute.
@@ -55,56 +64,60 @@ struct AggregateAttributes {
 impl AggregateAttributes {
     /// Merge the Astarte attributes from the other struct into self.
     fn merge(self, other: Self) -> Self {
-        let rename_all = match other.rename_all {
-            Some(_) => other.rename_all,
-            None => self.rename_all,
-        };
+        let rename_all = other.rename_all.or(self.rename_all);
 
         Self { rename_all }
     }
 }
 
-impl syn::parse::Parse for AggregateAttributes {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let mut vars: HashMap<String, syn::Expr> = syn::punctuated::Punctuated::<
-            syn::MetaNameValue,
-            syn::Token![,],
-        >::parse_terminated(input)?
+impl Parse for AggregateAttributes {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut vars = parse_name_value_attrs(input)?;
+
+        let rename_all = vars
+            .remove("rename_all")
+            .map(|expr| {
+                parse_str_lit(&expr).and_then(|rename| {
+                    RenameRule::from_str(&rename)
+                        .map_err(|_| syn::Error::new(expr.span(), "invalid rename rule"))
+                })
+            })
+            .transpose()?;
+
+        Ok(Self { rename_all })
+    }
+}
+
+/// Parses the content of a [`syn::MetaList`] as a list of [`syn::MetaNameValue`].
+///
+/// Will convert a list of `#[attr(name = "string",..)]` into an [`HashMap<String, string>`]
+fn parse_name_value_attrs(
+    input: &syn::parse::ParseBuffer<'_>,
+) -> Result<HashMap<String, Expr>, syn::Error> {
+    Punctuated::<MetaNameValue, Token![,]>::parse_terminated(input)?
         .into_iter()
         .map(|v| {
             v.path
                 .get_ident()
                 .ok_or_else(|| {
-                    syn::Error::new(v.path.span(), "expected an ident like `rename_all`")
+                    syn::Error::new(v.span(), "expected an identifier like `rename_all`")
                 })
                 .map(|i| (i.to_string(), v.value))
         })
-        .collect::<syn::Result<_>>()?;
+        .collect::<syn::Result<_>>()
+}
 
-        let rename_all = match vars.remove("rename_all") {
-            Some(expr) => {
-                // Cursed expression literal match
-                let syn::Expr::Lit(syn::ExprLit {
-                    lit: syn::Lit::Str(lit),
-                    ..
-                }) = expr
-                else {
-                    return Err(syn::Error::new(
-                        expr.span(),
-                        "expression must be a string literal",
-                    ));
-                };
-
-                let Ok(rule) = RenameRule::from_str(&lit.value()) else {
-                    return Err(syn::Error::new(lit.span(), "invalid rename rule"));
-                };
-
-                Some(rule)
-            }
-            None => None,
-        };
-
-        Ok(Self { rename_all })
+/// Parses a [`syn::Lit::Str`] into a [`String`].
+fn parse_str_lit(expr: &Expr) -> syn::Result<String> {
+    match expr {
+        Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(lit),
+            ..
+        }) => Ok(lit.value()),
+        _ => Err(syn::Error::new(
+            expr.span(),
+            "expression must be a string literal",
+        )),
     }
 }
 
@@ -168,45 +181,21 @@ impl AggregateDerive {
     }
 }
 
-impl syn::parse::Parse for AggregateDerive {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+impl Parse for AggregateDerive {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
         let ast = syn::DeriveInput::parse(input)?;
 
         // Find all the outer astarte_aggregate attributes and merge them
         let attrs = ast
             .attrs
             .iter()
-            .filter_map(parse_astarte_aggregate_attribute)
+            .filter_map(|a| parse_attribute_list::<AggregateAttributes>(a, "astarte_aggregate"))
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .reduce(|first, second| first.merge(second))
             .unwrap_or_default();
 
-        // TODO: this can support enums with inner aggregate structs
-        let syn::Data::Struct(ref st) = ast.data else {
-            return Err(syn::Error::new(
-                ast.span(),
-                "AstarteAggregate is only implementable over a struct.",
-            ));
-        };
-
-        let syn::Fields::Named(ref fields_named) = st.fields else {
-            return Err(syn::Error::new(
-                ast.span(),
-                "AstarteAggregate is only implementable over a named struct.",
-            ));
-        };
-
-        let fields = fields_named
-            .named
-            .iter()
-            .map(|field| {
-                field
-                    .ident
-                    .clone()
-                    .ok_or_else(|| syn::Error::new(field.span(), "field is not an ident"))
-            })
-            .collect::<Result<_, _>>()?;
+        let fields = parse_struct_fields(&ast)?;
 
         let name = ast.ident;
 
@@ -221,6 +210,261 @@ impl syn::parse::Parse for AggregateDerive {
     }
 }
 
+#[derive(Debug, Default)]
+struct FromEventAttrs {
+    interface: Option<String>,
+    path: Option<String>,
+    rename_rule: Option<RenameRule>,
+}
+
+impl FromEventAttrs {
+    fn merge(self, other: Self) -> Self {
+        let interface = other.interface.or(self.interface);
+        let path = other.path.or(self.path);
+        let rename_all = other.rename_rule.or(self.rename_rule);
+
+        Self {
+            interface,
+            path,
+            rename_rule: rename_all,
+        }
+    }
+}
+
+impl Parse for FromEventAttrs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut vars = parse_name_value_attrs(input)?;
+
+        let interface = vars
+            .remove("interface")
+            .map(|expr| parse_str_lit(&expr))
+            .transpose()?;
+
+        let path = vars
+            .remove("path")
+            .map(|expr| parse_str_lit(&expr))
+            .transpose()?;
+
+        let rename_all = vars
+            .remove("rename_all")
+            .map(|expr| {
+                parse_str_lit(&expr).and_then(|rename| {
+                    RenameRule::from_str(&rename)
+                        .map_err(|_| syn::Error::new(expr.span(), "invalid rename rule"))
+                })
+            })
+            .transpose()?;
+
+        Ok(Self {
+            rename_rule: rename_all,
+            interface,
+            path,
+        })
+    }
+}
+
+struct FromEventDerive {
+    interface: String,
+    path: String,
+    name: Ident,
+    rename_rule: Option<RenameRule>,
+    generics: Generics,
+    fields: Vec<Ident>,
+}
+
+impl FromEventDerive {
+    fn add_trait_bound(mut generics: Generics) -> Generics {
+        for param in &mut generics.params {
+            if let GenericParam::Type(ref mut type_param) = *param {
+                type_param.bounds.push(parse_quote!(
+                    std::convert::TryFrom<astarte_device_sdk::types::AstarteType, Error =  >
+                ));
+            }
+        }
+        generics
+    }
+
+    fn quote(&self) -> proc_macro2::TokenStream {
+        let rename_rule = self.rename_rule.unwrap_or_default();
+        let (impl_generics, ty_generics, where_clause) = &self.generics.split_for_impl();
+        let fields_val = self.fields.iter().map(|i| {
+            let name = i.to_string();
+            let name = rename_rule.apply_to_field(&name);
+            quote_spanned! {i.span() =>
+                let #i = object
+                    .remove(#name)
+                    .ok_or(FromEventError::MissingField {
+                        interface,
+                        base_path,
+                        path: #name,
+                    })?
+                    .try_into()?;
+            }
+        });
+        let fields = self.fields.iter();
+        let interface = &self.interface;
+        let path = &self.path;
+        let name = &self.name;
+
+        quote! {
+            impl #impl_generics astarte_device_sdk::FromEvent for #name #ty_generics #where_clause {
+                type Err = astarte_device_sdk::event::FromEventError;
+
+                fn from_event(event: astarte_device_sdk::AstarteDeviceDataEvent) -> Result<Self, Self::Err> {
+                    use astarte_device_sdk::Aggregation;
+                    use astarte_device_sdk::event::FromEventError;
+                    use astarte_device_sdk::interface::mapping::endpoint::Endpoint;
+
+                    let interface = #interface;
+                    let base_path = #path;
+                    let endpoint: Endpoint<&str> = Endpoint::try_from(base_path)?;
+
+                    if event.interface != interface {
+                        return Err(FromEventError::Interface(event.interface.clone()));
+                    }
+
+                    if !endpoint.eq_mapping(&event.path) {
+                        return Err(FromEventError::Path {
+                            interface,
+                            base_path: event.path.clone(),
+                        });
+                    }
+
+                    let Aggregation::Object(mut object) = event.data else {
+                        return Err(FromEventError::Individual {
+                            interface,
+                            base_path,
+                        });
+                    };
+
+                    #(#fields_val)*
+
+                    Ok(Self{#(#fields),*})
+                }
+            }
+        }
+    }
+}
+
+impl Parse for FromEventDerive {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let ast = syn::DeriveInput::parse(input)?;
+
+        // Find all the outer astarte_aggregate attributes and merge them
+        let attrs = ast
+            .attrs
+            .iter()
+            .filter_map(|a| parse_attribute_list::<FromEventAttrs>(a, "from_event"))
+            .collect::<Result<Vec<_>, _>>()?
+            // TODO: check for duplicates
+            .into_iter()
+            .reduce(|first, other| first.merge(other))
+            .ok_or_else(|| {
+                syn::Error::new(
+                    ast.span(),
+                    r#"missing attributes #[from_event(interface = "..", path = "..")]"#,
+                )
+            })?;
+
+        let interface = attrs.interface.ok_or_else(|| {
+            syn::Error::new(
+                ast.span(),
+                r#"missing interface attribute #[from_event(interface = "..")]"#,
+            )
+        })?;
+
+        let path = attrs.path.ok_or_else(|| {
+            syn::Error::new(
+                ast.span(),
+                r#"missing path attribute #[from_event(path = "..")]"#,
+            )
+        })?;
+
+        let fields = parse_struct_fields(&ast)?;
+
+        let generics = Self::add_trait_bound(ast.generics);
+
+        Ok(Self {
+            interface,
+            path,
+            rename_rule: attrs.rename_rule,
+            name: ast.ident,
+            generics,
+            fields,
+        })
+    }
+}
+
+/// Parses the fields of a struct
+fn parse_struct_fields(ast: &syn::DeriveInput) -> Result<Vec<Ident>, syn::Error> {
+    let syn::Data::Struct(ref st) = ast.data else {
+        return Err(syn::Error::new(
+            ast.span(),
+            "AstarteAggregate is only implementable over a struct.",
+        ));
+    };
+    let syn::Fields::Named(ref fields_named) = st.fields else {
+        return Err(syn::Error::new(
+            ast.span(),
+            "AstarteAggregate is only implementable over a named struct.",
+        ));
+    };
+    let fields = fields_named
+        .named
+        .iter()
+        .map(|field| {
+            field
+                .ident
+                .clone()
+                .ok_or_else(|| syn::Error::new(field.span(), "field is not an ident"))
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(fields)
+}
+
+/// Parse the `#[name(..)]` attribute.
+///
+/// This will skip other attributes or return an error if the attribute parsing failed. We expected
+/// the input to be an outer attribute in the form `#[name(foo = "...")]`.
+fn parse_attribute_list<T>(attr: &Attribute, name: &str) -> Option<syn::Result<T>>
+where
+    T: Parse,
+{
+    let is_attr = attr
+        .path()
+        .get_ident()
+        .map(ToString::to_string)
+        .filter(|ident| ident == name)
+        .is_some();
+
+    if !is_attr {
+        return None;
+    }
+
+    // TODO: outer and inner attributes check?
+    match &attr.meta {
+        // We ignore the path since it can be from another macro or `#[astarte_aggregate]` without
+        // parameters, which we still consider valid.
+        syn::Meta::Path(_) => None,
+        syn::Meta::NameValue(name) => Some(Err(syn::Error::new(
+            name.span(),
+            "cannot be used as a named value",
+        ))),
+        syn::Meta::List(list) => Some(syn::parse2::<T>(list.tokens.clone())),
+    }
+}
+
+/// Handle for the `#[astarte_aggregate(..)]` attribute.
+///
+/// ### Example
+///
+/// ```no_compile
+/// #[derive(AstarteAggregate)]
+/// #[astarte_aggregate(rename_all = "camelCase")]
+/// struct Foo {
+///     bar_v: String
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn astarte_aggregate(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Construct a representation of Rust code as a syntax tree
@@ -233,6 +477,16 @@ pub fn astarte_aggregate(attr: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(quote!(#ast_item))
 }
 
+/// Derive macro `#[derive(AstarteAggregate)]` to implement AstarteAggregate.
+///
+/// ### Example
+///
+/// ```no_compile
+/// #[derive(AstarteAggregate)]
+/// struct Foo {
+///     bar: String
+/// }
+/// ```
 #[proc_macro_derive(AstarteAggregate)]
 pub fn astarte_aggregate_derive(input: TokenStream) -> TokenStream {
     // Construct a representation of Rust code as a syntax tree
@@ -243,32 +497,46 @@ pub fn astarte_aggregate_derive(input: TokenStream) -> TokenStream {
     aggregate.quote().into()
 }
 
-/// Parse the `#[astarte_aggregate(..)]` attribute.
+/// Handle for the `#[from_event(..)]` macro attribute.
 ///
-/// This will skip other attributes or return an error if the attribute parsing failed. We expected
-/// the input to be an outer attribute in the form `astarte_aggregate(rename_all = "...")`.
-fn parse_astarte_aggregate_attribute(attr: &Attribute) -> Option<syn::Result<AggregateAttributes>> {
-    let is_attr = attr
-        .path()
-        .get_ident()
-        .map(ToString::to_string)
-        .filter(|ident| ident == "astarte_aggregate")
-        .is_some();
+/// ### Example
+///
+/// ```no_compile
+/// #[derive(FromEvent)]
+/// #[from_event(interface = "com.example.Foo", path = "obj")]
+/// struct Foo {
+///     bar: String
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn from_event(attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Construct a representation of Rust code as a syntax tree
+    // that we can manipulate
+    let _ast_attr = parse_macro_input!(attr as FromEventAttrs);
+    let ast_item = parse_macro_input!(item as syn::ItemStruct);
 
-    if !is_attr {
-        return None;
-    }
+    // Do not perform any operation. All the checks and changes are performed by the derive
+    // macro.
+    TokenStream::from(quote!(#ast_item))
+}
 
-    // TODO: outer and inner attributes check?
-    match &attr.meta {
-        // We ignore the path since it can the from another macro or the `#[astarte_aggregate]` without
-        // parameters, which we still consider valid.
-        syn::Meta::Path(_) => None,
-        syn::Meta::NameValue(name) => Some(Err(syn::Error::new(
-            name.span(),
-            "cannot be used as a named value, use it as a list `#[astarte_aggregate(..)]`",
-        ))),
-        //
-        syn::Meta::List(list) => Some(syn::parse2::<AggregateAttributes>(list.tokens.clone())),
-    }
+/// Derive macro `#[derive(FromEvent)]` to implement the FromEvent trait.
+///
+/// ### Example
+///
+/// ```no_compile
+/// #[derive(FromEvent)]
+/// #[from_event(interface = "com.example.Foo", path = "obj")]
+/// struct Foo {
+///     bar: String
+/// }
+/// ```
+#[proc_macro_derive(FromEvent)]
+pub fn from_event_derive(input: TokenStream) -> TokenStream {
+    // Construct a representation of Rust code as a syntax tree
+    // that we can manipulate
+    let from_event = parse_macro_input!(input as FromEventDerive);
+
+    // Build the trait implementation
+    from_event.quote().into()
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -109,6 +109,7 @@ pub enum FromEventError {
 ///                 path: "name",
 ///             })?
 ///             .try_into()?;
+///
 ///         let value = object
 ///             .remove("value")
 ///             .ok_or(FromEventError::MissingField {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,121 @@
+// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Event returned form the loop.
+
+use crate::AstarteDeviceDataEvent;
+
+/// Conversion error from an [`AstarteDeviceDataEvent`].
+#[non_exhaustive]
+#[derive(thiserror::Error, Debug)]
+pub enum FromEventError {
+    /// couldn't parse request from interface
+    #[error("couldn't parse request from interface {0}")]
+    Interface(String),
+    /// object has wrong base path
+    #[error("object has wrong base path ({interface}) {object}")]
+    Path {
+        /// Interface that generated the error
+        interface: &'static str,
+        /// Base path of the interface
+        object: String,
+    },
+    /// individual data passed to object
+    #[error("individual data passed to object ({interface}/{object})")]
+    Individual {
+        /// Interface that generated the error
+        interface: &'static str,
+        /// Base path of the interface
+        object: &'static str,
+    },
+    /// object missing field
+    #[error("object missing field ({interface}/{object}) {path}")]
+    MissingField {
+        /// Interface that generated the error
+        interface: &'static str,
+        /// Base path of the interface
+        object: &'static str,
+        /// Path of the endpoint in error
+        path: &'static str,
+    },
+    /// couldn't convert from [`AstarteType`](crate::types::AstarteType)
+    #[error("couldn't convert from AstarteType")]
+    Conversion(#[from] crate::types::TypeError),
+}
+
+/// Converts a struct form an [`AstarteDeviceDataEvent`].
+///
+/// # Example
+///
+/// ```rust
+/// use astarte_device_sdk::{Aggregation, AstarteDeviceDataEvent};
+/// use astarte_device_sdk::event::{FromEvent, FromEventError};
+///
+/// struct Sensor {
+///     name: String,
+///     value: i32,
+/// }
+///
+/// impl FromEvent for Sensor {
+///     type Err = FromEventError;
+///
+///     fn from_event(event: AstarteDeviceDataEvent) -> Result<Self, Self::Err> {
+///         if event.interface != "com.example.Sensor" {
+///             return Err(FromEventError::Interface(event.interface.clone()));
+///         }
+///
+///         if event.path != "/sensor" {
+///             return Err(FromEventError::Path {
+///                 interface: "com.example.Person",
+///                 object: event.path.clone(),
+///             });
+///         }
+///
+///         let Aggregation::Object(mut object) = event.data else {
+///             return Err(FromEventError::Individual {
+///                 interface: "com.example.Person",
+///                 object: "/sensor",
+///             });
+///         };
+///
+///         let name = object
+///             .remove("name")
+///             .ok_or(FromEventError::MissingField {
+///                 interface: "com.example.Person",
+///                 object: "/sensor",
+///                 path: "name",
+///             })?
+///             .try_into()?;
+///         let value = object
+///             .remove("value")
+///             .ok_or(FromEventError::MissingField {
+///                 interface: "com.example.Person",
+///                 object: "/sensor",
+///                 path: "value",
+///             })?
+///             .try_into()?;
+///
+///         Ok(Self { name, value })
+///     }
+/// }
+/// ```
+pub trait FromEvent: Sized {
+    type Err;
+
+    fn from_event(event: AstarteDeviceDataEvent) -> Result<Self, Self::Err>;
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -56,6 +56,9 @@ pub enum FromEventError {
     /// couldn't convert from [`AstarteType`](crate::types::AstarteType)
     #[error("couldn't convert from AstarteType")]
     Conversion(#[from] crate::types::TypeError),
+    /// couldn't parse the [`crate::interface::mapping::endpoint::Endpoint`]
+    #[error("couldn't parse the endpoint")]
+    Endpoint(#[from] crate::interface::mapping::endpoint::EndpointError),
 }
 
 /// Converts a struct form an [`AstarteDeviceDataEvent`].
@@ -65,6 +68,9 @@ pub enum FromEventError {
 /// ```rust
 /// use astarte_device_sdk::{Aggregation, AstarteDeviceDataEvent};
 /// use astarte_device_sdk::event::{FromEvent, FromEventError};
+/// use astarte_device_sdk::interface::mapping::endpoint::Endpoint;
+///
+/// use std::convert::TryFrom;
 ///
 /// struct Sensor {
 ///     name: String,
@@ -75,11 +81,13 @@ pub enum FromEventError {
 ///     type Err = FromEventError;
 ///
 ///     fn from_event(event: AstarteDeviceDataEvent) -> Result<Self, Self::Err> {
+///         let base_path: Endpoint<&str> = Endpoint::try_from("/sensor")?;
+///
 ///         if event.interface != "com.example.Sensor" {
 ///             return Err(FromEventError::Interface(event.interface.clone()));
 ///         }
 ///
-///         if event.path != "/sensor" {
+///         if base_path.eq_mapping(&event.path) {
 ///             return Err(FromEventError::Path {
 ///                 interface: "com.example.Person",
 ///                 object: event.path.clone(),

--- a/src/interface/mapping/endpoint.rs
+++ b/src/interface/mapping/endpoint.rs
@@ -41,9 +41,8 @@ use super::path::MappingPath;
 /// For more information see [Astarte - Docs](https://docs.astarte-platform.org/astarte/latest/030-interface.html#limitations)
 ///
 /// The endpoints uses Cow to not allocate the string if an error occurs.
-///
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) struct Endpoint<T> {
+pub struct Endpoint<T> {
     pub(super) path: T,
     pub(super) levels: Vec<Level<T>>,
 }

--- a/src/interface/mapping/endpoint.rs
+++ b/src/interface/mapping/endpoint.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 use itertools::{EitherOrBoth, Itertools};
-use log::{debug, info, trace};
+use log::{debug, error, info, trace};
 
 use super::path::MappingPath;
 
@@ -48,6 +48,22 @@ pub struct Endpoint<T> {
 }
 
 impl<T> Endpoint<T> {
+    /// Check that the endpoint is equal to the given mapping
+    pub fn eq_mapping<S>(&self, mapping: S) -> bool
+    where
+        S: AsRef<str>,
+        T: AsRef<str>,
+    {
+        match MappingPath::try_from(mapping.as_ref()) {
+            Ok(mapping) => mapping.eq(self),
+            Err(err) => {
+                error!("failed to parse mapping {err}");
+
+                false
+            }
+        }
+    }
+
     /// Iter the levels of the endpoint.
     pub(crate) fn iter(&self) -> SliceIter<Level<T>> {
         self.levels.iter()

--- a/src/interface/mapping/mod.rs
+++ b/src/interface/mapping/mod.rs
@@ -16,6 +16,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//! Mapping of an interface.
+
 use std::{borrow::Borrow, ops::Deref};
 
 use log::warn;

--- a/src/interface/mapping/path.rs
+++ b/src/interface/mapping/path.rs
@@ -18,10 +18,6 @@
 
 //! Path of a mapping in interface. It's the parsed struct path received from the MQTT levels
 //! structure of the topic received.
-//!
-//! It will be used to access the [`crate::interface::Mapping`] in an
-//! [`crate::interface::Interface`]. Since the mapping is a tree, the path will compared to the
-//! [`crate::interface::mapping::endpoint::Endpoint`] of the mapping.
 
 use std::{cmp::Ordering, fmt::Display};
 
@@ -89,8 +85,6 @@ where
     }
 }
 
-/// Implement [`PartialEq`] to index a [`super::vec::MappingVec`] by a tuble of [`MappingPath`] as
-/// the base path and field of an object aggregate.
 impl<'a, S, T> PartialEq<Endpoint<T>> for (&MappingPath<'a>, S)
 where
     S: AsRef<str>,
@@ -117,8 +111,6 @@ where
     }
 }
 
-/// Implement [`PartialOrd`] to index a [`super::vec::MappingVec`] by a tuble of [`MappingPath`] as
-/// the base path and field of an object aggregate.
 impl<'a, S, T> PartialOrd<Endpoint<T>> for (&MappingPath<'a>, S)
 where
     S: AsRef<str>,

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -22,7 +22,7 @@
 
 pub mod def;
 pub mod error;
-pub(crate) mod mapping;
+pub mod mapping;
 pub mod reference;
 pub(crate) mod validation;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ use log::{debug, error, info, trace, warn};
 use rumqttc::{Event, Publish};
 
 /// Re-exported internal structs
+pub use crate::event::FromEvent;
 pub use crate::interface::Interface;
 
 use crate::error::Error;
@@ -148,9 +149,9 @@ pub type EventReceiver = mpsc::Receiver<Result<AstarteDeviceDataEvent, Error>>;
 #[macro_use]
 extern crate astarte_device_sdk_derive;
 
-/// Derive macro to implement `AstarteAggregate` trait with `feature = ["derive"]`.
+/// Derive macros enable with the `feature = ["derive"]`.
 #[cfg(feature = "derive")]
-pub use astarte_device_sdk_derive::AstarteAggregate;
+pub use astarte_device_sdk_derive::*;
 
 /// Astarte device implementation.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod crypto;
 pub mod error;
+pub mod event;
 pub mod interface;
 mod interfaces;
 #[cfg(test)]


### PR DESCRIPTION
Implement a trait to convert an `AstarteDataEvent` into a rust struct. Since the implementation is repetitive and has to pass some standard checks, a derive macro is also implemented for named structs. It will parse the fields of the struct and extract the appropriate endpoints values from the event.