### PR TITLE
fix(store): add correct Send + Sync + 'static for tokio

### DIFF
--- a/src/store/error.rs
+++ b/src/store/error.rs
@@ -19,9 +19,9 @@
 //! Error for the store.
 
 /// Dynamic error type of an [`super::PropertyStore`].
-type DynError = Box<dyn std::error::Error>;
+type DynError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-/// Error type returned by the [`super::PropertyStore`] trait.
+/// Error that wraps the type returned by an implementation of the [`super::PropertyStore`] trait.
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -40,8 +40,9 @@ pub mod wrapper;
 #[async_trait]
 pub trait PropertyStore: Debug + Send + Sync + 'static
 where
-    // NOTE: the 'static bound is required for the MSRV, in other version the error is not present
-    Self::Err: StdError,
+    // NOTE: the bounds are required to be compatible with the tokio tasks, with an additional Sync
+    //       bound to further restrict the error type.
+    Self::Err: StdError + Send + Sync + 'static,
 {
     type Err;
 
@@ -84,6 +85,8 @@ pub struct StoredProp {
 
 #[cfg(test)]
 mod tests {
+    use crate::store::{memory::MemoryStore, wrapper::StoreWrapper};
+
     use super::*;
 
     pub(crate) async fn test_property_store<S>(store: S)
@@ -189,5 +192,21 @@ mod tests {
         props.sort_unstable_by(|a, b| a.interface.cmp(&b.interface));
 
         assert_eq!(props, expected);
+    }
+
+    /// Test that the error is Send + Sync + 'static to be send across task boundaries.
+    #[tokio::test]
+    async fn erro_should_compatible_with_tokio() {
+        let mem = StoreWrapper::new(MemoryStore::new());
+
+        let exp = AstarteType::Integer(1);
+        mem.store_prop("com.test", "/test", &exp, 1).await.unwrap();
+
+        let res = tokio::spawn(async move { mem.load_prop("com.test", "/test", 1).await })
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(res, Some(exp));
     }
 }


### PR DESCRIPTION
This will let the error be passed to a tokio task. The error is overzealous on the Sync bound, but most of the methods of the Error trait requires it anyway so I think it's safe to add.