### PR TITLE
fix(serde): serialize and deserialize mixed arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Check if an interface exists and the type is the same of the value
+  passed/received when sending or receiving data from Astarte.
+
 ### Fixed
 - Unset of property send empty buffer instead of document with null value.
+- Deserialize mixed integer BSON arrays from Astarte to the type specified in
+  the interface (longinteger and integer)
 
 ## [0.6.0] - 2023-07-05
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,6 @@ dependencies = [
  "bson",
  "cargo-husky",
  "chrono",
- "colored",
  "criterion",
  "ecdsa",
  "env_logger",
@@ -393,17 +392,6 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
-
-[[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
 
 [[package]]
 name = "const-oid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ x509-cert = { version = "0.2.3", features = ["builder"] }
 
 [dev-dependencies]
 astarte-device-sdk-derive = { path = "./astarte-device-sdk-derive" }
-colored = "2.0.0"
 criterion = "0.5.1"
 env_logger = "0.10.0"
 mockall = "0.11.4"

--- a/migrations/20230622092054_init.sql
+++ b/migrations/20230622092054_init.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS propcache (
     interface TEXT NOT NULl,
     path TEXT NOT NULL,
     value BLOB NOT NULL,
+    type INTEGER NOT NULL,
     interface_major INTEGER NOT NULL,
     PRIMARY KEY (interface, path)
 )

--- a/queries/load_all_props.sql
+++ b/queries/load_all_props.sql
@@ -2,5 +2,6 @@ SELECT
     interface,
     path,
     value,
-    interface_major AS "interface_major: i32"
+    type AS 'stored_type: u8',
+    interface_major AS 'interface_major: i32'
 FROM propcache

--- a/queries/load_prop.sql
+++ b/queries/load_prop.sql
@@ -1,4 +1,5 @@
 SELECT
     value,
-    interface_major AS "interface_major: i32"
+    type AS 'stored_type: u8',
+    interface_major AS 'interface_major: i32'
 FROM propcache WHERE interface = ? AND path = ?

--- a/queries/store_prop.sql
+++ b/queries/store_prop.sql
@@ -1,3 +1,7 @@
 INSERT OR REPLACE INTO propcache (
-    interface, path, value, interface_major
-) VALUES (?, ?, ?, ?)
+    interface,
+    path,
+    value,
+    type,
+    interface_major
+) VALUES (?, ?, ?, ?, ?)

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -20,7 +20,17 @@
     },
     "query": "DELETE FROM propcache WHERE interface = ? AND path = ?\n"
   },
-  "804a9c871aa5574facc14dc06e27916db45df75a89b5674ae9f7d3a54606d75e": {
+  "baddb61f1e374ef6ebc7ff926a78e210bc4023b9079426bfdff6e73dde5a6a63": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 5
+      }
+    },
+    "query": "INSERT OR REPLACE INTO propcache (\n    interface,\n    path,\n    value,\n    type,\n    interface_major\n) VALUES (?, ?, ?, ?, ?)\n"
+  },
+  "da93a9fb157687e399c85f23537613928646e2871f20e7cff0d9429c2bcd87a4": {
     "describe": {
       "columns": [
         {
@@ -29,12 +39,18 @@
           "type_info": "Blob"
         },
         {
-          "name": "interface_major: i32",
+          "name": "stored_type: u8",
           "ordinal": 1,
+          "type_info": "Int64"
+        },
+        {
+          "name": "interface_major: i32",
+          "ordinal": 2,
           "type_info": "Int64"
         }
       ],
       "nullable": [
+        false,
         false,
         false
       ],
@@ -42,9 +58,9 @@
         "Right": 2
       }
     },
-    "query": "SELECT\n    value,\n    interface_major AS \"interface_major: i32\"\nFROM propcache WHERE interface = ? AND path = ?\n"
+    "query": "SELECT\n    value,\n    type AS 'stored_type: u8',\n    interface_major AS 'interface_major: i32'\nFROM propcache WHERE interface = ? AND path = ?\n"
   },
-  "9a76747fa42999ead2991849a91f77176cfd07dee80f38c2e29e08f2e5f45bc1": {
+  "e51de10b171650842a86f2186785e89c4363876c15e30390c370ce53a0427f3f": {
     "describe": {
       "columns": [
         {
@@ -63,12 +79,18 @@
           "type_info": "Blob"
         },
         {
-          "name": "interface_major: i32",
+          "name": "stored_type: u8",
           "ordinal": 3,
+          "type_info": "Int64"
+        },
+        {
+          "name": "interface_major: i32",
+          "ordinal": 4,
           "type_info": "Int64"
         }
       ],
       "nullable": [
+        false,
         false,
         false,
         false,
@@ -78,16 +100,6 @@
         "Right": 0
       }
     },
-    "query": "SELECT\n    interface,\n    path,\n    value,\n    interface_major AS \"interface_major: i32\"\nFROM propcache\n"
-  },
-  "9b3f0a34400ba357a3a7ff8a91c68e815ca4cf0e481530ea0d33334fbf4fbdb3": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 4
-      }
-    },
-    "query": "INSERT OR REPLACE INTO propcache (\n    interface, path, value, interface_major\n) VALUES (?, ?, ?, ?)\n"
+    "query": "SELECT\n    interface,\n    path,\n    value,\n    type AS 'stored_type: u8',\n    interface_major AS 'interface_major: i32'\nFROM propcache\n"
   }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,13 +21,14 @@
 use std::convert::Infallible;
 
 use crate::interface::mapping::path::MappingError;
-use crate::interface::InterfaceError;
+use crate::interface::{Aggregation, InterfaceError, InterfaceTypeDef};
 use crate::options::OptionsError;
 use crate::payload::PayloadError;
 use crate::properties::PropertiesError;
 use crate::store::error::StoreError;
 use crate::topic::TopicError;
 use crate::types::TypeError;
+use crate::validate::ValidationError;
 
 /// Astarte error.
 ///
@@ -35,12 +36,14 @@ use crate::types::TypeError;
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[deprecated = "The error is unused and will be removed in a future version"]
     #[error("bson client error")]
     BsonClientError(#[from] rumqttc::ClientError),
 
     #[error("mqtt connection error")]
     ConnectionError(#[from] rumqttc::ConnectionError),
 
+    #[deprecated = "The error is unused and will be removed in a future version"]
     #[error("send error ({0})")]
     SendError(String),
 
@@ -53,6 +56,7 @@ pub enum Error {
     #[error("invalid interface")]
     Interface(#[from] InterfaceError),
 
+    #[deprecated = "The error is unused and will be removed in a future version"]
     #[error("generic error ({0})")]
     Reported(String),
 
@@ -83,4 +87,25 @@ pub enum Error {
     /// Error returned by a store operation.
     #[error("couldn't complete store operation")]
     Database(#[from] StoreError),
+
+    /// Error missing interface
+    #[error("couldn't find the interface {0}")]
+    MissingInterface(String),
+
+    /// Error missing mapping in interface
+    #[error("couldn't find mapping {mapping} in interface {interface}")]
+    MissingMapping { interface: String, mapping: String },
+
+    /// Send or receive validation failed
+    #[error("validation of the payload failed")]
+    Validation(#[from] ValidationError),
+
+    #[error("invalid aggregation, expected {exp} but got {got}")]
+    Aggregation { exp: Aggregation, got: Aggregation },
+
+    #[error("invalid interface type, expected {exp} but got {got}")]
+    InterfaceType {
+        exp: InterfaceTypeDef,
+        got: InterfaceTypeDef,
+    },
 }

--- a/src/interface/def.rs
+++ b/src/interface/def.rs
@@ -158,7 +158,7 @@ impl<'a> Mapping<'a> {
     pub(crate) fn retention(&self) -> Retention {
         match self.retention {
             RetentionDef::Discard => {
-                if self.expiry >= 0 {
+                if self.expiry > 0 {
                     warn!("Discard retention policy with expiry set, ignoring expiry");
                 }
 

--- a/src/interface/def.rs
+++ b/src/interface/def.rs
@@ -89,7 +89,7 @@ pub(super) struct InterfaceDef<'a> {
 //
 /// You can find the specification here
 /// [Mapping Schema - Astarte](https://docs.astarte-platform.org/astarte/latest/040-interface_schema.html#mapping)
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 pub(crate) struct Mapping<'a> {
     pub(super) endpoint: &'a str,
     #[serde(rename = "type")]
@@ -274,6 +274,15 @@ pub enum InterfaceTypeDef {
     Properties,
 }
 
+impl Display for InterfaceTypeDef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InterfaceTypeDef::Datastream => write!(f, "datastream"),
+            InterfaceTypeDef::Properties => write!(f, "properties"),
+        }
+    }
+}
+
 /// Ownership of an interface.
 ///
 /// See [Interface Schema](https://docs.astarte-platform.org/latest/040-interface_schema.html#reference-astarte-interface-schema)
@@ -295,6 +304,15 @@ pub enum Aggregation {
     #[default]
     Individual,
     Object,
+}
+
+impl Display for Aggregation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Aggregation::Individual => write!(f, "individual"),
+            Aggregation::Object => write!(f, "object"),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]

--- a/src/interface/error.rs
+++ b/src/interface/error.rs
@@ -19,7 +19,9 @@
 
 use std::io;
 
-use super::{mapping::endpoint::EndpointError, validation::VersionChangeError};
+use super::{
+    mapping::endpoint::EndpointError, validation::VersionChangeError, MAX_INTERFACE_MAPPINGS,
+};
 
 /// Error for parsing and validating an interface.
 #[non_exhaustive]
@@ -62,13 +64,15 @@ pub enum InterfaceError {
     #[error("object endpoint should have at least 2 levels: '{0}'")]
     ObjectEndpointTooShort(String),
     /// The name of the interface was changed.
-    #[error(
-        r#"this version has a different name than the previous version
-    name: {name}
-    prev_name: {prev_name}"#
-    )]
+    #[error( r#"this version has a different name than the previous version name: {name} prev_name: {prev_name}"#)]
     NameMismatch { name: String, prev_name: String },
     /// Invalid version change.
     #[error("invalid version: {0}")]
     Version(VersionChangeError),
+    /// Interface with too many mappings
+    #[error(
+        "too many mappings {0}, interfaces can have a max of {} mappings",
+        MAX_INTERFACE_MAPPINGS
+    )]
+    TooManyMappings(usize),
 }

--- a/src/interface/mapping/endpoint.rs
+++ b/src/interface/mapping/endpoint.rs
@@ -19,16 +19,13 @@
 //! Endpoint of an interface mapping.
 
 use std::{
-    borrow::{Borrow, Cow},
-    cmp::Ordering,
-    fmt::Display,
-    ops::Deref,
-    slice::Iter as SliceIter,
-    unreachable,
+    borrow::Borrow, cmp::Ordering, fmt::Display, ops::Deref, slice::Iter as SliceIter, unreachable,
 };
 
 use itertools::{EitherOrBoth, Itertools};
 use log::{debug, info, trace};
+
+use super::path::MappingPath;
 
 /// A mapping endpoint.
 ///
@@ -46,45 +43,28 @@ use log::{debug, info, trace};
 /// The endpoints uses Cow to not allocate the string if an error occurs.
 ///
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) struct Endpoint<'a> {
-    pub(super) path: Cow<'a, str>,
-    pub(super) levels: Vec<Level<'a>>,
+pub(crate) struct Endpoint<T> {
+    pub(super) path: T,
+    pub(super) levels: Vec<Level<T>>,
 }
 
-impl<'a> Endpoint<'a> {
-    pub(crate) fn into_owned(self) -> Endpoint<'static> {
-        // We try to not clone, so we do not have to allocate if we are already borrowed.
-        let Self { path, levels } = self;
-
-        let path = path.into_owned().into();
-
-        // There is no better way to reuse the same vector unfortunately.
-        let levels: Vec<Level<'static>> = levels.into_iter().map(Level::into_owned).collect();
-
-        Endpoint { path, levels }
-    }
-
-    /// Clone an owned endpoint, trying to be smart with allocations
-    pub(crate) fn clone_owned(&self) -> Endpoint<'static> {
-        let path = self.path.clone().into_owned();
-        let levels = self.levels.iter().map(Level::clone_owned).collect();
-
-        Endpoint {
-            path: path.into(),
-            levels,
-        }
-    }
-
-    pub(crate) fn iter(&self) -> SliceIter<Level> {
+impl<T> Endpoint<T> {
+    /// Iter the levels of the endpoint.
+    pub(crate) fn iter(&self) -> SliceIter<Level<T>> {
         self.levels.iter()
     }
 
-    pub(crate) fn cmp_levels(&self, levels: &[&str]) -> Ordering {
+    /// Compare the levels with the one of the endpoint.
+    pub(crate) fn cmp_levels<U>(&self, levels: &[U]) -> Ordering
+    where
+        T: AsRef<str>,
+        U: AsRef<str>,
+    {
         for element in self.iter().zip_longest(levels.iter()) {
             let ordering = match element {
                 EitherOrBoth::Left(_) => Ordering::Greater,
                 EitherOrBoth::Right(_) => Ordering::Less,
-                EitherOrBoth::Both(lvl, o_lvl) => lvl.cmp_str(o_lvl),
+                EitherOrBoth::Both(lvl, o_lvl) => lvl.cmp_str(o_lvl.as_ref()),
             };
 
             if ordering != Ordering::Equal {
@@ -101,7 +81,10 @@ impl<'a> Endpoint<'a> {
     }
 
     /// Check that two endpoints are compatible with the same object.
-    pub(crate) fn eq_till_last(&self, endpoint: &Endpoint) -> bool {
+    pub(crate) fn is_same_object(&self, endpoint: &Self) -> bool
+    where
+        T: PartialEq,
+    {
         if self.len() != endpoint.len() {
             return false;
         }
@@ -122,19 +105,25 @@ impl<'a> Endpoint<'a> {
     }
 }
 
-impl<'a> PartialOrd for Endpoint<'a> {
+impl<T> PartialOrd for Endpoint<T>
+where
+    T: Ord,
+{
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'a> Ord for Endpoint<'a> {
+impl<T> Ord for Endpoint<T>
+where
+    T: Ord,
+{
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.levels.cmp(&other.levels)
     }
 }
 
-impl<'a> TryFrom<&'a str> for Endpoint<'a> {
+impl<'a> TryFrom<&'a str> for Endpoint<&'a str> {
     type Error = EndpointError;
 
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {
@@ -142,13 +131,27 @@ impl<'a> TryFrom<&'a str> for Endpoint<'a> {
     }
 }
 
-impl<'a> Borrow<str> for Endpoint<'a> {
-    fn borrow(&self) -> &str {
-        &self.path
+impl TryFrom<&str> for Endpoint<String> {
+    type Error = EndpointError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Endpoint::<&str>::try_from(value).map(Endpoint::into)
     }
 }
 
-impl Deref for Endpoint<'_> {
+impl<T> Borrow<str> for Endpoint<T>
+where
+    T: Borrow<str>,
+{
+    fn borrow(&self) -> &str {
+        self.path.borrow()
+    }
+}
+
+impl<T> Deref for Endpoint<T>
+where
+    T: Deref<Target = str>,
+{
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -156,45 +159,84 @@ impl Deref for Endpoint<'_> {
     }
 }
 
-impl PartialEq<str> for Endpoint<'_> {
+impl<T> PartialEq<str> for Endpoint<T>
+where
+    T: PartialEq<str>,
+{
     fn eq(&self, other: &str) -> bool {
-        self.path == other
+        self.path.eq(other)
     }
 }
 
-impl Display for Endpoint<'_> {
+impl<T> Display for Endpoint<T>
+where
+    T: Display,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.path)
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) enum Level<'a> {
-    Simple(Cow<'a, str>),
-    Parameter(Cow<'a, str>),
-}
-
-impl<'a> Level<'a> {
-    pub(crate) fn into_owned(self) -> Level<'static> {
-        match self {
-            Self::Simple(level) => Level::Simple(level.into_owned().into()),
-            Self::Parameter(level) => Level::Parameter(level.into_owned().into()),
+impl From<Endpoint<&str>> for Endpoint<String> {
+    fn from(value: Endpoint<&str>) -> Self {
+        Self {
+            path: value.path.into(),
+            levels: value.levels.into_iter().map(Level::into).collect(),
         }
     }
+}
 
-    pub(crate) fn cmp_str(&self, other: &str) -> Ordering {
+impl<'a, T> PartialEq<MappingPath<'a>> for Endpoint<T>
+where
+    T: AsRef<str>,
+{
+    fn eq(&self, other: &MappingPath<'a>) -> bool {
+        self.levels == other.levels
+    }
+}
+
+impl<'a, T> PartialOrd<MappingPath<'a>> for Endpoint<T>
+where
+    T: AsRef<str>,
+{
+    fn partial_cmp(&self, other: &MappingPath<'a>) -> Option<Ordering> {
+        Some(self.cmp_levels(&other.levels))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum Level<T> {
+    Simple(T),
+    Parameter(T),
+}
+
+impl<T> Level<T> {
+    pub(crate) fn cmp_str(&self, other: &str) -> Ordering
+    where
+        T: AsRef<str>,
+    {
         match self {
             Self::Simple(level) => level.as_ref().cmp(other),
             Self::Parameter(_) => Ordering::Equal,
         }
     }
 
-    pub(crate) fn clone_owned(&self) -> Level<'static> {
-        self.clone().into_owned()
+    /// Check if the level is eq to the string
+    pub(crate) fn eq_str(&self, other: &str) -> bool
+    where
+        T: AsRef<str>,
+    {
+        match self {
+            Level::Simple(level) => level.as_ref() == other,
+            Level::Parameter(_) => true,
+        }
     }
 }
 
-impl<'a> Display for Level<'a> {
+impl<T> Display for Level<T>
+where
+    T: Display,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Simple(level) => write!(f, "{}", level),
@@ -204,13 +246,55 @@ impl<'a> Display for Level<'a> {
     }
 }
 
-impl<'a> PartialOrd for Level<'a> {
+impl<T> PartialOrd for Level<T>
+where
+    T: Ord,
+{
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'a> Ord for Level<'a> {
+impl<T> PartialEq<str> for Level<T>
+where
+    T: AsRef<str>,
+{
+    fn eq(&self, other: &str) -> bool {
+        self.eq_str(other)
+    }
+}
+
+impl<T> PartialOrd<str> for Level<T>
+where
+    T: AsRef<str>,
+{
+    fn partial_cmp(&self, other: &str) -> Option<Ordering> {
+        Some(self.cmp_str(other))
+    }
+}
+
+impl<T> PartialEq<&str> for Level<T>
+where
+    T: AsRef<str>,
+{
+    fn eq(&self, other: &&str) -> bool {
+        self.eq_str(other)
+    }
+}
+
+impl<T> PartialOrd<&str> for Level<T>
+where
+    T: AsRef<str>,
+{
+    fn partial_cmp(&self, other: &&str) -> Option<Ordering> {
+        Some(self.cmp_str(other))
+    }
+}
+
+impl<T> Ord for Level<T>
+where
+    T: Ord,
+{
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // This could be simplified in an if, but i kept it explicit for clarity.
         match (self, other) {
@@ -219,6 +303,15 @@ impl<'a> Ord for Level<'a> {
             (Self::Parameter(_), Self::Parameter(_))
             | (Self::Simple(_), Self::Parameter(_))
             | (Self::Parameter(_), Self::Simple(_)) => std::cmp::Ordering::Equal,
+        }
+    }
+}
+
+impl From<Level<&str>> for Level<String> {
+    fn from(value: Level<&str>) -> Self {
+        match value {
+            Level::Simple(simple) => Level::Simple(simple.into()),
+            Level::Parameter(param) => Level::Parameter(param.into()),
         }
     }
 }
@@ -289,7 +382,7 @@ pub enum LevelError {
 ///
 /// - We allow ending the level with a '%' since we can peek
 ///
-fn parse_endpoint(input: &str) -> Result<Endpoint, EndpointError> {
+fn parse_endpoint(input: &str) -> Result<Endpoint<&str>, EndpointError> {
     debug!("parsing endpoint: {}", input);
 
     let endpoint = input
@@ -299,7 +392,7 @@ fn parse_endpoint(input: &str) -> Result<Endpoint, EndpointError> {
     let levels = endpoint
         .split('/')
         .map(parse_level)
-        .collect::<Result<Vec<Level>, LevelError>>()
+        .collect::<Result<Vec<_>, LevelError>>()
         .map_err(|error| EndpointError::Level {
             input: input.to_string(),
             error,
@@ -312,26 +405,26 @@ fn parse_endpoint(input: &str) -> Result<Endpoint, EndpointError> {
     info!("levels: {:?}", levels);
 
     Ok(Endpoint {
-        path: input.into(),
+        path: input,
         levels,
     })
 }
 
-fn parse_level(input: &str) -> Result<Level, LevelError> {
+fn parse_level(input: &str) -> Result<Level<&str>, LevelError> {
     trace!("parsing level: {}", input);
 
     let level = match parse_parameter(input)? {
         Some(param) => {
             trace!("level is a parameter: {}", param);
 
-            Level::Parameter(Cow::from(param))
+            Level::Parameter(param)
         }
         None => {
             let level = parse_simple(input)?;
 
             trace!("level is simple: {}", level);
 
-            Level::Simple(Cow::from(level))
+            Level::Simple(level)
         }
     };
 
@@ -353,9 +446,7 @@ fn parse_simple(input: &str) -> Result<&str, LevelError> {
                 return Err(LevelError::Parameter);
             }
             '/' => unreachable!("level shouldn't contain '/' since it is used as separator"),
-            _ => {
-                trace!("level char: {}", chr)
-            }
+            _ => {}
         }
     }
 
@@ -383,8 +474,11 @@ fn parse_parameter(input: &str) -> Result<Option<&str>, LevelError> {
 mod tests {
     use super::*;
 
-    impl<'a> Endpoint<'a> {
-        pub(crate) fn eq_strict(&self, other: &Self) -> bool {
+    impl<T> Endpoint<T> {
+        pub(crate) fn eq_strict(&self, other: &Self) -> bool
+        where
+            T: PartialEq,
+        {
             if self.path != other.path {
                 return false;
             }
@@ -433,7 +527,7 @@ mod tests {
 
         let level = res.unwrap();
 
-        assert_eq!(level, Level::Parameter(Cow::from("test")));
+        assert_eq!(level, Level::Parameter("test"));
     }
 
     #[test]
@@ -449,11 +543,11 @@ mod tests {
         let endpoint = res.unwrap();
 
         let expected = Endpoint {
-            path: "/a/%{b}/c".into(),
+            path: "/a/%{b}/c",
             levels: vec![
-                Level::Simple(Cow::from("a")),
-                Level::Parameter(Cow::from("b")),
-                Level::Simple(Cow::from("c")),
+                Level::Simple("a"),
+                Level::Parameter("b"),
+                Level::Simple("c"),
             ],
         };
 
@@ -478,11 +572,11 @@ mod tests {
         let endpoint = res.unwrap();
 
         let expected = Endpoint {
-            path: "/%{a}/b/c".into(),
+            path: "/%{a}/b/c",
             levels: vec![
-                Level::Parameter(Cow::from("a")),
-                Level::Simple(Cow::from("b")),
-                Level::Simple(Cow::from("c")),
+                Level::Parameter("a"),
+                Level::Simple("b"),
+                Level::Simple("c"),
             ],
         };
 
@@ -507,13 +601,13 @@ mod tests {
         let endpoint = res.unwrap();
 
         let expected = Endpoint {
-            path: "/a/%{b}/c/%{d}/e".into(),
+            path: "/a/%{b}/c/%{d}/e",
             levels: vec![
-                Level::Simple(Cow::from("a")),
-                Level::Parameter(Cow::from("b")),
-                Level::Simple(Cow::from("c")),
-                Level::Parameter(Cow::from("d")),
-                Level::Simple(Cow::from("e")),
+                Level::Simple("a"),
+                Level::Parameter("b"),
+                Level::Simple("c"),
+                Level::Parameter("d"),
+                Level::Simple("e"),
             ],
         };
 
@@ -531,21 +625,18 @@ mod tests {
             (
                 "/%{sensor_id}/boolean_endpoint",
                 Endpoint {
-                    path: "/%{sensor_id}/boolean_endpoint".into(),
+                    path: "/%{sensor_id}/boolean_endpoint",
                     levels: vec![
-                        Level::Parameter(Cow::from("sensor_id")),
-                        Level::Simple(Cow::from("boolean_endpoint")),
+                        Level::Parameter("sensor_id"),
+                        Level::Simple("boolean_endpoint"),
                     ],
                 },
             ),
             (
                 "/%{sensor_id}/enable",
                 Endpoint {
-                    path: "/%{sensor_id}/enable".into(),
-                    levels: vec![
-                        Level::Parameter(Cow::from("sensor_id")),
-                        Level::Simple(Cow::from("enable")),
-                    ],
+                    path: "/%{sensor_id}/enable",
+                    levels: vec![Level::Parameter("sensor_id"), Level::Simple("enable")],
                 },
             ),
         ];

--- a/src/interface/mapping/iter.rs
+++ b/src/interface/mapping/iter.rs
@@ -18,13 +18,11 @@
 
 //! Iterators over an interface mappings mappings.
 
-use std::{collections::btree_map::Values, iter::FusedIterator};
+use std::iter::FusedIterator;
 
-use crate::interface::{DatastreamObject, InterfaceType, Mapping, MappingMap, MappingPath};
+use crate::interface::{DatastreamObject, InterfaceType, Mapping, MappingVec};
 
-use super::{BaseMapping, DatastreamIndividualMapping, PropertiesMapping};
-
-type ValuesIter<'a, T> = Values<'a, MappingPath<'a>, T>;
+use super::{vec::ItemIter, BaseMapping, DatastreamIndividualMapping, PropertiesMapping};
 
 pub(crate) enum MappingIter<'a> {
     Properties(PropertiesMappingIter<'a>),
@@ -88,13 +86,13 @@ impl FusedIterator for MappingIter<'_> {}
 
 #[derive(Debug, Clone)]
 pub(crate) struct PropertiesMappingIter<'a> {
-    properties: ValuesIter<'a, PropertiesMapping>,
+    properties: ItemIter<'a, PropertiesMapping>,
 }
 
 impl<'a> PropertiesMappingIter<'a> {
-    pub(crate) fn new(properties: &'a MappingMap<PropertiesMapping>) -> Self {
+    pub(crate) fn new(properties: &'a MappingVec<PropertiesMapping>) -> Self {
         Self {
-            properties: properties.values(),
+            properties: properties.iter(),
         }
     }
 }
@@ -127,13 +125,13 @@ impl FusedIterator for PropertiesMappingIter<'_> {}
 
 #[derive(Debug, Clone)]
 pub(crate) struct IndividualMappingIter<'a> {
-    properties: ValuesIter<'a, DatastreamIndividualMapping>,
+    properties: ItemIter<'a, DatastreamIndividualMapping>,
 }
 
 impl<'a> IndividualMappingIter<'a> {
-    pub(crate) fn new(properties: &'a MappingMap<DatastreamIndividualMapping>) -> Self {
+    pub(crate) fn new(properties: &'a MappingVec<DatastreamIndividualMapping>) -> Self {
         Self {
-            properties: properties.values(),
+            properties: properties.iter(),
         }
     }
 }
@@ -167,14 +165,14 @@ impl FusedIterator for IndividualMappingIter<'_> {}
 #[derive(Debug, Clone)]
 pub(crate) struct ObjectMappingIter<'a> {
     interface: &'a DatastreamObject,
-    properties: ValuesIter<'a, BaseMapping>,
+    properties: ItemIter<'a, BaseMapping>,
 }
 
 impl<'a> ObjectMappingIter<'a> {
     pub(crate) fn new(interface: &'a DatastreamObject) -> Self {
         Self {
             interface,
-            properties: interface.mappings.values(),
+            properties: interface.mappings.iter(),
         }
     }
 }

--- a/src/interface/mapping/vec.rs
+++ b/src/interface/mapping/vec.rs
@@ -1,0 +1,218 @@
+// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Sorted collection of interfaces accessible by endpoint or path.
+
+use std::{
+    cmp::Ordering, collections::BTreeSet, fmt::Debug, iter::FusedIterator, ops::Deref,
+    slice::Iter as SliceIter,
+};
+
+use itertools::Itertools;
+
+use super::{endpoint::Endpoint, InterfaceMapping};
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct MappingVec<T> {
+    mappings: Vec<Item<T>>,
+}
+
+impl<T> MappingVec<T> {
+    /// Create an empty vector.
+    pub(crate) fn new() -> Self {
+        Self {
+            mappings: Vec::new(),
+        }
+    }
+
+    /// Get's the mapping searching the [`Endpoint`]'s for the one matching the path.
+    pub(crate) fn get<U>(&self, path: &U) -> Option<&T>
+    where
+        T: InterfaceMapping + Debug,
+        U: PartialOrd<Endpoint<String>> + Eq + Debug,
+    {
+        self.mappings
+            .binary_search_by(|item| {
+                let endpoint = item.endpoint();
+                // We invert the ordering for less/greater since the trait is implemented on the
+                // path, but we need to actually check the argument
+                path.partial_cmp(endpoint)
+                    .map_or(Ordering::Less, Ordering::reverse)
+            })
+            .ok()
+            .and_then(|idx| self.mappings.get(idx))
+            .map(|item| &item.0)
+    }
+
+    /// Returns the number of mappings.
+    pub(crate) fn len(&self) -> usize {
+        self.mappings.len()
+    }
+
+    /// Iterate over the mappings.
+    pub(crate) fn iter(&self) -> ItemIter<T> {
+        ItemIter {
+            items: self.mappings.iter(),
+        }
+    }
+}
+
+impl<T> PartialEq for MappingVec<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.mappings
+            .iter()
+            .zip_longest(other.mappings.iter())
+            .all(|e| match e {
+                itertools::EitherOrBoth::Both(a, b) => a.0 == b.0,
+                itertools::EitherOrBoth::Left(_) | itertools::EitherOrBoth::Right(_) => false,
+            })
+    }
+}
+
+impl<T> Eq for MappingVec<T> where T: Eq {}
+
+impl<T> From<BTreeSet<Item<T>>> for MappingVec<T> {
+    fn from(value: BTreeSet<Item<T>>) -> Self {
+        let mappings = value.into_iter().collect();
+
+        Self { mappings }
+    }
+}
+
+/// Item of the [`MappingVec`] to check that the inner type is [`Ord`] by the [`Endpoint`] returned by
+/// [`InterfaceMapping::endpoint`]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Item<T>(T);
+
+impl<T> Item<T> {
+    pub(crate) fn new(mapping: T) -> Self {
+        Self(mapping)
+    }
+}
+
+impl<T> Deref for Item<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> PartialEq for Item<T>
+where
+    T: InterfaceMapping,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.endpoint() == other.endpoint()
+    }
+}
+
+impl<T> Eq for Item<T> where T: InterfaceMapping {}
+
+impl<T> PartialOrd for Item<T>
+where
+    T: InterfaceMapping,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for Item<T>
+where
+    T: InterfaceMapping,
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.endpoint().cmp(other.endpoint())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ItemIter<'a, T> {
+    items: SliceIter<'a, Item<T>>,
+}
+
+impl<'a, T> Iterator for ItemIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.items.next().map(|i| &i.0)
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for ItemIter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.items.next_back().map(|i| &i.0)
+    }
+}
+
+impl<'a, T> ExactSizeIterator for ItemIter<'a, T> {
+    fn len(&self) -> usize {
+        self.items.len()
+    }
+}
+
+impl<'a, T> FusedIterator for ItemIter<'a, T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl InterfaceMapping for Endpoint<String> {
+        fn endpoint(&self) -> &Endpoint<String> {
+            self
+        }
+    }
+
+    fn enpt(s: impl AsRef<str>) -> Endpoint<String> {
+        let endpoint = s.as_ref();
+
+        Endpoint::try_from(endpoint).unwrap()
+    }
+
+    #[test]
+    fn should_get_mapping() {
+        let cases = [enpt("/foo/32"), enpt("/foo/bar"), enpt("/%{param}/param")];
+        let btree: BTreeSet<_> = cases.iter().map(|i| Item(i.clone())).collect();
+        let mappings = MappingVec::from(btree);
+
+        for case in cases {
+            let e = mappings
+                .get(&case)
+                .unwrap_or_else(|| panic!("failed to get {case}"));
+
+            assert_eq!(*e, case);
+        }
+    }
+
+    #[test]
+    fn should_iter_mappings() {
+        // Order is important
+        let cases = [enpt("/foo/32"), enpt("/foo/bar"), enpt("/%{param}/param")];
+        let btree: BTreeSet<_> = cases.iter().map(|i| Item(i.clone())).collect();
+        let mappings = MappingVec::from(btree);
+
+        mappings
+            .iter()
+            .zip_eq(cases)
+            .for_each(|(a, b)| assert_eq!(*a, b))
+    }
+}

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -28,10 +28,8 @@ use itertools::Itertools;
 use log::debug;
 
 use crate::{
-    interface::{mapping::path::MappingPath, InterfaceError, Mapping},
-    payload,
-    types::AstarteType,
-    Aggregation, Error, Interface,
+    interface::{mapping::path::MappingPath, DatastreamObject, InterfaceError, Mapping},
+    Error, Interface,
 };
 
 /// Struct to hold a reference to an interface, which is a property.
@@ -39,7 +37,7 @@ use crate::{
 /// This type can be use to guaranty that the interface is a property when accessed from the
 /// [`Interfaces`] struct with the [get_property](`Interfaces::get_property`) method.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct PropertyRef<'a>(&'a Interface);
+pub(crate) struct PropertyRef<'a>(pub(crate) &'a Interface);
 
 impl<'a> Borrow<Interface> for PropertyRef<'a> {
     fn borrow(&self) -> &Interface {
@@ -55,41 +53,92 @@ impl<'a> Deref for PropertyRef<'a> {
     }
 }
 
+/// Reference to an [`Interface`] and a [`DatastreamObject`] that is guaranty to belong to the interface.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ObjectRef<'a> {
+    pub(crate) interface: &'a Interface,
+    pub(crate) object: &'a DatastreamObject,
+}
+
+impl<'a> ObjectRef<'a> {
+    /// Create a new reference only if the interface is an object.
+    pub(crate) fn new(interface: &'a Interface) -> Option<Self> {
+        match &interface.inner {
+            crate::interface::InterfaceType::DatastreamIndividual(_)
+            | crate::interface::InterfaceType::Properties(_) => None,
+            crate::interface::InterfaceType::DatastreamObject(object) => {
+                Some(Self { interface, object })
+            }
+        }
+    }
+}
+
+impl<'a> Deref for ObjectRef<'a> {
+    type Target = DatastreamObject;
+
+    fn deref(&self) -> &Self::Target {
+        self.object
+    }
+}
+
+/// Reference to an [`Interface`] and a [`Mapping`] that is guaranty to belong to the interface.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MappingRef<'m, I> {
+    interface: I,
+    mapping: Mapping<'m>,
+}
+
+impl<'a> MappingRef<'a, &'a Interface> {
+    pub(crate) fn new(interface: &'a Interface, path: &MappingPath) -> Option<Self> {
+        interface
+            .mapping(path)
+            .map(|mapping| Self { interface, mapping })
+    }
+
+    pub(crate) fn as_prop(&self) -> Option<MappingRef<'a, PropertyRef<'a>>> {
+        self.interface().as_prop_ref().map(|interface| MappingRef {
+            interface,
+            mapping: self.mapping,
+        })
+    }
+}
+
+impl<'a> MappingRef<'a, PropertyRef<'a>> {
+    pub(crate) fn with_prop(interface: PropertyRef<'a>, path: &MappingPath) -> Option<Self> {
+        let mapping = interface.0.mapping(path)?;
+
+        Some(Self { interface, mapping })
+    }
+}
+
+impl<'a, I> MappingRef<'a, I> {
+    #[inline]
+    pub(crate) fn mapping(&self) -> &Mapping {
+        &self.mapping
+    }
+
+    #[inline]
+    pub(crate) fn interface(&self) -> &I {
+        &self.interface
+    }
+}
+
+impl<'a, I> Deref for MappingRef<'a, I> {
+    type Target = Mapping<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.mapping
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Interfaces {
     interfaces: HashMap<String, Interface>,
 }
 
-/// Validates that a float is a valid Astarte float
-fn validate_float(d: &f64) -> Result<(), Error> {
-    if d.is_infinite() || d.is_nan() || d.is_subnormal() {
-        Err(Error::SendError(
-            "You are sending the wrong type for this mapping".into(),
-        ))
-    } else {
-        Ok(())
-    }
-}
-
 impl Interfaces {
     pub(crate) fn new() -> Self {
         Self::default()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn from<I>(interfaces: I) -> Result<Self, InterfaceError>
-    where
-        I: IntoIterator<Item = Interface>,
-    {
-        let mut ints = Self {
-            interfaces: HashMap::new(),
-        };
-
-        for interface in interfaces {
-            ints.add(interface)?;
-        }
-
-        Ok(ints)
     }
 
     /// Inserts an interface and returns the previous one if present.
@@ -154,194 +203,59 @@ impl Interfaces {
     }
 
     pub(crate) fn get_property(&self, interface_name: &str) -> Option<PropertyRef> {
-        self.interfaces.get(interface_name).and_then(|interface| {
-            if !interface.is_property() {
-                None
-            } else {
-                Some(PropertyRef(interface))
-            }
-        })
-    }
-
-    /// Gets mapping from the json description, given the path
-    pub(crate) fn get_mapping<'a: 's, 's>(
-        &'s self,
-        interface_name: &str,
-        interface_path: &MappingPath<'a>,
-    ) -> Option<Mapping> {
         self.interfaces
             .get(interface_name)
-            .and_then(|interface| interface.mapping(interface_path))
+            .and_then(|interface| interface.is_property().then_some(PropertyRef(interface)))
     }
 
-    pub(crate) fn get_mqtt_reliability(
+    /// Gets an interface and mapping given the name and path.
+    ///
+    /// # Errors
+    ///
+    /// Will return error if either the interface or the mapping is missing.
+    pub(crate) fn interface_mapping(
         &self,
         interface_name: &str,
         interface_path: &MappingPath,
-    ) -> rumqttc::QoS {
-        self.get_mapping(interface_name, interface_path)
-            .map(|mapping| mapping.reliability())
-            .unwrap_or_default()
-            .into()
-    }
-
-    /// returns major version if the property exists, None otherwise
-    pub fn get_property_major(&self, interface: &str, path: &MappingPath) -> Option<i32> {
-        let interface = self.get(interface)?;
-
-        if !interface.contains(path) || !interface.is_property() {
-            return None;
-        }
-
-        Some(interface.version_major())
-    }
-
-    pub(crate) fn validate_float(data: &AstarteType) -> Result<(), Error> {
-        match data {
-            AstarteType::Double(d) => validate_float(d),
-            AstarteType::DoubleArray(d) => d.iter().try_for_each(validate_float),
-            _ => Ok(()),
-        }
-    }
-
-    pub(crate) fn validate_send(
-        &self,
-        interface_name: &str,
-        interface_path: &MappingPath<'_>,
-        data: &[u8],
-        timestamp: &Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<(), Error> {
-        let data_deserialized = payload::deserialize(data)?;
-
-        let interface = self
-            .interfaces
+    ) -> Result<MappingRef<&Interface>, Error> {
+        self.interfaces
             .get(interface_name)
-            .ok_or_else(|| Error::SendError("Interface does not exists".into()))?;
-
-        match data_deserialized {
-            Aggregation::Individual(individual) => {
-                let mapping = interface
-                    .mapping(interface_path)
-                    .ok_or_else(|| Error::SendError("Mapping doesn't exist".into()))?;
-
-                if individual != AstarteType::Unset && individual != mapping.mapping_type() {
-                    return Err(Error::SendError(format!(
-                        "You are sending the wrong type for this mapping: got {:?}, expected {:?}",
-                        individual,
-                        mapping.mapping_type()
-                    )));
-                }
-
-                Interfaces::validate_float(&individual)?;
-
-                if !mapping.explicit_timestamp() && timestamp.is_some() {
-                    return Err(Error::SendError(
-                        "Do not send timestamp to a mapping without explicit timestamp".into(),
-                    ));
-                }
-
-                if !mapping.allow_unset() && data.is_empty() {
-                    return Err(Error::SendError(
-                        "Do not unset a mapping without allow_unset".into(),
-                    ));
-                }
-            }
-            Aggregation::Object(object) => {
-                for (obj_key, obj_value) in &object {
-                    Interfaces::validate_float(obj_value)?;
-                    let object_path = format!("{}/{}", interface_path, obj_key);
-
-                    let mapping_path = MappingPath::try_from(object_path.as_str())?;
-
-                    let mapping = interface.mapping(&mapping_path).ok_or_else(|| {
-                        Error::SendError(format!("Mapping '{mapping_path}' doesn't exist"))
-                    })?;
-
-                    if *obj_value != mapping.mapping_type() {
-                        return Err(Error::SendError(
-                            format!("You are sending the wrong type for this object mapping: got {:?}, expected {}", obj_value, mapping.mapping_type()),
-                        ));
-                    }
-
-                    if !mapping.explicit_timestamp() && timestamp.is_some() {
-                        return Err(Error::SendError(
-                            "Do not send timestamp to a mapping without explicit timestamp".into(),
-                        ));
-                    }
-                }
-
-                if object.len() < interface.mappings_len() {
-                    return Err(Error::SendError(
-                        "You are missing some mappings from the object".into(),
-                    ));
-                }
-            }
-        }
-
-        Ok(())
+            .ok_or_else(|| Error::MissingInterface(interface_name.to_string()))
+            .and_then(|interface| {
+                MappingRef::new(interface, interface_path).ok_or_else(|| Error::MissingMapping {
+                    interface: interface_name.to_string(),
+                    mapping: interface_path.to_string(),
+                })
+            })
     }
 
-    pub(crate) fn validate_receive(
+    /// Gets a property and mapping given the name and path.
+    ///
+    /// # Errors
+    ///
+    /// Will return error if either the interface or the mapping is missing.
+    pub(crate) fn property_mapping(
         &self,
         interface_name: &str,
-        path: &MappingPath,
-        bdata: &[u8],
-    ) -> Result<(), Error> {
-        if interface_name == "control" {
-            return Ok(());
-        }
-
-        let interface = self.interfaces.get(interface_name).ok_or_else(|| {
-            Error::ReceiveError(format!("Interface '{interface_name}' does not exists"))
-        })?;
-
-        let data = payload::deserialize(bdata)?;
-
-        match data {
-            Aggregation::Individual(individual) => {
-                let mapping = interface.mapping(path).ok_or_else(|| {
-                    Error::ReceiveError(format!("Mapping '{path}' doesn't exist",))
-                })?;
-
-                if individual == AstarteType::Unset {
-                    if !mapping.allow_unset() {
-                        return Err(Error::ReceiveError(
-                            "Do not unset a mapping without allow_unset".into(),
-                        ));
-                    } else {
-                        return Ok(());
+        interface_path: &MappingPath,
+    ) -> Result<MappingRef<PropertyRef>, Error> {
+        self.interfaces
+            .get(interface_name)
+            .ok_or_else(|| Error::MissingInterface(interface_name.to_string()))
+            .and_then(|interface| {
+                interface.as_prop_ref().ok_or_else(|| Error::InterfaceType {
+                    exp: crate::interface::InterfaceTypeDef::Properties,
+                    got: interface.interface_type(),
+                })
+            })
+            .and_then(|interface| {
+                MappingRef::with_prop(interface, interface_path).ok_or_else(|| {
+                    Error::MissingMapping {
+                        interface: interface_name.to_string(),
+                        mapping: interface_path.to_string(),
                     }
-                }
-
-                if individual != mapping.mapping_type() {
-                    return Err(Error::ReceiveError(
-                        "You are receiving the wrong type for this mapping".into(),
-                    ));
-                }
-
-                Interfaces::validate_float(&individual)?;
-            }
-            Aggregation::Object(object) => {
-                for (name, value) in &object {
-                    Interfaces::validate_float(value)?;
-
-                    let mapping_path = format!("{}/{}", path, name);
-                    let mapping = interface
-                        .mapping(&mapping_path.as_str().try_into()?)
-                        .ok_or_else(|| {
-                            Error::ReceiveError(format!("Mapping '{mapping_path}' doesn't exist",))
-                        })?;
-
-                    if *value != mapping.mapping_type() {
-                        return Err(Error::ReceiveError(
-                            "You are receiving the wrong type for this object mapping".into(),
-                        ));
-                    }
-                }
-            }
-        }
-
-        Ok(())
+                })
+            })
     }
 
     pub(crate) fn iter_interfaces(&self) -> impl Iterator<Item = &Interface> {
@@ -349,19 +263,26 @@ impl Interfaces {
     }
 }
 
+impl FromIterator<(String, Interface)> for Interfaces {
+    fn from_iter<T: IntoIterator<Item = (String, Interface)>>(iter: T) -> Self {
+        Self {
+            interfaces: iter.into_iter().collect(),
+        }
+    }
+}
+
 #[cfg(test)]
-mod test {
-    use chrono::{TimeZone, Utc};
-    use std::{collections::HashMap, str::FromStr};
+pub(crate) mod tests {
+    use std::str::FromStr;
 
     use crate::{
-        interfaces::Interfaces, mapping, options::AstarteOptions, payload, types::AstarteType,
-        Interface,
+        error::Error, interface::MappingType, interfaces::Interfaces, mapping,
+        options::AstarteOptions, Interface,
     };
 
-    #[test]
-    fn test_get_property() {
-        let interface_json = r#"
+    pub(crate) const PROPERTIES_SERVER: (&str, &str) = (
+        "org.astarte-platform.test.test",
+        r#"
         {
             "interface_name": "org.astarte-platform.test.test",
             "version_major": 12,
@@ -371,404 +292,27 @@ mod test {
             "mappings": [
                 {
                     "endpoint": "/button",
-                    "type": "boolean",
-                    "explicit_timestamp": true
+                    "type": "boolean"
                 },
                 {
                     "endpoint": "/uptimeSeconds",
-                    "type": "integer",
-                    "explicit_timestamp": true
-                }
-            ]
-        }
-        "#;
-        let deser_interface = Interface::from_str(interface_json).unwrap();
-        let mut ifa = Interfaces::default();
-        ifa.add(deser_interface).expect("valid interface");
-
-        assert!(
-            ifa.get_property_major("org.astarte-platform.test.test", mapping!("/button"))
-                .unwrap()
-                == 12
-        );
-        assert!(
-            ifa.get_property_major("org.astarte-platform.test.test", mapping!("/uptimeSeconds"))
-                .unwrap()
-                == 12
-        );
-        assert!(ifa
-            .get_property_major("org.astarte-platform.test.test", mapping!("/button/foo"))
-            .is_none());
-        assert!(ifa
-            .get_property_major("org.astarte-platform.test.test", mapping!("/buttonfoo"))
-            .is_none());
-        assert!(ifa
-            .get_property_major("org.astarte-platform.test.test", mapping!("/foo/button"))
-            .is_none());
-        assert!(ifa
-            .get_property_major("org.astarte-platform.test.test", mapping!("/obj"))
-            .is_none());
-
-        let interface_json = r#"{
-            "interface_name": "org.astarte-platform.genericsensors.SamplingRate",
-            "version_major": 12,
-            "version_minor": 0,
-            "type": "properties",
-            "ownership": "server",
-            "description": "Configure sensors sampling rate and enable/disable.",
-            "doc": "",
-            "mappings": [
+                    "type": "integer"
+                },
                 {
                     "endpoint": "/%{sensor_id}/enable",
                     "type": "boolean",
-                    "allow_unset": true,
-                    "description": "Enable/disable sensor data transmission.",
-                    "doc": ""
+                    "allow_unset": true
                 },
                 {
                     "endpoint": "/%{sensor_id}/samplingPeriod",
                     "type": "integer",
-                    "allow_unset": true,
-                    "description": "Sensor sample transmission period.",
-                    "doc": ""
+                    "allow_unset": true
                 }
             ]
-        }"#;
+        }"#,
+    );
 
-        let deser_interface = Interface::from_str(interface_json).unwrap();
-        let mut ifa = Interfaces::default();
-        ifa.add(deser_interface).expect("valid interface");
-
-        assert_eq!(
-            ifa.get_property_major(
-                "org.astarte-platform.genericsensors.SamplingRate",
-                mapping!("/1/enable")
-            )
-            .unwrap(),
-            12
-        );
-        assert_eq!(
-            ifa.get_property_major(
-                "org.astarte-platform.genericsensors.SamplingRate",
-                mapping!("/999999/enable")
-            )
-            .unwrap(),
-            12
-        );
-        assert_eq!(
-            ifa.get_property_major(
-                "org.astarte-platform.genericsensors.SamplingRate",
-                mapping!("/foobar/enable")
-            )
-            .unwrap(),
-            12
-        );
-        assert!(ifa
-            .get_property_major(
-                "org.astarte-platform.genericsensors.SamplingRate",
-                mapping!("/foo/bar/enable")
-            )
-            .is_none());
-        assert!(ifa
-            .get_property_major(
-                "org.astarte-platform.genericsensors.SamplingRate",
-                mapping!("/obj")
-            )
-            .is_none());
-    }
-
-    #[test]
-    fn test_validate_float() {
-        Interfaces::validate_float(&AstarteType::Double(f64::NAN)).unwrap_err();
-        Interfaces::validate_float(&AstarteType::DoubleArray(vec![1.0, 2.0, f64::NAN, 4.0]))
-            .unwrap_err();
-        Interfaces::validate_float(&AstarteType::Double(54.4)).unwrap();
-        Interfaces::validate_float(&AstarteType::Integer(12)).unwrap();
-    }
-
-    #[test]
-    fn test_validate_send_for_aggregate_datastream() {
-        let (_, interface_name, _, _, _, interfaces) = helper_prepare_interfaces();
-
-        let mut aggregate: HashMap<String, AstarteType> = HashMap::new();
-        aggregate.insert(
-            "double_endpoint".to_string(),
-            AstarteType::Double(37.534543),
-        );
-        aggregate.insert("integer_endpoint".to_string(), AstarteType::Integer(45));
-        aggregate.insert("boolean_endpoint".to_string(), AstarteType::Boolean(true));
-        aggregate.insert(
-            "booleanarray_endpoint".to_string(),
-            AstarteType::BooleanArray(vec![true, false, true]),
-        );
-
-        // Test non existant interface
-        interfaces
-            .validate_send("gibberish", mapping!("/1"), &Vec::new(), &None)
-            .unwrap_err();
-
-        // Test non existant endpoint
-        let aggregate_data = payload::serialize_object(&aggregate, None).unwrap();
-        interfaces
-            .validate_send(&interface_name, mapping!("/1/25"), &aggregate_data, &None)
-            .unwrap_err();
-
-        // Test sending an aggregate (with and without timestamp)
-        let timestamp = Some(TimeZone::timestamp_opt(&Utc, 1537449422, 0).unwrap());
-        interfaces
-            .validate_send(&interface_name, mapping!("/1"), &aggregate_data, &None)
-            .unwrap();
-        interfaces
-            .validate_send(&interface_name, mapping!("/1"), &aggregate_data, &timestamp)
-            .unwrap();
-
-        // Test sending an aggregate with an object field with incorrect type
-        aggregate.insert("integer_endpoint".to_string(), AstarteType::Boolean(false));
-        let aggregate_data = payload::serialize_object(&aggregate, None).unwrap();
-        interfaces
-            .validate_send(&interface_name, mapping!("/1"), &aggregate_data, &None)
-            .unwrap_err();
-        aggregate.insert("integer_endpoint".to_string(), AstarteType::Integer(45));
-
-        // Test sending an aggregate with an non existing object field
-        aggregate.insert("gibberish".to_string(), AstarteType::Boolean(false));
-        let aggregate_data = payload::serialize_object(&aggregate, None).unwrap();
-        interfaces
-            .validate_send(&interface_name, mapping!("/1"), &aggregate_data, &None)
-            .unwrap_err();
-        aggregate.remove("gibberish");
-
-        // Test sending an aggregate with a missing object field
-        aggregate.remove("integer_endpoint");
-        let aggregate_data = payload::serialize_object(&aggregate, None).unwrap();
-        interfaces
-            .validate_send(&interface_name, mapping!("/1"), &aggregate_data, &None)
-            .unwrap_err();
-    }
-
-    #[test]
-    fn test_validate_send_for_individual_datastream() {
-        let (interface_name, _, _, _, _, interfaces) = helper_prepare_interfaces();
-
-        // Test non existant interface
-        interfaces
-            .validate_send("gibberish", mapping!("/boolean"), &Vec::new(), &None)
-            .unwrap_err();
-
-        // Test sending a value on an unexisting endpoint
-        interfaces
-            .validate_send(&interface_name, mapping!("/gibberish"), &Vec::new(), &None)
-            .unwrap_err();
-
-        // Test sending a value (with and without timestamp)
-        let boolean_endpoint_data =
-            payload::serialize_individual(&AstarteType::Boolean(true), None).unwrap();
-        interfaces
-            .validate_send(
-                &interface_name,
-                mapping!("/boolean"),
-                &boolean_endpoint_data,
-                &None,
-            )
-            .unwrap();
-        let double_endpoint_data =
-            payload::serialize_individual(&AstarteType::Double(23.2), None).unwrap();
-        let timestamp = Some(TimeZone::timestamp_opt(&Utc, 1537449422, 0).unwrap());
-        interfaces
-            .validate_send(
-                &interface_name,
-                mapping!("/double"),
-                &double_endpoint_data,
-                &timestamp,
-            )
-            .unwrap();
-
-        // Test sending a value of the wrong type
-        interfaces
-            .validate_send(
-                &interface_name,
-                mapping!("/double"),
-                &boolean_endpoint_data,
-                &None,
-            )
-            .unwrap_err();
-        interfaces
-            .validate_send(
-                &interface_name,
-                mapping!("/booleanarray"),
-                &boolean_endpoint_data,
-                &None,
-            )
-            .unwrap_err();
-    }
-
-    #[test]
-    fn test_validate_receive_for_individual_datastream() {
-        let (_, _, _, _, interface_name, interfaces) = helper_prepare_interfaces();
-
-        // Test non existant interface
-        interfaces
-            .validate_receive("gibberish", mapping!("/boolean_endpoint"), &Vec::new())
-            .unwrap_err();
-
-        // Test non existant path
-        interfaces
-            .validate_receive(&interface_name, mapping!("/gibberish"), &Vec::new())
-            .unwrap_err();
-
-        // Test receiving a new value
-        let boolean_endpoint_data =
-            payload::serialize_individual(&AstarteType::Boolean(true), None).unwrap();
-        interfaces
-            .validate_receive(
-                &interface_name,
-                mapping!("/boolean_endpoint"),
-                &boolean_endpoint_data,
-            )
-            .unwrap();
-
-        // Test receiving a new value with the wrong type
-        let integer_endpoint_data =
-            payload::serialize_individual(&AstarteType::Integer(23), None).unwrap();
-        interfaces
-            .validate_receive(
-                &interface_name,
-                mapping!("/boolean_endpoint"),
-                &integer_endpoint_data,
-            )
-            .unwrap_err();
-    }
-
-    #[test]
-    fn test_validate_receive_for_aggregate_datastream() {
-        let (_, _, _, interface_name, _, interfaces) = helper_prepare_interfaces();
-
-        // Test non existant interface
-        interfaces
-            .validate_receive("gibberish", mapping!("/boolean_endpoint"), &Vec::new())
-            .unwrap_err();
-
-        // Test non existant path
-        interfaces
-            .validate_receive(&interface_name, mapping!("/gibberish"), &Vec::new())
-            .unwrap_err();
-
-        // Test non existant path for aggregate
-        interfaces
-            .validate_receive(&interface_name, mapping!("/gibberish"), &Vec::new())
-            .unwrap_err();
-
-        // Test receiving an aggregate
-        let aggr_data: HashMap<String, AstarteType> = HashMap::from([
-            ("boolean_endpoint".to_string(), AstarteType::Boolean(false)),
-            ("integer_endpoint".to_string(), AstarteType::Integer(324)),
-        ]);
-        let aggr_data = payload::serialize_object(&aggr_data, None).unwrap();
-        interfaces
-            .validate_receive(&interface_name, mapping!("/obj"), &aggr_data)
-            .unwrap();
-
-        // Test receiving an aggregate with wrong type
-        let aggr_data: HashMap<String, AstarteType> = HashMap::from([
-            ("boolean_endpoint".to_string(), AstarteType::Boolean(false)),
-            ("integer_endpoint".to_string(), AstarteType::Boolean(false)),
-        ]);
-        let aggr_data = payload::serialize_object(&aggr_data, None).unwrap();
-        interfaces
-            .validate_receive(&interface_name, mapping!("/foo"), &aggr_data)
-            .unwrap_err();
-    }
-
-    #[test]
-    fn test_validate_receive_for_individual_property() {
-        let (_, _, interface_name, _, _, interfaces) = helper_prepare_interfaces();
-
-        // Test non existant interface
-        interfaces
-            .validate_receive("gibberish", mapping!("/boolean_endpoint"), &[])
-            .unwrap_err();
-
-        // Test non existant path
-        interfaces
-            .validate_receive(&interface_name, mapping!("/gibberish"), &[])
-            .unwrap_err();
-
-        // Test receiving a set property
-        let boolean_endpoint_data =
-            payload::serialize_individual(&AstarteType::Boolean(true), None).unwrap();
-        interfaces
-            .validate_receive(
-                &interface_name,
-                mapping!("/boolean_endpoint"),
-                &boolean_endpoint_data,
-            )
-            .unwrap();
-
-        // Test receiving an unset property
-        interfaces
-            .validate_receive(&interface_name, mapping!("/boolean_endpoint"), &[])
-            .unwrap();
-
-        // Test receiving an unset property for a property that can't be unset
-        interfaces
-            .validate_receive(&interface_name, mapping!("/integer_endpoint"), &[])
-            .unwrap_err();
-
-        // Test receiving a set property with the wrong type
-        let integer_endpoint_data =
-            payload::serialize_individual(&AstarteType::Integer(23), None).unwrap();
-        interfaces
-            .validate_receive(
-                &interface_name,
-                mapping!("/boolean_endpoint"),
-                &integer_endpoint_data,
-            )
-            .unwrap_err();
-
-        // Test receiving an aggregate on an property interface
-        let aggr_data: HashMap<String, AstarteType> = HashMap::from([
-            ("boolean_endpoint".to_string(), AstarteType::Boolean(false)),
-            ("integer_endpoint".to_string(), AstarteType::Integer(324)),
-        ]);
-        let aggr_data = payload::serialize_object(&aggr_data, None).unwrap();
-        interfaces
-            .validate_receive(&interface_name, mapping!("/obj"), &aggr_data)
-            .unwrap_err();
-    }
-
-    fn helper_prepare_interfaces() -> (String, String, String, String, String, Interfaces) {
-        let device_datastream_interface_json = r#"
-        {
-            "interface_name": "test.device.datastream",
-            "version_major": 0,
-            "version_minor": 1,
-            "type": "datastream",
-            "ownership": "device",
-            "mappings": [
-                {
-                    "endpoint": "/boolean",
-                    "type": "boolean",
-                    "explicit_timestamp": true
-                },
-                {
-                    "endpoint": "/booleanarray",
-                    "type": "booleanarray",
-                    "explicit_timestamp": true
-                },
-                {
-                    "endpoint": "/double",
-                    "type": "double",
-                    "explicit_timestamp": true
-                }
-            ]
-        }
-        "#;
-        let device_datastream_interface =
-            Interface::from_str(device_datastream_interface_json).unwrap();
-        let device_datastream_interface_name =
-            device_datastream_interface.interface_name().to_string();
-
-        let device_aggregate_interface_json = r#"
+    pub(crate) const DEVICE_OBJECT: &str = r#"
         {
             "interface_name": "test.device.object",
             "version_major": 0,
@@ -800,108 +344,112 @@ mod test {
             ]
         }
         "#;
-        let device_aggregate_interface =
-            Interface::from_str(device_aggregate_interface_json).unwrap();
-        let device_aggregate_interface_name =
-            device_aggregate_interface.interface_name().to_string();
 
-        let server_property_interface_json = r#"
-        {
-            "interface_name": "test.server.property",
-            "version_major": 0,
-            "version_minor": 1,
-            "type": "properties",
-            "ownership": "server",
-            "mappings": [
-                {
-                    "endpoint": "/boolean_endpoint",
-                    "type": "boolean",
-                    "allow_unset": true,
-                    "explicit_timestamp": true
-                },
-                {
-                    "endpoint": "/integer_endpoint",
-                    "type": "integer",
-                    "allow_unset": false,
-                    "explicit_timestamp": true
-                }
-            ]
-        }
-        "#;
-        let server_property_interface =
-            Interface::from_str(server_property_interface_json).unwrap();
-        let server_property_interface_name = server_property_interface.interface_name().to_string();
-
-        let server_aggregate_interface_json = r#"
-        {
-            "interface_name": "test.server.object",
-            "version_major": 0,
-            "version_minor": 1,
-            "type": "datastream",
-            "ownership": "server",
-            "aggregation": "object",
-            "mappings": [
-                {
-                    "endpoint": "/obj/boolean_endpoint",
-                    "type": "boolean",
-                    "explicit_timestamp": true
-                },
-                {
-                    "endpoint": "/obj/integer_endpoint",
-                    "type": "integer",
-                    "explicit_timestamp": true
-                }
-            ]
-        }
-        "#;
-        let server_aggregate_interface =
-            Interface::from_str(server_aggregate_interface_json).unwrap();
-        let server_aggregate_interface_name =
-            server_aggregate_interface.interface_name().to_string();
-
-        let server_datastream_interface_json = r#"
-        {
-            "interface_name": "test.server.datastream",
-            "version_major": 0,
-            "version_minor": 1,
-            "type": "datastream",
-            "ownership": "server",
-            "mappings": [
-                {
-                    "endpoint": "/boolean_endpoint",
-                    "type": "boolean",
-                    "explicit_timestamp": true
-                },
-                {
-                    "endpoint": "/double_endpoint",
-                    "type": "double",
-                    "explicit_timestamp": true
-                }
-            ]
-        }
-        "#;
-        let server_datastream_interface =
-            Interface::from_str(server_datastream_interface_json).unwrap();
-        let server_datastream_interface_name =
-            server_datastream_interface.interface_name().to_string();
-
-        let interfaces = Interfaces::from([
-            device_datastream_interface,
-            device_aggregate_interface,
-            server_property_interface,
-            server_aggregate_interface,
-            server_datastream_interface,
-        ])
-        .expect("valid interfaces");
-
-        (
-            device_datastream_interface_name,
-            device_aggregate_interface_name,
-            server_property_interface_name,
-            server_aggregate_interface_name,
-            server_datastream_interface_name,
-            interfaces,
+    pub(crate) fn create_interfaces(interfaces: &[(&str, &str)]) -> Interfaces {
+        Interfaces::from_iter(
+            interfaces
+                .iter()
+                .map(|(n, i)| (n.to_string(), Interface::from_str(i).unwrap())),
         )
+    }
+
+    pub(crate) struct CheckEndpoint<'a> {
+        interfaces: &'a Interfaces,
+        name: &'a str,
+        path: &'a str,
+        version_major: i32,
+        mapping_type: MappingType,
+        endpoint: &'a str,
+        explicit_timestamp: bool,
+        allow_unset: bool,
+    }
+
+    impl<'a> CheckEndpoint<'a> {
+        pub(crate) fn check(&self) {
+            let path = mapping!(self.path);
+            let mapping = self.interfaces.interface_mapping(self.name, path).unwrap();
+            assert_eq!(mapping.interface().interface_name(), self.name);
+            assert_eq!(mapping.interface().version_major(), self.version_major);
+            assert_eq!(mapping.mapping_type(), self.mapping_type);
+            assert_eq!(mapping.endpoint(), self.endpoint);
+            assert_eq!(mapping.explicit_timestamp(), self.explicit_timestamp);
+            assert_eq!(mapping.allow_unset(), self.allow_unset);
+        }
+    }
+
+    #[test]
+    fn test_get_property_simple() {
+        let ifa = create_interfaces(&[PROPERTIES_SERVER]);
+
+        CheckEndpoint {
+            interfaces: &ifa,
+            name: "org.astarte-platform.test.test",
+            path: "/button",
+            version_major: 12,
+            mapping_type: MappingType::Boolean,
+            endpoint: "/button",
+            explicit_timestamp: false,
+            allow_unset: false,
+        }
+        .check();
+
+        CheckEndpoint {
+            interfaces: &ifa,
+            name: "org.astarte-platform.test.test",
+            path: "/uptimeSeconds",
+            version_major: 12,
+            mapping_type: MappingType::Integer,
+            endpoint: "/uptimeSeconds",
+            explicit_timestamp: false,
+            allow_unset: false,
+        }
+        .check();
+
+        assert!(matches!(
+            ifa.interface_mapping("org.astarte-platform.test.test", mapping!("/button/foo")),
+            Err(Error::MissingMapping { .. })
+        ));
+        assert!(matches!(
+            ifa.interface_mapping("org.astarte-platform.test.test", mapping!("/foo/button")),
+            Err(Error::MissingMapping { .. })
+        ));
+        assert!(matches!(
+            ifa.interface_mapping("org.astarte-platform.test.test", mapping!("/obj")),
+            Err(Error::MissingMapping { .. })
+        ));
+    }
+
+    #[test]
+    fn test_get_property_endpoint() {
+        let ifa = create_interfaces(&[PROPERTIES_SERVER]);
+
+        let parameters = ["1", "999999", "foobar"];
+
+        for parameter in parameters {
+            CheckEndpoint {
+                interfaces: &ifa,
+                name: "org.astarte-platform.test.test",
+                path: &format!("/{parameter}/enable"),
+                version_major: 12,
+                mapping_type: MappingType::Boolean,
+                endpoint: "/%{sensor_id}/enable",
+                explicit_timestamp: false,
+                allow_unset: true,
+            }
+            .check();
+        }
+
+        assert!(matches!(
+            ifa.interface_mapping(
+                "org.astarte-platform.test.test",
+                mapping!("/foo/bar/enable")
+            ),
+            Err(Error::MissingMapping { .. })
+        ));
+        assert!(matches!(
+            ifa.interface_mapping("org.astarte-platform.test.test", mapping!("/obj")),
+            Err(Error::MissingMapping { .. })
+        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -758,6 +758,8 @@ where
             return Err(Error::Validation(err));
         }
 
+        trace!("sending individual type {}", data.display_type());
+
         let opt_prop = mapping.as_prop();
         if let Some(prop_mapping) = opt_prop {
             let stored = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,9 @@ pub mod registration;
 pub mod store;
 mod topic;
 pub mod types;
+mod validate;
 
+use chrono::{DateTime, Utc};
 #[cfg(test)]
 use mock::{MockAsyncClient as AsyncClient, MockEventLoop as EventLoop};
 #[cfg(not(test))]
@@ -58,15 +60,20 @@ pub use crate::interface::Interface;
 
 use crate::error::Error;
 use crate::interface::mapping::path::MappingPath;
-use crate::interface::{InterfaceError, Ownership};
+use crate::interface::{Aggregation as InterfaceAggregation, InterfaceError, Ownership};
+use crate::interfaces::MappingRef;
 use crate::interfaces::PropertyRef;
 use crate::options::AstarteOptions;
+use crate::payload::{
+    deserialize_individual, deserialize_object, serialize_individual, serialize_object, Payload,
+};
 use crate::store::memory::MemoryStore;
 use crate::store::sqlite::SqliteStore;
 use crate::store::wrapper::StoreWrapper;
 use crate::store::{PropertyStore, StoredProp};
 use crate::topic::parse_topic;
 use crate::types::{AstarteType, TypeError};
+use crate::validate::{validate_send_individual, validate_send_object};
 
 /// A **trait** required by all data to be sent using
 /// [send_object()][crate::AstarteDeviceSdk::send_object] and
@@ -381,28 +388,19 @@ where
                             let (_, _, interface, path) = parse_topic(&publish.topic)?;
 
                             // It can be borrowed as a &[u8]
-                            let bdata = publish.payload;
+                            let payload = publish.payload;
 
                             if interface == "control" && path == "/consumer/properties" {
                                 debug!("Purging properties");
 
-                                self.purge_properties(&bdata).await?;
+                                self.purge_properties(&payload).await?;
 
                                 continue;
                             }
 
-                            debug!("Incoming publish = {} {:?}", publish.topic, bdata);
+                            debug!("Incoming publish = {} {:?}", publish.topic, payload);
 
-                            let data = payload::deserialize(&bdata)?;
-
-                            self.handle_payload(interface, &path, &data).await?;
-
-                            if cfg!(debug_assertions) {
-                                self.interfaces
-                                    .read()
-                                    .await
-                                    .validate_receive(interface, &path, &bdata)?;
-                            }
+                            let data = self.handle_payload(interface, &path, &payload).await?;
 
                             return Ok(AstarteDeviceDataEvent {
                                 interface: interface.to_string(),
@@ -423,45 +421,74 @@ where
         &self,
         interface: &str,
         path: &MappingPath<'a>,
-        payload: &Aggregation,
-    ) -> Result<(), Error> {
-        match payload {
-            Aggregation::Object(_) => Ok(()),
-            Aggregation::Individual(ref data) => {
-                let r_interfaces = self.interfaces.read().await;
-                let interface = r_interfaces
-                    .get_property(interface)
-                    .filter(|interface| interface.mapping(path).is_some());
+        payload: &[u8],
+    ) -> Result<Aggregation, Error> {
+        let interfaces = self.interfaces.read().await;
+        let interface = interfaces.get(interface).ok_or_else(|| {
+            warn!("publish on missing interface {interface} ({path})");
+            Error::MissingInterface(interface.to_string())
+        })?;
 
-                if let Some(property) = interface {
-                    self.store_property(property, path, data).await?;
-                }
-
-                Ok(())
+        let (data, timestamp) = match interface.aggregation() {
+            InterfaceAggregation::Individual => {
+                self.handle_payload_individual(interface, path, payload)
+                    .await?
             }
-        }
+            InterfaceAggregation::Object => {
+                self.handle_payload_object(interface, path, payload).await?
+            }
+        };
+
+        debug!("received {{v: {data:?}, t: {timestamp:?}}}");
+
+        Ok(data)
     }
 
-    /// Store the property.
-    async fn store_property<'a>(
+    /// Handles the payload of an interface with [`InterfaceAggregation::Individual`]
+    async fn handle_payload_individual<'a>(
         &self,
-        interface: PropertyRef<'a>,
+        interface: &Interface,
         path: &MappingPath<'a>,
-        data: &AstarteType,
-    ) -> Result<(), Error> {
-        debug_assert!(interface.is_property());
-        debug_assert!(interface.mapping(path).is_some());
+        payload: &[u8],
+    ) -> Result<(Aggregation, Option<chrono::DateTime<chrono::Utc>>), Error> {
+        let mapping = interface
+            .as_mapping_ref(path)
+            .ok_or_else(|| Error::MissingMapping {
+                interface: interface.interface_name().to_string(),
+                mapping: path.to_string(),
+            })?;
 
-        let interface_name = interface.interface_name();
-        let version_major = interface.version_major();
+        let (data, timestamp) = deserialize_individual(mapping, payload)?;
 
-        self.store
-            .store_prop(interface_name, path.as_str(), data, version_major)
-            .await?;
+        if interface.is_property() {
+            let interface_name = interface.interface_name();
+            let version_major = interface.version_major();
 
-        trace!("property stored");
+            self.store
+                .store_prop(interface_name, path.as_str(), &data, version_major)
+                .await?;
 
-        Ok(())
+            info!("property stored {interface}:{version_major} {path} ");
+        }
+
+        Ok((Aggregation::Individual(data), timestamp))
+    }
+
+    /// Handles the payload of an interface with [`InterfaceAggregation::Object`]
+    async fn handle_payload_object<'a>(
+        &self,
+        interface: &Interface,
+        path: &MappingPath<'a>,
+        payload: &[u8],
+    ) -> Result<(Aggregation, Option<DateTime<Utc>>), Error> {
+        let object = interface.as_object_ref().ok_or(Error::Aggregation {
+            exp: InterfaceAggregation::Object,
+            got: InterfaceAggregation::Individual,
+        })?;
+
+        let (data, timestamp) = deserialize_object(object, path, payload)?;
+
+        Ok((Aggregation::Object(data), timestamp))
     }
 
     fn client_id(&self) -> String {
@@ -537,7 +564,7 @@ where
                 prop.interface, prop.path
             );
 
-            let payload = payload::serialize_individual(&prop.value, None)?;
+            let payload = Payload::new(&prop.value).to_vec()?;
 
             self.client
                 .publish(topic, rumqttc::QoS::ExactlyOnce, false, payload)
@@ -567,13 +594,6 @@ where
         trace!("unsetting {} {}", interface_name, interface_path);
 
         let path = MappingPath::try_from(interface_path)?;
-
-        if cfg!(debug_assertions) {
-            self.interfaces
-                .read()
-                .await
-                .validate_send(interface_name, &path, &[], &None)?;
-        }
 
         self.send_with_timestamp_impl(interface_name, &path, AstarteType::Unset, None)
             .await?;
@@ -608,33 +628,54 @@ where
         interface: &str,
         path: &str,
     ) -> Result<Option<AstarteType>, Error> {
-        let path_mappings = MappingPath::try_from(path)?;
+        let path_mapping = MappingPath::try_from(path)?;
 
-        self.property(interface, &path_mappings).await
+        let interfaces = &self.interfaces.read().await;
+        let mapping = interfaces.property_mapping(interface, &path_mapping)?;
+
+        self.property(&mapping, &path_mapping).await
     }
 
     /// Get property, when present, from the allocated storage.
     ///
     /// This will use a [`MappingPath`] to get the property, which is an parsed endpoint.
-    pub(crate) async fn property<'a>(
+    pub(crate) async fn property(
         &self,
-        interface: &str,
-        path: &MappingPath<'a>,
+        mapping: &MappingRef<'_, PropertyRef<'_>>,
+        path: &MappingPath<'_>,
     ) -> Result<Option<AstarteType>, Error> {
-        let major = self
-            .interfaces
-            .read()
-            .await
-            .get_property_major(interface, path);
+        let interface = mapping.interface().interface_name();
+        let path = path.as_str();
 
-        match major {
-            Some(major) => self
-                .store
-                .load_prop(interface, path.as_str(), major)
-                .await
-                .map_err(Error::from),
-            None => Ok(None),
-        }
+        let value = self
+            .store
+            .load_prop(interface, path, mapping.interface().version_major())
+            .await?;
+
+        let value = match value {
+            Some(AstarteType::Unset) if !mapping.allow_unset() => {
+                error!("stored property is unset, but interface doesn't allow it");
+                self.store.delete_prop(interface, path).await?;
+
+                None
+            }
+            Some(AstarteType::Unset) => Some(AstarteType::Unset),
+            Some(value) if value != mapping.mapping_type() => {
+                error!(
+                    "stored property type mismatch, expected {} got {:?}",
+                    mapping.mapping_type(),
+                    value
+                );
+                self.store.delete_prop(interface, path).await?;
+
+                None
+            }
+
+            Some(value) => Some(value),
+            None => None,
+        };
+
+        Ok(value)
     }
 
     // ------------------------------------------------------------------------
@@ -698,38 +739,29 @@ where
     async fn send_with_timestamp_impl<'a, D>(
         &self,
         interface_name: &str,
-        interface_path: &MappingPath<'a>,
+        path: &MappingPath<'a>,
         data: D,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<(), Error>
     where
         D: TryInto<AstarteType>,
     {
-        debug!("sending {} {}", interface_name, interface_path);
+        let interfaces = self.interfaces.read().await;
+        let mapping = interfaces.interface_mapping(interface_name, path)?;
+        debug!("sending {} {}", interface_name, path);
 
         let data = data.try_into().map_err(|_| TypeError::Conversion)?;
+        if let Err(err) = validate_send_individual(mapping, &timestamp) {
+            error!("send validation failed: {err}");
 
-        let buf = match data {
-            // When sending unset we should send an empty payload.
-            // https://docs.astarte-platform.org/latest/080-mqtt-v1-protocol.html#payload-format
-            AstarteType::Unset => Vec::new(),
-            _ => payload::serialize_individual(&data, timestamp)?,
-        };
-
-        if cfg!(debug_assertions) {
-            self.interfaces.read().await.validate_send(
-                interface_name,
-                interface_path,
-                &buf,
-                &timestamp,
-            )?;
+            #[cfg(debug_assertions)]
+            return Err(Error::Validation(err));
         }
 
-        let interfaces = self.interfaces.read().await;
-        let opt_property = interfaces.get_property(interface_name);
-        if let Some(property) = opt_property {
+        let opt_prop = mapping.as_prop();
+        if let Some(prop_mapping) = opt_prop {
             let stored = self
-                .check_property_already_stored(property, interface_path, &data)
+                .check_property_already_stored(&prop_mapping, path, &data)
                 .await?;
 
             if stored {
@@ -738,22 +770,24 @@ where
             }
         }
 
-        self.client
-            .publish(
-                self.client_id() + "/" + interface_name.trim_matches('/') + interface_path.as_str(),
-                self.interfaces
-                    .read()
-                    .await
-                    .get_mqtt_reliability(interface_name, interface_path),
-                false,
-                buf,
-            )
-            .await?;
+        let buf = serialize_individual(mapping, &data, timestamp)?;
 
-        // we store the property in the database after it has been successfully sent
-        if let Some(property) = opt_property {
-            self.store_property_on_send(property, interface_path, &data)
+        let qos = mapping.mapping().reliability().into();
+        let topic = self.client_id() + "/" + interface_name.trim_matches('/') + path.as_str();
+        self.client.publish(topic, qos, false, buf).await?;
+
+        //  Store the property in the database after it has been successfully sent
+        if let Some(prop_mapping) = opt_prop {
+            self.store
+                .store_prop(
+                    prop_mapping.interface().interface_name(),
+                    path.as_str(),
+                    &data,
+                    prop_mapping.interface().version_major(),
+                )
                 .await?;
+
+            info!("Stored new property in database");
         }
 
         Ok(())
@@ -761,53 +795,19 @@ where
 
     /// Check if a property is already stored in the database with the same value.
     /// Useful to prevent sending a property twice with the same value.
-    async fn check_property_already_stored<'a>(
+    async fn check_property_already_stored<'a, 'm, 'p>(
         &self,
-        interface: PropertyRef<'a>,
-        interface_path: &MappingPath<'a>,
-        data: &AstarteType,
+        mapping: &MappingRef<'m, PropertyRef<'p>>,
+        path: &MappingPath<'a>,
+        new: &AstarteType,
     ) -> Result<bool, Error> {
-        // Check the mapping exists
-        interface
-            .mapping(interface_path)
-            .ok_or_else(|| Error::SendError(format!("Mapping {interface_path} doesn't exist")))?;
-
         // Check if already in db
-        let stored = self
-            .store
-            .load_prop(interface.interface_name(), interface_path.as_str(), 0)
-            .await?;
+        let stored = self.property(mapping, path).await?;
 
         match stored {
-            Some(value) => Ok(value.eq(data)),
+            Some(value) => Ok(value.eq(new)),
             None => Ok(false),
         }
-    }
-
-    async fn store_property_on_send<'a>(
-        &self,
-        property: PropertyRef<'a>,
-        interface_path: &MappingPath<'a>,
-        data: &AstarteType,
-    ) -> Result<(), Error> {
-        property.mapping(interface_path).ok_or_else(|| {
-            Error::Interface(InterfaceError::MappingNotFound {
-                path: interface_path.to_string(),
-            })
-        })?;
-
-        self.store
-            .store_prop(
-                property.interface_name(),
-                interface_path.as_str(),
-                data,
-                property.version_major(),
-            )
-            .await?;
-
-        debug!("Stored new property in database");
-
-        Ok(())
     }
 
     async fn remove_properties_from_store(&self, interface_name: &str) -> Result<(), Error> {
@@ -835,32 +835,40 @@ where
     async fn send_object_with_timestamp_impl<'a, T>(
         &self,
         interface_name: &str,
-        interface_path: &MappingPath<'a>,
+        path: &MappingPath<'a>,
         data: T,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<(), Error>
     where
         T: AstarteAggregate,
     {
-        let aggregate = data.astarte_aggregate()?;
-        let buf = payload::serialize_object(&aggregate, timestamp)?;
+        let interfaces = self.interfaces.read().await;
+        let interface = interfaces
+            .get(interface_name)
+            .ok_or_else(|| Error::MissingInterface(interface_name.to_string()))?;
 
-        if cfg!(debug_assertions) {
-            self.interfaces.read().await.validate_send(
-                interface_name,
-                interface_path,
-                &buf,
-                &timestamp,
-            )?;
+        let object = interface
+            .as_object_ref()
+            .ok_or_else(|| Error::Aggregation {
+                exp: InterfaceAggregation::Object,
+                got: interface.aggregation(),
+            })?;
+
+        debug!("sending {} {}", interface_name, path);
+
+        let aggregate = data.astarte_aggregate()?;
+
+        if let Err(err) = validate_send_object(object, &timestamp) {
+            error!("send validation failed: {err}");
+
+            #[cfg(debug_assertions)]
+            return Err(Error::Validation(err));
         }
 
-        let topic =
-            self.client_id() + "/" + interface_name.trim_matches('/') + interface_path.as_str();
-        let qos = self
-            .interfaces
-            .read()
-            .await
-            .get_mqtt_reliability(interface_name, interface_path);
+        let buf = serialize_object(object, path, &aggregate, timestamp)?;
+
+        let topic = self.client_id() + "/" + interface_name.trim_matches('/') + path.as_str();
+        let qos = object.reliability().into();
 
         self.client.publish(topic, qos, false, buf).await?;
 
@@ -954,10 +962,11 @@ mod test {
     use tokio::sync::{Mutex, RwLock};
 
     use crate::interfaces::Interfaces;
+    use crate::payload::Payload;
     use crate::properties::tests::PROPERTIES_PAYLOAD;
     use crate::store::memory::MemoryStore;
     use crate::store::wrapper::StoreWrapper;
-    use crate::{self as astarte_device_sdk, payload, Interface};
+    use crate::{self as astarte_device_sdk, Interface};
     use astarte_device_sdk::AstarteAggregate;
     use astarte_device_sdk::{types::AstarteType, Aggregation, AstarteDeviceSdk};
     use astarte_device_sdk_derive::astarte_aggregate;
@@ -980,12 +989,16 @@ mod test {
     where
         I: IntoIterator<Item = Interface>,
     {
+        let interfaces = interfaces
+            .into_iter()
+            .map(|i| (i.interface_name().to_string(), i));
+
         AstarteDeviceSdk {
             realm: "realm".to_string(),
             device_id: "device_id".to_string(),
             client,
             store: StoreWrapper::new(MemoryStore::new()),
-            interfaces: Arc::new(RwLock::new(Interfaces::from(interfaces).unwrap())),
+            interfaces: Arc::new(RwLock::new(Interfaces::from_iter(interfaces))),
             eventloop: Arc::new(Mutex::new(eventloop)),
         }
     }
@@ -1151,7 +1164,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_proprety_set_unset() {
+    async fn test_property_set_unset() {
         let eventloop = EventLoop::default();
 
         let mut client = AsyncClient::default();
@@ -1412,7 +1425,7 @@ mod test {
         let mut client = AsyncClient::default();
 
         let value = AstarteType::String(String::from("name number 1"));
-        let buf = payload::serialize_individual(&value, None).unwrap();
+        let buf = Payload::new(&value).to_vec().unwrap();
 
         let unset = Vec::new();
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -87,6 +87,8 @@ pub struct StoredProp {
 mod tests {
     use crate::store::{memory::MemoryStore, wrapper::StoreWrapper};
 
+    use chrono::{TimeZone, Utc};
+
     use super::*;
 
     pub(crate) async fn test_property_store<S>(store: S)
@@ -97,7 +99,7 @@ mod tests {
 
         store.clear().await.unwrap();
 
-        //non existing
+        // non existing
         assert_eq!(store.load_prop("com.test", "/test", 1).await.unwrap(), None);
 
         store.store_prop("com.test", "/test", &ty, 1).await.unwrap();
@@ -192,6 +194,37 @@ mod tests {
         props.sort_unstable_by(|a, b| a.interface.cmp(&b.interface));
 
         assert_eq!(props, expected);
+
+        // test all types
+        let all_types = [
+            AstarteType::Double(4.5),
+            AstarteType::Integer(-4),
+            AstarteType::Boolean(true),
+            AstarteType::LongInteger(45543543534_i64),
+            AstarteType::String("hello".into()),
+            AstarteType::BinaryBlob(b"hello".to_vec()),
+            AstarteType::DateTime(TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap()),
+            AstarteType::DoubleArray(vec![1.2, 3.4, 5.6, 7.8]),
+            AstarteType::IntegerArray(vec![1, 3, 5, 7]),
+            AstarteType::BooleanArray(vec![true, false, true, true]),
+            AstarteType::LongIntegerArray(vec![45543543534_i64, 45543543535_i64, 45543543536_i64]),
+            AstarteType::StringArray(vec!["hello".to_owned(), "world".to_owned()]),
+            AstarteType::BinaryBlobArray(vec![b"hello".to_vec(), b"world".to_vec()]),
+            AstarteType::DateTimeArray(vec![
+                TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1627580809, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1627580810, 0).unwrap(),
+            ]),
+        ];
+
+        for ty in all_types {
+            let path = format!("/test/{}", ty.display_type());
+            store.store_prop("com.test", &path, &ty, 1).await.unwrap();
+
+            let res = store.load_prop("com.test", &path, 1).await.unwrap();
+
+            assert_eq!(res, Some(ty));
+        }
     }
 
     /// Test that the error is Send + Sync + 'static to be send across task boundaries.

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -26,8 +26,9 @@ use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
 use super::{PropertyStore, StoredProp};
 use crate::{
-    payload::{self, Payload, PayloadError},
-    types::AstarteType,
+    interface::MappingType,
+    payload::{Payload, PayloadError},
+    types::{AstarteType, BsonConverter, TypeError},
 };
 
 /// Error returned by the [`SqliteStore`].
@@ -50,16 +51,47 @@ pub enum SqliteError {
     /// Error returned when the database query fails
     #[error("could not execute query")]
     Query(#[from] sqlx::Error),
+    /// Couldn't convert the stored value.
+    #[error("couldn't convert the stored value")]
+    Value(#[from] ValueError),
     /// Error returned when the decode of the bson fails
     #[error("could not decode property from bson")]
+    #[deprecated = "moved to the ValueError"]
     Decode(#[from] PayloadError),
+}
+
+/// Error when de/serializing a value stored in the [`SqliteStore`].
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum ValueError {
+    /// Couldn't convert to AstarteType.
+    #[error("couldn't convert to AstarteType")]
+    Conversion(#[from] TypeError),
+    /// Couldn't decode the BSON buffer.
+    #[error("couldn't decode property from bson")]
+    Decode(#[from] PayloadError),
+    /// Unsupported [`AstarteType`].
+    #[error("unsupported property type {0}")]
+    UnsupportedType(&'static str),
+    /// Unsupported [`AstarteType`].
+    #[error("unsupported stored type {0}, expected [0-13]")]
+    StoredType(u8),
 }
 
 /// Result of the load_prop query
 #[derive(Debug, Clone)]
 struct PropRecord {
     value: Vec<u8>,
+    stored_type: u8,
     interface_major: i32,
+}
+
+impl TryFrom<PropRecord> for AstarteType {
+    type Error = ValueError;
+
+    fn try_from(record: PropRecord) -> Result<Self, Self::Error> {
+        deserialize_prop(record.stored_type, &record.value)
+    }
 }
 
 /// Result of the load_all_props query
@@ -68,19 +100,74 @@ struct StoredRecord {
     interface: String,
     path: String,
     value: Vec<u8>,
+    stored_type: u8,
     interface_major: i32,
 }
 
+fn into_stored_type(value: &AstarteType) -> Result<u8, ValueError> {
+    let mapping_type = match value {
+        AstarteType::Unset => 0,
+        AstarteType::Double(_) => 1,
+        AstarteType::Integer(_) => 2,
+        AstarteType::Boolean(_) => 3,
+        AstarteType::LongInteger(_) => 4,
+        AstarteType::String(_) => 5,
+        AstarteType::BinaryBlob(_) => 6,
+        AstarteType::DateTime(_) => 7,
+        AstarteType::DoubleArray(_) => 8,
+        AstarteType::IntegerArray(_) => 9,
+        AstarteType::BooleanArray(_) => 10,
+        AstarteType::LongIntegerArray(_) => 11,
+        AstarteType::StringArray(_) => 12,
+        AstarteType::BinaryBlobArray(_) => 13,
+        AstarteType::DateTimeArray(_) => 14,
+        #[allow(deprecated)]
+        AstarteType::EmptyArray => {
+            return Err(ValueError::UnsupportedType(value.display_type()));
+        }
+    };
+
+    Ok(mapping_type)
+}
+
+fn from_stored_type(value: u8) -> Result<Option<MappingType>, ValueError> {
+    let mapping_type = match value {
+        // Property is unset
+        0 => {
+            return Ok(None);
+        }
+        1 => MappingType::Double,
+        2 => MappingType::Integer,
+        3 => MappingType::Boolean,
+        4 => MappingType::LongInteger,
+        5 => MappingType::String,
+        6 => MappingType::BinaryBlob,
+        7 => MappingType::DateTime,
+        8 => MappingType::DoubleArray,
+        9 => MappingType::IntegerArray,
+        10 => MappingType::BooleanArray,
+        11 => MappingType::LongIntegerArray,
+        12 => MappingType::StringArray,
+        13 => MappingType::BinaryBlobArray,
+        14 => MappingType::DateTimeArray,
+        15.. => {
+            return Err(ValueError::StoredType(value));
+        }
+    };
+
+    Ok(Some(mapping_type))
+}
+
 impl TryFrom<StoredRecord> for StoredProp {
-    type Error = PayloadError;
+    type Error = ValueError;
 
     fn try_from(record: StoredRecord) -> Result<Self, Self::Error> {
-        let payload = Payload::try_from(record.value.as_slice())?;
+        let value = deserialize_prop(record.stored_type, &record.value)?;
 
         Ok(StoredProp {
             interface: record.interface,
             path: record.path,
-            value: payload.value,
+            value,
             interface_major: record.interface_major,
         })
     }
@@ -151,13 +238,15 @@ impl PropertyStore for SqliteStore {
             interface, path, value
         );
 
-        let ser = payload::serialize_individual(value, None)?;
+        let mapping_type = into_stored_type(value)?;
+        let buf = Payload::new(value).to_vec()?;
 
         sqlx::query_file!(
             "queries/store_prop.sql",
             interface,
             path,
-            ser,
+            buf,
+            mapping_type,
             interface_major
         )
         .execute(&self.db_conn)
@@ -193,9 +282,9 @@ impl PropertyStore for SqliteStore {
                     return Ok(None);
                 }
 
-                payload::deserialize_individual(&record.value)
-                    .map(Some)
-                    .map_err(SqliteError::from)
+                let ast_ty = record.try_into()?;
+
+                Ok(Some(ast_ty))
             }
             None => Ok(None),
         }
@@ -225,6 +314,18 @@ impl PropertyStore for SqliteStore {
 
         Ok(res)
     }
+}
+
+/// Deserialize a property from the store.
+fn deserialize_prop(stored_type: u8, buf: &[u8]) -> Result<AstarteType, ValueError> {
+    let Some(mapping_type) = from_stored_type(stored_type)? else {
+        return Ok(AstarteType::Unset);
+    };
+
+    let payload = Payload::from_slice(buf)?;
+    let value = BsonConverter::new(mapping_type, payload.value);
+
+    value.try_into().map_err(ValueError::from)
 }
 
 #[cfg(test)]

--- a/src/topic.rs
+++ b/src/topic.rs
@@ -53,7 +53,7 @@ impl TopicError {
     }
 }
 
-pub(crate) fn parse_topic(topic: &str) -> Result<(&str, &str, &str, MappingPath<'_>), TopicError> {
+pub(crate) fn parse_topic(topic: &str) -> Result<(&str, &str, &str, MappingPath), TopicError> {
     if topic.is_empty() {
         return Err(TopicError::Empty);
     }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,0 +1,126 @@
+// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Validate the submission and reception of a payload.
+
+use crate::{
+    interfaces::{MappingRef, ObjectRef},
+    Interface,
+};
+
+/// Errors returning while validating a send or a receive
+#[non_exhaustive]
+#[derive(thiserror::Error, Debug)]
+pub enum ValidationError {
+    /// Sending timestamp to a mapping without `explicit_timestamp`
+    #[error("sending timestamp to a mapping without `explicit_timestamp`")]
+    Timestamp,
+}
+
+/// Optionals check on the sent individual payload.
+pub(crate) fn validate_send_individual(
+    mapping: MappingRef<&Interface>,
+    timestamp: &Option<chrono::DateTime<chrono::Utc>>,
+) -> Result<(), ValidationError> {
+    if !mapping.mapping().explicit_timestamp() && timestamp.is_some() {
+        return Err(ValidationError::Timestamp);
+    }
+
+    Ok(())
+}
+
+/// Optionals check on the sent object payload.
+pub(crate) fn validate_send_object(
+    object: ObjectRef,
+    timestamp: &Option<chrono::DateTime<chrono::Utc>>,
+) -> Result<(), ValidationError> {
+    if !object.explicit_timestamp() && timestamp.is_some() {
+        return Err(ValidationError::Timestamp);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, str::FromStr};
+
+    use crate::{interfaces::tests::DEVICE_OBJECT, mapping, types::AstarteType};
+
+    use super::*;
+
+    use chrono::{TimeZone, Utc};
+
+    const DEVICE_DATASTREAM: &str = include_str!(
+        "../tests/e2etest/interfaces/org.astarte-platform.rust.e2etest.DeviceDatastream.json"
+    );
+
+    fn inititialize_aggregate() -> (Interface, HashMap<String, AstarteType>) {
+        let aggregate = HashMap::from_iter([
+            (
+                "double_endpoint".to_string(),
+                AstarteType::Double(37.534543),
+            ),
+            ("integer_endpoint".to_string(), AstarteType::Integer(45)),
+            ("boolean_endpoint".to_string(), AstarteType::Boolean(true)),
+            (
+                "booleanarray_endpoint".to_string(),
+                AstarteType::BooleanArray(vec![true, false, true]),
+            ),
+        ]);
+
+        let interface = Interface::from_str(DEVICE_OBJECT).unwrap();
+
+        (interface, aggregate)
+    }
+
+    #[test]
+    fn test_validate_send_for_aggregate_datastream() {
+        let (interface, _aggregate) = inititialize_aggregate();
+        let object = interface.as_object_ref().unwrap();
+
+        // Test sending an aggregate (with and without timestamp)
+        let timestamp = Some(TimeZone::timestamp_opt(&Utc, 1537449422, 0).unwrap());
+        validate_send_object(object, &None).unwrap();
+        validate_send_object(object, &timestamp).unwrap();
+    }
+
+    #[test]
+    fn test_validate_send_for_aggregate_datastream_extra_field() {
+        let (interface, mut aggregate) = inititialize_aggregate();
+        let object = interface.as_object_ref().unwrap();
+
+        // Test sending an aggregate with an non existing object field
+        aggregate.insert("gibberish".to_string(), AstarteType::Boolean(false));
+        let res = validate_send_object(object, &None);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_validate_send_for_individual_datastream() {
+        let interface = Interface::from_str(DEVICE_DATASTREAM).unwrap();
+
+        let mapping = MappingRef::new(&interface, mapping!("/boolean_endpoint")).unwrap();
+
+        let res = validate_send_individual(mapping, &None);
+        assert!(res.is_ok());
+
+        let res = validate_send_individual(mapping, &Some(Utc::now()));
+        assert!(res.is_ok());
+    }
+}

--- a/tests/e2etest/main.rs
+++ b/tests/e2etest/main.rs
@@ -30,7 +30,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{env, panic, process};
 
-use colored::Colorize;
+use log::{debug, info};
 use reqwest::StatusCode;
 use serde_json::Value;
 use tokio::{task, time};
@@ -127,6 +127,8 @@ async fn e2etest_impl() {
         process::exit(1);
     }));
 
+    env_logger::init();
+
     let test_cfg = TestCfg::init().expect("Failed configuration initialization");
 
     let mut sdk_options = AstarteOptions::new(
@@ -176,7 +178,7 @@ async fn e2etest_impl() {
             .await
             .unwrap();
 
-        println!("\nTest datastreams completed successfully");
+        info!("Test datastreams completed successfully");
         process::exit(0);
     });
 
@@ -241,8 +243,7 @@ async fn test_datastream_device_to_server(
     let tx_data = mock_data.get_device_to_server_data_as_astarte();
 
     // Send all the mock test data
-    let msg = "\nSending device owned datastreams from device to server.".cyan();
-    println!("{msg}");
+    debug!("Sending device owned datastreams from device to server.");
     for (key, value) in tx_data.clone() {
         device
             .send(&test_cfg.interface_datastream_do, &format!("/{key}"), value)
@@ -254,7 +255,7 @@ async fn test_datastream_device_to_server(
     time::sleep(Duration::from_secs(1)).await;
 
     // Get the stored data using http requests
-    println!("{}", "\nChecking data stored on the server.".cyan());
+    debug!("Checking data stored on the server.");
     let http_get_response = http_get_intf(test_cfg, &test_cfg.interface_datastream_do).await?;
 
     // Check if the sent and received data match
@@ -290,8 +291,7 @@ async fn test_datastream_server_to_device(
     let mock_data = MockDataDatastream::init();
 
     // Send the data using http requests
-    let msg = "\nSending server owned datastreams from server to device.".cyan();
-    println!("{msg}");
+    debug!("Sending server owned datastreams from server to device.");
     for (key, value) in mock_data.get_server_to_device_data_as_json() {
         http_post_to_intf(test_cfg, &test_cfg.interface_datastream_so, &key, value).await?;
     }
@@ -300,7 +300,7 @@ async fn test_datastream_server_to_device(
 
     // Lock the shared data and check if everything sent has been correctly received
 
-    println!("{}", "\nChecking data received by the device.".cyan());
+    debug!("Checking data received by the device.");
     let rx_data_rw_acc = rx_data
         .lock()
         .map_err(|e| format!("Failed to lock the shared data. {e}"))?;
@@ -331,8 +331,7 @@ async fn test_aggregate_device_to_server(
     let sensor_number: i8 = 45;
 
     // Send all the mock test data
-    let msg = "\nSending device owned aggregate from device to server.".cyan();
-    println!("{msg}");
+    debug!("Sending device owned aggregate from device to server");
     device
         .send_object(
             &test_cfg.interface_aggregate_do,
@@ -345,7 +344,7 @@ async fn test_aggregate_device_to_server(
     time::sleep(Duration::from_secs(1)).await;
 
     // Get the stored data using http requests
-    println!("{}", "\nChecking data stored on the server.".cyan());
+    debug!("Checking data stored on the server.");
     let http_get_response = http_get_intf(test_cfg, &test_cfg.interface_aggregate_do).await?;
 
     // Check if the sent and received data match
@@ -382,8 +381,7 @@ async fn test_aggregate_server_to_device(
     let sensor_number: i8 = 11;
 
     // Send the data using http requests
-    let msg = "\nSending server owned aggregate from server to device.".cyan();
-    println!("{msg}");
+    debug!("Sending server owned aggregate from server to device.");
     http_post_to_intf(
         test_cfg,
         &test_cfg.interface_aggregate_so,
@@ -395,7 +393,7 @@ async fn test_aggregate_server_to_device(
     time::sleep(Duration::from_secs(1)).await;
 
     // Lock the shared data and check if everything sent has been correctly received
-    println!("{}", "\nChecking data received by the device.".cyan());
+    debug!("Checking data received by the device.");
     let rx_data_rw_acc = rx_data
         .lock()
         .map_err(|e| format!("Failed to lock the shared data. {e}"))?;
@@ -427,8 +425,7 @@ async fn test_property_device_to_server(
     let sensor_number = 1;
 
     // Send all the mock test data
-    let msg = "\nSet device owned property (will be also sent to server).".cyan();
-    println!("{msg}");
+    debug!("Set device owned property (will be also sent to server).");
     for (key, value) in tx_data.clone() {
         device
             .send(
@@ -443,7 +440,7 @@ async fn test_property_device_to_server(
     time::sleep(Duration::from_secs(1)).await;
 
     // Get the stored data using http requests
-    println!("{}", "\nChecking data stored on the server.".cyan());
+    debug!("Checking data stored on the server.");
     let http_get_response = http_get_intf(test_cfg, &test_cfg.interface_property_do).await?;
 
     // Check if the sent and received data match
@@ -463,8 +460,7 @@ async fn test_property_device_to_server(
     }
 
     // Unset one specific property
-    let msg = "\nUnset all the device owned property (will be also sent to server).".cyan();
-    println!("{msg}");
+    debug!("Unset all the device owned property (will be also sent to server).");
     for (key, _) in tx_data.clone() {
         device
             .unset(
@@ -478,7 +474,7 @@ async fn test_property_device_to_server(
     time::sleep(Duration::from_secs(1)).await;
 
     // Get the stored data using http requests
-    println!("{}", "\nChecking data stored on the server.".cyan());
+    debug!("Checking data stored on the server.");
     let http_get_response = http_get_intf(test_cfg, &test_cfg.interface_property_do).await?;
 
     if http_get_response != "{\"data\":{}}" {
@@ -507,8 +503,7 @@ async fn test_property_server_to_device(
     let sensor_number: i8 = 42;
 
     // Send the data using http requests
-    let msg = "\nSending server owned properties from server to device.".cyan();
-    println!("{msg}");
+    debug!("Sending server owned properties from server to device.");
     for (key, value) in mock_data.get_server_to_device_data_as_json() {
         http_post_to_intf(
             test_cfg,
@@ -523,7 +518,7 @@ async fn test_property_server_to_device(
 
     // Lock the shared data and check if everything sent has been correctly received
     {
-        println!("{}", "\nChecking data received by the device.".cyan());
+        debug!("Checking data received by the device.");
         let rx_data_rw_acc = rx_data
             .lock()
             .map_err(|e| format!("Failed to lock the shared data. {e}"))?;
@@ -539,8 +534,7 @@ async fn test_property_server_to_device(
     }
 
     // Unset all the properties
-    let msg = "\nUnsetting all the server owned properties (will be also sent to device).".cyan();
-    println!("{msg}");
+    debug!("Unsetting all the server owned properties (will be also sent to device).");
     for (key, _) in mock_data.get_server_to_device_data_as_json() {
         http_delete_to_intf(
             test_cfg,
@@ -554,7 +548,7 @@ async fn test_property_server_to_device(
 
     // Lock the shared data and check if everything sent has been correctly received
     {
-        println!("{}", "\nChecking data received by the device.".cyan());
+        debug!("Checking data received by the device.");
         let rx_data_rw_acc = rx_data
             .lock()
             .map_err(|e| format!("Failed to lock the shared data. {e}"))?;
@@ -583,7 +577,7 @@ async fn http_get_intf(test_cfg: &TestCfg, interface: &str) -> Result<String, St
         "{}/v1/{}/devices/{}/interfaces/{}",
         test_cfg.api_url, test_cfg.realm, test_cfg.device_id, interface
     );
-    println!("Sending HTTP GET request: {get_cmd}");
+    debug!("Sending HTTP GET request: {get_cmd}");
     reqwest::Client::new()
         .get(get_cmd)
         .header(
@@ -615,7 +609,7 @@ async fn http_post_to_intf(
         "{}/v1/{}/devices/{}/interfaces/{}/{}",
         test_cfg.api_url, test_cfg.realm, test_cfg.device_id, interface, path
     );
-    println!("Sending HTTP POST request: {post_cmd} {value_json}");
+    debug!("Sending HTTP POST request: {post_cmd} {value_json}");
     let response = reqwest::Client::new()
         .post(post_cmd)
         .header(
@@ -654,7 +648,7 @@ async fn http_delete_to_intf(
         "{}/v1/{}/devices/{}/interfaces/{}/{}",
         test_cfg.api_url, test_cfg.realm, test_cfg.device_id, interface, path
     );
-    println!("Sending HTTP DELETE request: {post_cmd}");
+    debug!("Sending HTTP DELETE request: {post_cmd}");
     let response = reqwest::Client::new()
         .delete(post_cmd)
         .header(


### PR DESCRIPTION
Fixes a bug when deserializing integer arrays of mixed sizes received from astarte. Also improve the validation when sending and receiving data, introduced more ergonomic ways to access the interfaces mappings/objects. Upgraded to hard errors when interfaces are non-existing or of a different type.

Closes #238 