### PR TITLE
fix(unset): send an empty buffer on property unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Unset of property send empty buffer instead of document with null value.
+
 ## [0.6.0] - 2023-07-05
 ### Added
 - Support for different case conventions on `AstarteAggregate` derive macro

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -74,14 +74,14 @@ struct StoredRecord {
 impl TryFrom<StoredRecord> for StoredProp {
     type Error = PayloadError;
 
-    fn try_from(value: StoredRecord) -> Result<Self, Self::Error> {
-        let payload = Payload::from_slice(&value.value)?;
+    fn try_from(record: StoredRecord) -> Result<Self, Self::Error> {
+        let payload = Payload::try_from(record.value.as_slice())?;
 
         Ok(StoredProp {
-            interface: value.interface,
-            path: value.path,
+            interface: record.interface,
+            path: record.path,
             value: payload.value,
-            interface_major: value.interface_major,
+            interface_major: record.interface_major,
         })
     }
 }


### PR DESCRIPTION
This is the documented way on how to unset a property. Before we were sending a bson document with a null value which was also working, but it's not the way described in the mqtt-v1-protocol.