### PR TITLE
refactor(deps): loosen the dependencies minimum version reqs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -88,6 +88,23 @@ jobs:
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       - name: cargo hack
         run: cargo hack --feature-powerset check
+  minimal-versions:
+    runs-on: ubuntu-latest
+    name: ubuntu / nightly / minimal-versions
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install nightly
+        uses: dtolnay/rust-toolchain@nightly
+      - name: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: remove dev-deps
+        run: cargo hack --remove-dev-deps
+      - name: update to minimal deps
+        run: cargo update -Z direct-minimal-versions
+      - name: cargo check
+        run: cargo check --all-features
+        env:
+          RUSTDOCFLAGS: -D warnings
   msrv:
     runs-on: ubuntu-latest
     # we use a matrix here just because env can't be used in job names

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,32 +25,32 @@ harness = false
 
 [dependencies]
 astarte-device-sdk-derive = { version = "=0.6.0", optional = true, path = "./astarte-device-sdk-derive" }
-async-trait = "0.1.68"
-base64 = "0.21.2"
-bson = { version = "2.6.1", features = ["chrono-0_4"] }
-chrono = { version = "0.4.26", features = ["serde"] }
+async-trait = "0.1.2"
+base64 = "0.21.0"
+bson = { version = "2.1.0", features = ["chrono-0_4"] }
+chrono = { version = "0.4.14", features = ["serde"] }
 ecdsa = { version = "0.16.7", features = ["sha2"] }
-flate2 = "1.0.26"
-http = "0.2.9"
+flate2 = "1.0.0"
+http = "0.2.0"
 itertools = "0.11.0"
-log = "0.4.19"
-openssl = { version = "0.10.55", optional = true }
+log = "0.4.14"
+openssl = { version = "0.10.46", optional = true }
 p384 = "0.13.0"
 rand_core = { version = "0.6.4", features = ["getrandom"] }
-reqwest = { version = "0.11.18", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11.0", features = ["json", "rustls-tls"] }
 rumqttc = "0.21.0"
-rustls = { version = "0.20.8", features = ["dangerous_configuration"] }
-rustls-native-certs = "0.6.3"
-rustls-pemfile = "1.0.2"
-serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.99"
-sqlx = { version = "0.6.3", features = ["runtime-tokio-rustls", "sqlite", "macros", "offline", "migrate"] }
-thiserror = "1.0.40"
-tokio = { version = "1.28.2", features = ["parking_lot", "macros"] }
-url = "2.4.0"
-uuid = { version = "1.3.4", features = ["v5", "v4"] }
+rustls = { version = "0.20.1", features = ["dangerous_configuration"] }
+rustls-native-certs = "0.6.0"
+rustls-pemfile = "1.0.0"
+serde = { version = "1.0.132", features = ["derive"] }
+serde_json = "1.0.73"
+sqlx = { version = "0.6.0", features = ["runtime-tokio-rustls", "sqlite", "macros", "offline", "migrate"] }
+thiserror = "1.0.30"
+tokio = { version = "1.18.0", features = ["parking_lot", "macros"] }
+url = "2.2.2"
+uuid = { version = "1.0.0", features = ["v5", "v4"] }
 webpki = "0.22.0"
-x509-cert = { version = "0.2.3", features = ["builder"] }
+x509-cert = { version = "0.2.2", features = ["builder"] }
 
 [dev-dependencies]
 astarte-device-sdk-derive = { path = "./astarte-device-sdk-derive" }


### PR DESCRIPTION
Make the patch/minor version of the dependencies match the actual required one this will loosen the requirements of the library. Add a ci action to check that the direct-minimal-versions is respected.