### PR TITLE
fix(interface): make escaped strings deserializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Allow escaped character in the `Interface` description and documentation.
+
 ## [0.6.1] - 2023-10-02
 ### Added
 - Check if an interface exists and the type is the same of the value

--- a/src/interface/mapping/iter.rs
+++ b/src/interface/mapping/iter.rs
@@ -43,7 +43,7 @@ impl<'a> MappingIter<'a> {
 }
 
 impl<'a> Iterator for MappingIter<'a> {
-    type Item = Mapping<'a>;
+    type Item = Mapping<&'a str>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -98,7 +98,7 @@ impl<'a> PropertiesMappingIter<'a> {
 }
 
 impl<'a> Iterator for PropertiesMappingIter<'a> {
-    type Item = Mapping<'a>;
+    type Item = Mapping<&'a str>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.properties.next().map(|mapping| mapping.into())
@@ -137,7 +137,7 @@ impl<'a> IndividualMappingIter<'a> {
 }
 
 impl<'a> Iterator for IndividualMappingIter<'a> {
-    type Item = Mapping<'a>;
+    type Item = Mapping<&'a str>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.properties.next().map(|mapping| mapping.into())
@@ -178,7 +178,7 @@ impl<'a> ObjectMappingIter<'a> {
 }
 
 impl<'a> Iterator for ObjectMappingIter<'a> {
-    type Item = Mapping<'a>;
+    type Item = Mapping<&'a str>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.properties

--- a/src/interface/mapping/mod.rs
+++ b/src/interface/mapping/mod.rs
@@ -56,7 +56,7 @@ impl Ord for DatastreamIndividualMapping {
     }
 }
 
-impl<'a> From<&'a DatastreamIndividualMapping> for Mapping<'a> {
+impl<'a> From<&'a DatastreamIndividualMapping> for Mapping<&'a str> {
     fn from(value: &'a DatastreamIndividualMapping) -> Self {
         let mut mapping = Mapping::from(&value.mapping);
 
@@ -70,10 +70,13 @@ impl<'a> From<&'a DatastreamIndividualMapping> for Mapping<'a> {
     }
 }
 
-impl TryFrom<&Mapping<'_>> for DatastreamIndividualMapping {
+impl<T> TryFrom<&Mapping<T>> for DatastreamIndividualMapping
+where
+    T: AsRef<str> + Into<String>,
+{
     type Error = InterfaceError;
 
-    fn try_from(value: &Mapping<'_>) -> Result<Self, Self::Error> {
+    fn try_from(value: &Mapping<T>) -> Result<Self, Self::Error> {
         let base_mapping = BaseMapping::try_from(value)?;
 
         if value.allow_unset {
@@ -134,7 +137,7 @@ impl Ord for PropertiesMapping {
     }
 }
 
-impl<'a> From<&'a PropertiesMapping> for Mapping<'a> {
+impl<'a> From<&'a PropertiesMapping> for Mapping<&'a str> {
     fn from(value: &'a PropertiesMapping) -> Self {
         let mut mapping = Mapping::from(&value.mapping);
 
@@ -144,10 +147,13 @@ impl<'a> From<&'a PropertiesMapping> for Mapping<'a> {
     }
 }
 
-impl TryFrom<&Mapping<'_>> for PropertiesMapping {
+impl<T> TryFrom<&Mapping<T>> for PropertiesMapping
+where
+    T: AsRef<str> + Into<String>,
+{
     type Error = InterfaceError;
 
-    fn try_from(value: &Mapping<'_>) -> Result<Self, Self::Error> {
+    fn try_from(value: &Mapping<T>) -> Result<Self, Self::Error> {
         let base_mapping = BaseMapping::try_from(value)?;
 
         if value.explicit_timestamp {
@@ -227,7 +233,7 @@ impl Ord for BaseMapping {
     }
 }
 
-impl<'a> From<&'a BaseMapping> for Mapping<'a> {
+impl<'a> From<&'a BaseMapping> for Mapping<&'a str> {
     fn from(value: &'a BaseMapping) -> Self {
         Self::new(value.endpoint(), value.mapping_type())
             .with_description(value.description())
@@ -235,17 +241,20 @@ impl<'a> From<&'a BaseMapping> for Mapping<'a> {
     }
 }
 
-impl<'a> TryFrom<&Mapping<'a>> for BaseMapping {
+impl<T> TryFrom<&Mapping<T>> for BaseMapping
+where
+    T: AsRef<str> + Into<String>,
+{
     type Error = InterfaceError;
 
-    fn try_from(value: &Mapping<'a>) -> Result<Self, Self::Error> {
-        let endpoint = Endpoint::try_from(value.endpoint())?;
+    fn try_from(value: &Mapping<T>) -> Result<Self, Self::Error> {
+        let endpoint = Endpoint::try_from(value.endpoint().as_ref())?;
 
         Ok(Self {
             endpoint,
             mapping_type: value.mapping_type(),
-            description: value.description().map(ToString::to_string),
-            doc: value.doc().map(ToString::to_string),
+            description: value.description().map(|t| t.as_ref().into()),
+            doc: value.doc().map(|t| t.as_ref().into()),
         })
     }
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -80,7 +80,7 @@ pub(crate) const MAX_INTERFACE_MAPPINGS: usize = 1024;
 ///
 /// Should be used only through its methods, not instantiated directly.
 #[derive(Deserialize, Debug, PartialEq, Clone)]
-#[serde(try_from = "InterfaceDef")]
+#[serde(try_from = "InterfaceDef<std::borrow::Cow<str>>")]
 pub struct Interface {
     interface_name: String,
     version_major: i32,
@@ -156,7 +156,7 @@ impl Interface {
         MappingIter::new(&self.inner)
     }
 
-    pub(crate) fn mapping(&self, path: &MappingPath) -> Option<Mapping> {
+    pub(crate) fn mapping(&self, path: &MappingPath) -> Option<Mapping<&str>> {
         match &self.inner {
             InterfaceType::DatastreamIndividual(individual) => individual.mapping(path),
             InterfaceType::DatastreamObject(object) => object.mapping(path),
@@ -312,16 +312,19 @@ impl DatastreamIndividual {
         IndividualMappingIter::new(&self.mappings)
     }
 
-    pub(crate) fn add_mapping(
+    pub(crate) fn add_mapping<T>(
         tree: &mut MappingSet<DatastreamIndividualMapping>,
-        mapping: &Mapping,
-    ) -> Result<(), InterfaceError> {
+        mapping: &Mapping<T>,
+    ) -> Result<(), InterfaceError>
+    where
+        T: AsRef<str> + Into<String>,
+    {
         let individual = Item::new(DatastreamIndividualMapping::try_from(mapping)?);
 
         if let Some(existing) = tree.get(&individual) {
             return Err(InterfaceError::DuplicateMapping {
                 endpoint: existing.endpoint().to_string(),
-                duplicate: mapping.endpoint().to_string(),
+                duplicate: mapping.endpoint().as_ref().into(),
             });
         }
 
@@ -334,15 +337,18 @@ impl DatastreamIndividual {
         self.mappings.get(path)
     }
 
-    pub fn mapping(&self, path: &MappingPath) -> Option<Mapping> {
+    pub fn mapping(&self, path: &MappingPath) -> Option<Mapping<&str>> {
         self.get(path).map(Mapping::from)
     }
 }
 
-impl TryFrom<&InterfaceDef<'_>> for DatastreamIndividual {
+impl<'a, T> TryFrom<&'a InterfaceDef<T>> for DatastreamIndividual
+where
+    T: AsRef<str> + Into<String>,
+{
     type Error = InterfaceError;
 
-    fn try_from(value: &InterfaceDef) -> Result<Self, Self::Error> {
+    fn try_from(value: &InterfaceDef<T>) -> Result<Self, Self::Error> {
         let mut btree = MappingSet::new();
 
         for mapping in value.mappings.iter() {
@@ -365,7 +371,7 @@ pub(crate) struct DatastreamObject {
 }
 
 impl DatastreamObject {
-    pub(crate) fn apply<'a>(&self, base_mapping: &'a BaseMapping) -> Mapping<'a> {
+    pub(crate) fn apply<'a>(&self, base_mapping: &'a BaseMapping) -> Mapping<&'a str> {
         let mut mapping = Mapping::from(base_mapping);
 
         mapping.reliability = self.reliability;
@@ -382,7 +388,7 @@ impl DatastreamObject {
     }
 
     /// Check if the mapping is compatible with the interface
-    pub fn is_compatible(&self, mapping: &Mapping) -> bool {
+    pub fn is_compatible<T>(&self, mapping: &Mapping<T>) -> bool {
         mapping.reliability() == self.reliability
             && mapping.explicit_timestamp() == self.explicit_timestamp
             && mapping.retention() == self.retention
@@ -393,11 +399,14 @@ impl DatastreamObject {
     ///
     /// Since the interface is an object, the mapping must be compatible with the interface. It
     /// needs to have the same length and prefix as the other mapping.
-    pub(crate) fn add_mapping(
+    pub(crate) fn add_mapping<T>(
         &self,
         btree: &mut MappingSet<BaseMapping>,
-        mapping: &Mapping,
-    ) -> Result<(), InterfaceError> {
+        mapping: &Mapping<T>,
+    ) -> Result<(), InterfaceError>
+    where
+        T: AsRef<str> + Into<String>,
+    {
         if !self.is_compatible(mapping) {
             return Err(InterfaceError::InconsistentMapping);
         }
@@ -446,7 +455,7 @@ impl DatastreamObject {
         self.mappings.len()
     }
 
-    pub fn mapping(&self, path: &MappingPath) -> Option<Mapping> {
+    pub fn mapping(&self, path: &MappingPath) -> Option<Mapping<&str>> {
         self.get(path).map(|base| self.apply(base))
     }
 
@@ -459,10 +468,13 @@ impl DatastreamObject {
     }
 }
 
-impl TryFrom<&InterfaceDef<'_>> for DatastreamObject {
+impl<T> TryFrom<&InterfaceDef<T>> for DatastreamObject
+where
+    T: AsRef<str> + Into<String>,
+{
     type Error = InterfaceError;
 
-    fn try_from(value: &InterfaceDef) -> Result<Self, Self::Error> {
+    fn try_from(value: &InterfaceDef<T>) -> Result<Self, Self::Error> {
         let mut mappings_iter = value.mappings.iter();
         let mut btree = MappingSet::new();
 
@@ -505,20 +517,23 @@ impl Properties {
         self.mappings.get(path)
     }
 
-    pub fn mapping(&self, endpoint: &MappingPath) -> Option<Mapping> {
+    pub fn mapping(&self, endpoint: &MappingPath) -> Option<Mapping<&str>> {
         self.get(endpoint).map(Mapping::from)
     }
 
-    pub fn add_mapping(
+    pub fn add_mapping<T>(
         btree: &mut MappingSet<PropertiesMapping>,
-        mapping: &Mapping,
-    ) -> Result<(), InterfaceError> {
+        mapping: &Mapping<T>,
+    ) -> Result<(), InterfaceError>
+    where
+        T: AsRef<str> + Into<String>,
+    {
         let property = Item::new(PropertiesMapping::try_from(mapping)?);
 
         if let Some(existing) = btree.get(&property) {
             return Err(InterfaceError::DuplicateMapping {
                 endpoint: existing.endpoint().to_string(),
-                duplicate: mapping.endpoint().to_string(),
+                duplicate: mapping.endpoint().as_ref().into(),
             });
         }
 
@@ -528,10 +543,13 @@ impl Properties {
     }
 }
 
-impl<'a> TryFrom<&InterfaceDef<'a>> for Properties {
+impl<T> TryFrom<&InterfaceDef<T>> for Properties
+where
+    T: AsRef<str> + Into<String>,
+{
     type Error = InterfaceError;
 
-    fn try_from(value: &InterfaceDef) -> Result<Self, Self::Error> {
+    fn try_from(value: &InterfaceDef<T>) -> Result<Self, Self::Error> {
         let mut btree = MappingSet::new();
 
         for mapping in value.mappings.iter() {
@@ -558,7 +576,7 @@ pub(crate) enum Retention {
 }
 
 impl Retention {
-    pub(self) fn apply(&self, mapping: &mut Mapping) {
+    pub(self) fn apply<T>(&self, mapping: &mut Mapping<T>) {
         match self {
             Retention::Discard => {
                 mapping.retention = RetentionDef::Discard;
@@ -592,7 +610,7 @@ pub(crate) enum DatabaseRetention {
 }
 
 impl DatabaseRetention {
-    pub(self) fn apply(&self, mapping: &mut Mapping) {
+    pub(self) fn apply<T>(&self, mapping: &mut Mapping<T>) {
         match self {
             DatabaseRetention::NoTtl => {
                 mapping.database_retention_policy = DatabaseRetentionPolicyDef::NoTtl;
@@ -627,7 +645,7 @@ mod tests {
             Aggregation, DatabaseRetention, DatastreamIndividual, InterfaceType, InterfaceTypeDef,
             Mapping, MappingSet, MappingType, Ownership, Reliability, Retention,
         },
-        Interface,
+        mapping, Interface,
     };
 
     // The mappings are sorted alphabetically by endpoint, so we can confront them
@@ -773,8 +791,8 @@ mod tests {
         let paths: Vec<_> = interface.iter_mappings().collect();
 
         assert_eq!(paths.len(), 2);
-        assert_eq!(paths[0].endpoint(), "/%{sensor_id}/aaaa");
-        assert_eq!(paths[1].endpoint(), "/%{sensor_id}/bbbb");
+        assert_eq!(*paths[0].endpoint(), "/%{sensor_id}/aaaa");
+        assert_eq!(*paths[1].endpoint(), "/%{sensor_id}/bbbb");
 
         let path = MappingPath::try_from("/1/aaaa").unwrap();
 
@@ -851,5 +869,39 @@ mod tests {
         let value = serde_json::Value::from_str(&serialized).unwrap();
         let expected = serde_json::Value::from_str(INTERFACE_JSON).unwrap();
         assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn test_with_escaped_descriptions() {
+        let json = r#"{
+            "interface_name": "org.astarte-platform.genericproperties.Values",
+            "version_major": 1,
+            "version_minor": 0,
+            "type": "properties",
+            "ownership": "server",
+            "description": "Interface description \"escaped\"",
+            "doc": "Interface doc \"escaped\"",
+            "mappings": [{
+                "endpoint": "/double_endpoint",
+                "type": "double",
+                "doc": "Mapping doc \"escaped\""
+            }]
+        }"#;
+
+        let interface = Interface::from_str(json).unwrap();
+
+        assert_eq!(
+            interface.description().unwrap(),
+            r#"Interface description "escaped""#
+        );
+        assert_eq!(interface.doc().unwrap(), r#"Interface doc "escaped""#);
+        assert_eq!(
+            *interface
+                .mapping(mapping!("/double_endpoint"))
+                .unwrap()
+                .doc()
+                .unwrap(),
+            r#"Mapping doc "escaped""#
+        );
     }
 }

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -83,9 +83,9 @@ impl<'a> Deref for ObjectRef<'a> {
 
 /// Reference to an [`Interface`] and a [`Mapping`] that is guaranty to belong to the interface.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct MappingRef<'m, I> {
+pub(crate) struct MappingRef<'a, I> {
     interface: I,
-    mapping: Mapping<'m>,
+    mapping: Mapping<&'a str>,
 }
 
 impl<'a> MappingRef<'a, &'a Interface> {
@@ -113,7 +113,7 @@ impl<'a> MappingRef<'a, PropertyRef<'a>> {
 
 impl<'a, I> MappingRef<'a, I> {
     #[inline]
-    pub(crate) fn mapping(&self) -> &Mapping {
+    pub(crate) fn mapping(&self) -> &Mapping<&str> {
         &self.mapping
     }
 
@@ -124,7 +124,7 @@ impl<'a, I> MappingRef<'a, I> {
 }
 
 impl<'a, I> Deref for MappingRef<'a, I> {
-    type Target = Mapping<'a>;
+    type Target = Mapping<&'a str>;
 
     fn deref(&self) -> &Self::Target {
         &self.mapping
@@ -371,7 +371,7 @@ pub(crate) mod tests {
             assert_eq!(mapping.interface().interface_name(), self.name);
             assert_eq!(mapping.interface().version_major(), self.version_major);
             assert_eq!(mapping.mapping_type(), self.mapping_type);
-            assert_eq!(mapping.endpoint(), self.endpoint);
+            assert_eq!(*mapping.endpoint(), self.endpoint);
             assert_eq!(mapping.explicit_timestamp(), self.explicit_timestamp);
             assert_eq!(mapping.allow_unset(), self.allow_unset);
         }


### PR DESCRIPTION
Make the interface doc and description deserializable when there are escaped characters in the string.

Closes #250 