### PR TITLE
Prepeare release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.7.1] - 2024-02-16
 ## Changed
 - `MqttConfig` now receives `Into<String>` instead of `&str`
 - Bump MSRV to 1.72.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
 name = "astarte-device-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "astarte-device-sdk-derive",
  "astarte-message-hub-proto",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -671,7 +671,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "e2e-test"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "astarte-device-sdk",
  "base64 0.21.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,16 @@ members = [
   "e2e-test",
 ]
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [workspace.package]
+version = "0.7.1"
 edition = "2021"
+exclude = [".github"]
 homepage = "https://astarte.cloud/"
 license = "Apache-2.0"
 repository = "https://github.com/astarte-platform/astarte-device-sdk-rust"
 rust-version = "1.72.0"
-version = "0.7.0"
-exclude = [".github"]
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bench]]
 name = "benchmark"
@@ -88,7 +89,7 @@ openssl = ["dep:openssl"]
 message-hub = ["dep:astarte-message-hub-proto"]
 
 [workspace.dependencies]
-astarte-device-sdk-derive = { version = "=0.7.0", path = "./astarte-device-sdk-derive" }
+astarte-device-sdk-derive = { version = "=0.7.1", path = "./astarte-device-sdk-derive" }
 astarte-message-hub-proto = "0.6.1"
 async-trait = "0.1.43"
 base64 = "0.21.0"

--- a/astarte-device-sdk-derive/CHANGELOG.md
+++ b/astarte-device-sdk-derive/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.1] - 2024-02-16
 - Bump MSRV to 1.72.0.
 
 ## [0.6.3] - 2024-02-13


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

### Bug Fixes

- Remove debug macro

### Features

- Bump Rust version to 1.72.0

### Refactor

- Pass owned object to not clone internally
