### PR TITLE
refactor(unset): remove the AstarteType::Unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce Node ID into gRPC metadata.
 - Add one or more interfaces at once with `extend_interfaces`
   [#293](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/293)
+- Add a method `unset` to unset a property
+  [#296](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/296)
+
+### Changed
+- Rename the enum `Aggregation` into `Value`
+  [#296](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/296)
+- Move the `AstarteType::Unset` to the `Value::Unset` for the astarte event
+  [#296](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/296)
 
 ## [0.7.2] - 2024-03-21
 ### Fixed

--- a/astarte-device-sdk-derive/src/lib.rs
+++ b/astarte-device-sdk-derive/src/lib.rs
@@ -314,7 +314,7 @@ impl FromEventDerive {
                 type Err = astarte_device_sdk::event::FromEventError;
 
                 fn from_event(event: astarte_device_sdk::AstarteDeviceDataEvent) -> Result<Self, Self::Err> {
-                    use astarte_device_sdk::Aggregation;
+                    use astarte_device_sdk::Value;
                     use astarte_device_sdk::event::FromEventError;
                     use astarte_device_sdk::interface::mapping::endpoint::Endpoint;
 
@@ -333,7 +333,7 @@ impl FromEventDerive {
                         });
                     }
 
-                    let Aggregation::Object(mut object) = event.data else {
+                    let Value::Object(mut object) = event.data else {
                         return Err(FromEventError::Individual {
                             interface,
                             base_path,

--- a/astarte-device-sdk-derive/src/lib.rs
+++ b/astarte-device-sdk-derive/src/lib.rs
@@ -506,7 +506,7 @@ pub fn astarte_aggregate_derive(input: TokenStream) -> TokenStream {
 ///
 /// ```no_compile
 /// #[derive(FromEvent)]
-/// #[from_event(interface = "com.example.Foo", path = "obj")]
+/// #[from_event(interface = "com.example.Foo", path = "/obj")]
 /// struct Foo {
 ///     bar: String
 /// }

--- a/e2e-test/src/main.rs
+++ b/e2e-test/src/main.rs
@@ -215,15 +215,14 @@ async fn main() -> eyre::Result<()> {
             } else if event.interface == test_cfg.interface_property_so {
                 let mut rx_data = rx_data_ind_prop.lock().await;
 
-                let mut path = event.path.clone();
-                path.remove(0); // Remove first forward slash
+                let path = event.path.as_str();
                 let (sensor_n, key) = path
-                    .split_once('/')
-                    .ok_or_else(|| eyre!("Incorrect path in message {:?}", event))?;
+                    .strip_prefix('/')
+                    .and_then(|s| s.split_once('/'))
+                    .unwrap_or_else(|| panic!("Incorrect path in message {:?}", event.clone()));
 
                 rx_data.0 = sensor_n.to_string();
-
-                match event.clone().data {
+                match event.data {
                     Value::Individual(var) => {
                         rx_data.1.insert(key.to_string(), var);
                     }

--- a/e2e-test/src/main.rs
+++ b/e2e-test/src/main.rs
@@ -32,6 +32,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use astarte_device_sdk::Aggregation;
 use astarte_device_sdk::Interface;
 use eyre::WrapErr;
 use itertools::Itertools;
@@ -201,7 +202,7 @@ async fn main() -> eyre::Result<()> {
             match event {
                 Ok(data) => {
                     if data.interface == test_cfg.interface_datastream_so {
-                        if let astarte_device_sdk::Aggregation::Individual(var) = data.data {
+                        if let Aggregation::Individual(var) = data.data {
                             let mut rx_data = rx_data_ind_datastream.lock().unwrap();
                             let mut key = data.path.clone();
                             key.remove(0);
@@ -222,8 +223,7 @@ async fn main() -> eyre::Result<()> {
                             panic!("Received unexpected message!");
                         }
                     } else if data.interface == test_cfg.interface_property_so {
-                        if let astarte_device_sdk::Aggregation::Individual(var) = data.clone().data
-                        {
+                        if let Aggregation::Individual(var) = data.clone().data {
                             let mut rx_data = rx_data_ind_prop.lock().unwrap();
                             let mut path = data.path.clone();
                             path.remove(0); // Remove first forward slash
@@ -609,12 +609,7 @@ async fn test_property_server_to_device(
             .lock()
             .map_err(|e| format!("Failed to lock the shared data. {e}"))?;
 
-        if (sensor_number.to_string() != rx_data_rw_acc.0)
-            || rx_data_rw_acc
-                .1
-                .iter()
-                .any(|(_, value)| value != &AstarteType::Unset)
-        {
+        if sensor_number.to_string() != rx_data_rw_acc.0 {
             return Err(format!(
                 "Incorrect received data. Server data: {rx_data_rw_acc:?}."
             ));

--- a/e2e-test/src/mock_data_datastream.rs
+++ b/e2e-test/src/mock_data_datastream.rs
@@ -197,6 +197,7 @@ impl MockDataDatastream {
         json_obj: &serde_json::Value,
     ) -> Result<Self, String> {
         let err = format!("Incorrectly formatted json: {json_obj:#?}.");
+
         let json_map = json_obj.get("data").ok_or(&err)?.as_object().ok_or(&err)?;
         let mut data = HashMap::new();
         for (key, value) in json_map {

--- a/e2e-test/src/utils.rs
+++ b/e2e-test/src/utils.rs
@@ -283,6 +283,5 @@ pub fn json_string_from_astarte_type(atype: AstarteType) -> String {
                     .join(",")
                 + "]"
         }
-        _ => "".to_string(),
     }
 }

--- a/examples/individual_datastream/main.rs
+++ b/examples/individual_datastream/main.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Error> {
         while let Some(event) = rx_events.recv().await {
             match event {
                 Ok(data) => {
-                    if let astarte_device_sdk::Aggregation::Individual(var) = data.data {
+                    if let astarte_device_sdk::Value::Individual(var) = data.data {
                         let mut iter = data.path.splitn(3, '/').skip(1);
                         let led_id = iter
                             .next()

--- a/examples/individual_properties/main.rs
+++ b/examples/individual_properties/main.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 
 use astarte_device_sdk::{
     builder::DeviceBuilder, error::Error, prelude::*, store::SqliteStore,
-    transport::mqtt::MqttConfig,
+    transport::mqtt::MqttConfig, Value,
 };
 
 type DynError = Box<dyn StdError + Send + Sync + 'static>;
@@ -128,7 +128,7 @@ async fn main() -> Result<(), DynError> {
         while let Some(event) = rx_events.recv().await {
             match event {
                 Ok(data) => {
-                    if let astarte_device_sdk::Aggregation::Individual(var) = data.data {
+                    if let Value::Individual(var) = data.data {
                         let mut iter = data.path.splitn(3, '/').skip(1);
                         let sensor_id = iter
                             .next()

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -96,6 +96,16 @@ impl Value {
         }
     }
 
+    /// Take out of the enum an [`AstarteType`] if the aggregate is
+    /// [`Individual`](Value::Individual).
+    pub fn take_individual(self) -> Option<AstarteType> {
+        if let Self::Individual(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
     /// Returns `true` if the aggregation is [`Object`].
     ///
     /// [`Object`]: Value::Object
@@ -106,6 +116,15 @@ impl Value {
 
     /// Get a reference to the [`HashMap`] if the aggregate is [`Object`](Value::Object).
     pub fn as_object(&self) -> Option<&HashMap<String, AstarteType>> {
+        if let Self::Object(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Take out of the enum an [`HashMap`] if the aggregate is [`Object`](Value::Object).
+    pub fn take_object(self) -> Option<HashMap<String, AstarteType>> {
         if let Self::Object(v) = self {
             Some(v)
         } else {

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -66,9 +66,9 @@ impl AstarteAggregate for HashMap<String, AstarteType> {
     }
 }
 
-/// Payload format for an Astarte device event data.
+/// Data for an [`Astarte data event`](crate::AstarteDeviceDataEvent).
 #[derive(Debug, Clone, PartialEq)]
-pub enum Aggregation {
+pub enum Value {
     /// Individual data, can be both from a datastream or property.
     Individual(AstarteType),
     /// Object data, also called aggregate. Can only be from a datastream.
@@ -77,17 +77,17 @@ pub enum Aggregation {
     Unset,
 }
 
-impl Aggregation {
+impl Value {
     /// Returns `true` if the aggregation is [`Individual`].
     ///
-    /// [`Individual`]: Aggregation::Individual
+    /// [`Individual`]: Value::Individual
     #[must_use]
     pub fn is_individual(&self) -> bool {
         matches!(self, Self::Individual(..))
     }
 
     /// Get a reference to the [`AstarteType`] if the aggregate is
-    /// [`Individual`](Aggregation::Individual).
+    /// [`Individual`](Value::Individual).
     pub fn as_individual(&self) -> Option<&AstarteType> {
         if let Self::Individual(v) = self {
             Some(v)
@@ -98,13 +98,13 @@ impl Aggregation {
 
     /// Returns `true` if the aggregation is [`Object`].
     ///
-    /// [`Object`]: Aggregation::Object
+    /// [`Object`]: Value::Object
     #[must_use]
     pub fn is_object(&self) -> bool {
         matches!(self, Self::Object(..))
     }
 
-    /// Get a reference to the [`HashMap`] if the aggregate is [`Object`](Aggregation::Object).
+    /// Get a reference to the [`HashMap`] if the aggregate is [`Object`](Value::Object).
     pub fn as_object(&self) -> Option<&HashMap<String, AstarteType>> {
         if let Self::Object(v) = self {
             Some(v)
@@ -115,7 +115,7 @@ impl Aggregation {
 
     /// Returns `true` if the aggregation is [`Unset`].
     ///
-    /// [`Unset`]: Aggregation::Unset
+    /// [`Unset`]: Value::Unset
     #[must_use]
     pub fn is_unset(&self) -> bool {
         matches!(self, Self::Unset)
@@ -129,16 +129,16 @@ mod tests {
     #[test]
     fn should_increase_coverage() {
         let individual = AstarteType::Integer(42);
-        let val = Aggregation::Individual(AstarteType::Integer(42));
+        let val = Value::Individual(AstarteType::Integer(42));
         assert!(val.is_individual());
         assert_eq!(val.as_individual(), Some(&individual));
         assert_eq!(val.as_object(), None);
 
-        let val = Aggregation::Object(HashMap::new());
+        let val = Value::Object(HashMap::new());
         assert!(val.is_object());
         assert_eq!(val.as_individual(), None);
         assert_eq!(val.as_object(), Some(&HashMap::new()));
 
-        assert!(Aggregation::Unset.is_unset());
+        assert!(Value::Unset.is_unset());
     }
 }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -73,6 +73,8 @@ pub enum Aggregation {
     Individual(AstarteType),
     /// Object data, also called aggregate. Can only be from a datastream.
     Object(HashMap<String, AstarteType>),
+    /// Unset of a property
+    Unset,
 }
 
 impl Aggregation {
@@ -109,5 +111,34 @@ impl Aggregation {
         } else {
             None
         }
+    }
+
+    /// Returns `true` if the aggregation is [`Unset`].
+    ///
+    /// [`Unset`]: Aggregation::Unset
+    #[must_use]
+    pub fn is_unset(&self) -> bool {
+        matches!(self, Self::Unset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_increase_coverage() {
+        let individual = AstarteType::Integer(42);
+        let val = Aggregation::Individual(AstarteType::Integer(42));
+        assert!(val.is_individual());
+        assert_eq!(val.as_individual(), Some(&individual));
+        assert_eq!(val.as_object(), None);
+
+        let val = Aggregation::Object(HashMap::new());
+        assert!(val.is_object());
+        assert_eq!(val.as_individual(), None);
+        assert_eq!(val.as_object(), Some(&HashMap::new()));
+
+        assert!(Aggregation::Unset.is_unset());
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -66,7 +66,7 @@ pub enum FromEventError {
 /// # Example
 ///
 /// ```rust
-/// use astarte_device_sdk::{Aggregation, AstarteDeviceDataEvent};
+/// use astarte_device_sdk::{Value, AstarteDeviceDataEvent};
 /// use astarte_device_sdk::event::{FromEvent, FromEventError};
 /// use astarte_device_sdk::interface::mapping::endpoint::Endpoint;
 ///
@@ -94,7 +94,7 @@ pub enum FromEventError {
 ///             });
 ///         }
 ///
-///         let Aggregation::Object(mut object) = event.data else {
+///         let Value::Object(mut object) = event.data else {
 ///             return Err(FromEventError::Individual {
 ///                 interface: "com.example.Sensor",
 ///                 base_path: "sensor",
@@ -136,7 +136,7 @@ mod tests {
     fn should_derive_form_event() {
         use std::collections::HashMap;
 
-        use crate::{Aggregation, FromEvent};
+        use crate::{FromEvent, Value};
 
         // Alias the crate to the resulting macro
         use crate::{self as astarte_device_sdk, AstarteDeviceDataEvent};
@@ -155,7 +155,7 @@ mod tests {
         let event = AstarteDeviceDataEvent {
             interface: "com.example.Sensor".to_string(),
             path: "/sensor".to_string(),
-            data: Aggregation::Object(data),
+            data: Value::Object(data),
         };
 
         let sensor = Sensor::from_event(event).expect("couldn't parse the event");

--- a/src/interface/mapping/path.rs
+++ b/src/interface/mapping/path.rs
@@ -190,17 +190,14 @@ fn parse_mapping(input: &str) -> Result<MappingPath, MappingError> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use crate::interface::mapping::endpoint::Level;
 
     use super::*;
 
-    /// Helper macro to create a `MappingPath` from a string literal.
-    #[macro_export]
-    macro_rules! mapping {
-        ($mapping:expr) => {
-            &$crate::MappingPath::try_from($mapping).expect("failed to create mapping path")
-        };
+    /// Helper to create a `MappingPath` from a string literal.
+    pub(crate) fn mapping(path: &str) -> MappingPath<'_> {
+        MappingPath::try_from(path).expect("failed to create mapping path")
     }
 
     #[test]
@@ -235,11 +232,11 @@ mod tests {
             ],
         };
 
-        assert_eq!(endpoint, *mapping!("/foo/value"));
-        assert_eq!(endpoint, *mapping!("/bar/value"));
-        assert_ne!(endpoint, *mapping!("/value"));
-        assert_ne!(endpoint, *mapping!("/foo/bar/value"));
-        assert_ne!(endpoint, *mapping!("/foo/value/bar"));
+        assert_eq!(endpoint, mapping("/foo/value"));
+        assert_eq!(endpoint, mapping("/bar/value"));
+        assert_ne!(endpoint, mapping("/value"));
+        assert_ne!(endpoint, mapping("/foo/bar/value"));
+        assert_ne!(endpoint, mapping("/foo/value/bar"));
     }
 
     #[test]
@@ -254,11 +251,11 @@ mod tests {
         };
 
         let cases = [
-            ((mapping!("/1/foo"), "bar"), Ordering::Equal),
-            ((mapping!("/1/foo"), "a"), Ordering::Less),
-            ((mapping!("/1"), "foo"), Ordering::Less),
-            ((mapping!("/1/foo"), "some"), Ordering::Greater),
-            ((mapping!("/1/foo/bar"), "some"), Ordering::Greater),
+            ((&mapping("/1/foo"), "bar"), Ordering::Equal),
+            ((&mapping("/1/foo"), "a"), Ordering::Less),
+            ((&mapping("/1"), "foo"), Ordering::Less),
+            ((&mapping("/1/foo"), "some"), Ordering::Greater),
+            ((&mapping("/1/foo/bar"), "some"), Ordering::Greater),
         ];
 
         for (mapping, exp) in cases {

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -164,7 +164,10 @@ impl Interface {
     }
 
     /// Get a [`MappingRef`] reference of the path if the endpoint is present in the interface.
-    pub(crate) fn as_mapping_ref(&self, path: &MappingPath) -> Option<MappingRef<&Interface>> {
+    pub(crate) fn as_mapping_ref<'a>(
+        &'a self,
+        path: &'a MappingPath,
+    ) -> Option<MappingRef<&Interface>> {
         MappingRef::new(self, path)
     }
 
@@ -620,14 +623,14 @@ mod tests {
         interface::{
             def::{DatabaseRetentionPolicyDef, RetentionDef},
             mapping::{
-                path::MappingPath,
+                path::{tests::mapping, MappingPath},
                 vec::{Item, MappingVec},
                 BaseMapping, DatastreamIndividualMapping,
             },
             Aggregation, DatabaseRetention, DatastreamIndividual, InterfaceType, InterfaceTypeDef,
             Mapping, MappingSet, MappingType, Ownership, Reliability, Retention,
         },
-        mapping, Interface,
+        Interface,
     };
 
     // The mappings are sorted alphabetically by endpoint, so we can confront them
@@ -892,7 +895,7 @@ mod tests {
         assert_eq!(interface.doc().unwrap(), r#"Interface doc "escaped""#);
         assert_eq!(
             *interface
-                .mapping(mapping!("/double_endpoint"))
+                .mapping(&mapping("/double_endpoint"))
                 .unwrap()
                 .doc()
                 .unwrap(),

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -110,10 +110,10 @@ impl Interfaces {
     /// # Errors
     ///
     /// Will return error if either the interface or the mapping is missing.
-    pub(crate) fn interface_mapping(
-        &self,
+    pub(crate) fn interface_mapping<'a>(
+        &'a self,
         interface_name: &str,
-        interface_path: &MappingPath,
+        interface_path: &'a MappingPath,
     ) -> Result<MappingRef<&Interface>, Error> {
         self.interfaces
             .get(interface_name)
@@ -133,10 +133,10 @@ impl Interfaces {
     /// # Errors
     ///
     /// Will return error if either the interface or the mapping is missing.
-    pub(crate) fn property_mapping(
-        &self,
+    pub(crate) fn property_mapping<'a>(
+        &'a self,
         interface_name: &str,
-        interface_path: &MappingPath,
+        interface_path: &'a MappingPath,
     ) -> Result<MappingRef<PropertyRef>, Error> {
         self.interfaces
             .get(interface_name)
@@ -309,7 +309,10 @@ pub(crate) mod tests {
 
     use super::*;
 
-    use crate::{builder::DeviceBuilder, interface::MappingType, mapping};
+    use crate::{
+        builder::DeviceBuilder,
+        interface::{mapping::path::tests::mapping, MappingType},
+    };
 
     pub(crate) const PROPERTIES_SERVER: &str = r#"
         {
@@ -390,8 +393,8 @@ pub(crate) mod tests {
 
     impl<'a> CheckEndpoint<'a> {
         pub(crate) fn check(&self) {
-            let path = mapping!(self.path);
-            let mapping = self.interfaces.interface_mapping(self.name, path).unwrap();
+            let path = mapping(self.path);
+            let mapping = self.interfaces.interface_mapping(self.name, &path).unwrap();
             assert_eq!(mapping.interface().interface_name(), self.name);
             assert_eq!(mapping.interface().version_major(), self.version_major);
             assert_eq!(mapping.mapping_type(), self.mapping_type);
@@ -430,15 +433,15 @@ pub(crate) mod tests {
         .check();
 
         assert!(matches!(
-            ifa.interface_mapping("org.astarte-platform.test.test", mapping!("/button/foo")),
+            ifa.interface_mapping("org.astarte-platform.test.test", &mapping("/button/foo")),
             Err(Error::MappingNotFound { .. })
         ));
         assert!(matches!(
-            ifa.interface_mapping("org.astarte-platform.test.test", mapping!("/foo/button")),
+            ifa.interface_mapping("org.astarte-platform.test.test", &mapping("/foo/button")),
             Err(Error::MappingNotFound { .. })
         ));
         assert!(matches!(
-            ifa.interface_mapping("org.astarte-platform.test.test", mapping!("/obj")),
+            ifa.interface_mapping("org.astarte-platform.test.test", &mapping("/obj")),
             Err(Error::MappingNotFound { .. })
         ));
     }
@@ -466,12 +469,12 @@ pub(crate) mod tests {
         assert!(matches!(
             ifa.interface_mapping(
                 "org.astarte-platform.test.test",
-                mapping!("/foo/bar/enable")
+                &mapping("/foo/bar/enable")
             ),
             Err(Error::MappingNotFound { .. })
         ));
         assert!(matches!(
-            ifa.interface_mapping("org.astarte-platform.test.test", mapping!("/obj")),
+            ifa.interface_mapping("org.astarte-platform.test.test", &mapping("/obj")),
             Err(Error::MappingNotFound { .. })
         ));
     }

--- a/src/transport/grpc/convert.rs
+++ b/src/transport/grpc/convert.rs
@@ -312,7 +312,7 @@ mod test {
     };
     use chrono::{DateTime, Utc};
 
-    use crate::{Aggregation, AstarteDeviceDataEvent};
+    use crate::{AstarteDeviceDataEvent, Value};
 
     use super::*;
 
@@ -327,16 +327,16 @@ mod test {
             let data = match payload {
                 // Unset
                 ProtoPayload::AstarteUnset(astarte_message_hub_proto::AstarteUnset {}) => {
-                    Aggregation::Unset
+                    Value::Unset
                 }
                 // Individual
                 ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
                     data: Some(ProtoData::AstarteIndividual(individual)),
-                }) => Aggregation::Individual(individual.try_into()?),
+                }) => Value::Individual(individual.try_into()?),
                 // Object
                 ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
                     data: Some(ProtoData::AstarteObject(obj)),
-                }) => Aggregation::Object(map_values_to_astarte_type(obj)?),
+                }) => Value::Object(map_values_to_astarte_type(obj)?),
                 // Error case
                 ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
                     data: None,
@@ -364,24 +364,24 @@ mod test {
         }
     }
 
-    impl From<Aggregation> for ProtoPayload {
-        fn from(value: Aggregation) -> Self {
+    impl From<Value> for ProtoPayload {
+        fn from(value: Value) -> Self {
             use astarte_message_hub_proto::astarte_data_type::Data;
 
             match value {
-                Aggregation::Individual(val) => {
+                Value::Individual(val) => {
                     ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
                         data: Some(Data::AstarteIndividual(val.into())),
                     })
                 }
-                Aggregation::Object(val) => {
+                Value::Object(val) => {
                     let object_data = val.into_iter().map(|(k, v)| (k, v.into())).collect();
 
                     ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
                         data: Some(Data::AstarteObject(AstarteDataTypeObject { object_data })),
                     })
                 }
-                Aggregation::Unset => {
+                Value::Unset => {
                     ProtoPayload::AstarteUnset(astarte_message_hub_proto::AstarteUnset {})
                 }
             }
@@ -667,7 +667,7 @@ mod test {
         let interface_name = "test.name.json".to_string();
         let interface_path = "test".to_string();
 
-        let astarte_type = Aggregation::Unset;
+        let astarte_type = Value::Unset;
         let payload: ProtoPayload = astarte_type.into();
 
         let astarte_message = AstarteMessage {
@@ -682,7 +682,7 @@ mod test {
         assert_eq!(interface_name, astarte_device_data_event.interface);
         assert_eq!(interface_path, astarte_device_data_event.path);
 
-        assert_eq!(Aggregation::Unset, astarte_device_data_event.data);
+        assert_eq!(Value::Unset, astarte_device_data_event.data);
     }
 
     #[test]
@@ -786,7 +786,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Unset,
+            data: Value::Unset,
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -821,7 +821,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -844,7 +844,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -867,7 +867,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -889,7 +889,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -912,7 +912,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -935,7 +935,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -958,7 +958,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -981,7 +981,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -1004,7 +1004,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -1027,7 +1027,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -1050,7 +1050,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -1074,7 +1074,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -1097,7 +1097,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -1120,7 +1120,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data.clone()),
+            data: Value::Individual(expected_data.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -1147,7 +1147,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Object(expected_map.clone()),
+            data: Value::Object(expected_map.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -1188,7 +1188,7 @@ mod test {
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Object(expected_map.clone()),
+            data: Value::Object(expected_map.clone()),
         };
 
         let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
@@ -1237,7 +1237,7 @@ mod test {
     fn from_sdk_astarte_aggregate_to_astarte_message_payload_success() {
         let expected_data: f64 = 15.5;
         use std::collections::HashMap;
-        let astarte_type_map = Aggregation::Object(HashMap::from([(
+        let astarte_type_map = Value::Object(HashMap::from([(
             "key1".to_string(),
             AstarteType::Double(expected_data),
         )]));

--- a/src/transport/grpc/convert.rs
+++ b/src/transport/grpc/convert.rs
@@ -25,16 +25,24 @@ use std::collections::HashMap;
 use std::num::TryFromIntError;
 use std::str::{FromStr, Utf8Error};
 
-use astarte_message_hub_proto::{astarte_message::Payload as ProtoPayload, pbjson_types};
-use chrono::DateTime;
+use astarte_message_hub_proto::astarte_data_type::Data as ProtoData;
+use astarte_message_hub_proto::types::InterfaceJson;
+use astarte_message_hub_proto::AstarteDataTypeObject;
+use astarte_message_hub_proto::{
+    astarte_data_type_individual::IndividualData as ProtoIndividualData,
+    astarte_message::Payload as ProtoPayload, pbjson_types,
+};
+use chrono::TimeZone;
+use itertools::Itertools;
 
+use crate::validate::ValidatedUnset;
+use crate::Interface;
 use crate::{
-    transport::grpc::GrpcReceivePayload, transport::ReceivedEvent, types::AstarteType,
-    validate::ValidatedIndividual, validate::ValidatedObject, Aggregation, AstarteDeviceDataEvent,
-    Timestamp,
+    transport::ReceivedEvent, types::AstarteType, validate::ValidatedIndividual,
+    validate::ValidatedObject,
 };
 
-use super::GrpcError;
+use super::{GrpcError, GrpcPayload};
 
 /// Error returned by the Message Hub types conversions.
 #[non_exhaustive]
@@ -48,10 +56,6 @@ pub enum MessageHubProtoError {
     #[error("Missing the expected field '{0}'")]
     ExpectedField(&'static str),
 
-    /// Cannot convert [`AstarteType::Unset`] to a proto [`IndividualData`]
-    #[error("Cannot perform conversion of an Unset to a proto IndividualData")]
-    UnsetConversion,
-
     /// Conversion error while trying to convert the byte array into a string
     #[error("The received byte array is not a valid utf8 string")]
     ByteToUtf8StringConversion(#[from] Utf8Error),
@@ -61,109 +65,62 @@ pub enum MessageHubProtoError {
     DateConversion(String),
 }
 
-/// Unwraps a variable chain of nested optionals by calling the [`Option::and_then`] assoctiated function
-/// The optional items can be properties or function that do not take parameters.
-/// Terminates the chain with an [`Option::ok_or`] method that returns a result
-/// # Example:
-/// `optional_chain!(payload.take_data().take_individual().individual_data);`
-///
-/// This would compile to code similar to:
-/// ```rust
-/// use astarte_device_sdk::transport::grpc::convert::MessageHubProtoError;
-/// use astarte_message_hub_proto::astarte_message::Payload;
-/// use astarte_message_hub_proto::AstarteUnset;
-/// let payload = Payload::AstarteUnset(AstarteUnset {});
-/// payload.take_data()
-///     .and_then(|d| d.take_individual())
-///     .and_then(|d| d.individual_data)
-///     .ok_or(MessageHubProtoError::ExpectedField("payload.take_data().take_individual().individual_data"));
-/// ```
-macro_rules! optional_chain {
-    // callable from outside first token is a function ident
-    ($wrapper:ident.$func:ident()$($token:tt)*) => {{
-        optional_chain!(@subprop ($wrapper.$func()) ($wrapper.$func()) $($token)*)
-    }};
+impl TryFrom<ProtoIndividualData> for AstarteType {
+    type Error = MessageHubProtoError;
 
-    // callable from outside first token is an ident
-    ($wrapper:ident.$ident:ident$($token:tt)*) => {{
-        optional_chain!(@subprop ($wrapper.$ident) ($wrapper.$ident) $($token)*)
-    }};
-
-    // match next identifier as function followed by one or more tokens
-    (@subprop ($msg_acc:expr) ($chain_acc:expr) .$func:ident()$($token:tt)*) => {
-        optional_chain!(@subprop ($msg_acc.$func()) ($chain_acc.and_then(|d| d.$func())) $($token)*)
-    };
-
-    // match next identifier as property followed by one or more tokens
-    (@subprop ($msg_acc:expr) ($chain_acc:expr) .$ident:ident$($token:tt)*) => {
-        optional_chain!(@subprop ($msg_acc.$ident) ($chain_acc.and_then(|d| d.$ident)) $($token)*)
-    };
-
-    // called to close the expression chain and append the message
-    (@subprop ($msg_acc:expr) ($chain_acc:expr)) => {
-        $chain_acc
-            .ok_or(MessageHubProtoError::ExpectedField(stringify!($msg_acc)))
-    };
-}
-
-/// This macro can be used to implement the TryFrom trait for the AstarteType from one or more of
-/// the protobuf types.
-macro_rules! impl_individual_data_to_astarte_type_conversion_traits {
-    (scalar $($typ:ident, $astartedatatype:ident),*; vector $($arraytyp:ident, $astartearraydatatype:ident),*) => {
-        use astarte_message_hub_proto::astarte_data_type_individual::IndividualData;
-
-        impl TryFrom<IndividualData> for AstarteType {
-            type Error = MessageHubProtoError;
-
-            fn try_from(
-                d: IndividualData
-            ) -> Result<Self, Self::Error> {
-
-                match d {
-                    $(
-                    IndividualData::$typ(val) => {
-                        Ok(AstarteType::$astartedatatype(val.into()))
-                    }
-                    )?
-                    IndividualData::AstarteDateTime(val) => {
-                        Ok(AstarteType::DateTime(val.try_into()
-                            .map_err(|e: &str| MessageHubProtoError::DateConversion(e.to_owned()))?))
-                    }
-                    $(
-                    IndividualData::$arraytyp(val) => {
-                        Ok(AstarteType::$astartearraydatatype(val.values.into()))
-                    }
-                    )?
-                    IndividualData::AstarteDateTimeArray(val) => {
-                        let timestamps = val.values.into_iter()
-                            .map(|t| t.try_into())
-                            .collect::<Result<Vec<DateTime<chrono::Utc>>, &str>>()
-                            .map_err(|e| MessageHubProtoError::DateConversion(e.to_owned()))?;
-
-                        Ok(AstarteType::DateTimeArray(timestamps))
-                    }
-                }
+    fn try_from(value: ProtoIndividualData) -> Result<Self, Self::Error> {
+        match value {
+            ProtoIndividualData::AstarteDouble(val) => Ok(AstarteType::Double(val)),
+            ProtoIndividualData::AstarteDoubleArray(val) => {
+                Ok(AstarteType::DoubleArray(val.values))
             }
+            ProtoIndividualData::AstarteInteger(val) => Ok(AstarteType::Integer(val)),
+            ProtoIndividualData::AstarteBoolean(val) => Ok(AstarteType::Boolean(val)),
+            ProtoIndividualData::AstarteLongInteger(val) => Ok(AstarteType::LongInteger(val)),
+            ProtoIndividualData::AstarteString(val) => Ok(AstarteType::String(val)),
+            ProtoIndividualData::AstarteBinaryBlob(val) => Ok(AstarteType::BinaryBlob(val)),
+            ProtoIndividualData::AstarteIntegerArray(val) => {
+                Ok(AstarteType::IntegerArray(val.values))
+            }
+            ProtoIndividualData::AstarteBooleanArray(val) => {
+                Ok(AstarteType::BooleanArray(val.values))
+            }
+            ProtoIndividualData::AstarteLongIntegerArray(val) => {
+                Ok(AstarteType::LongIntegerArray(val.values))
+            }
+            ProtoIndividualData::AstarteStringArray(val) => {
+                Ok(AstarteType::StringArray(val.values))
+            }
+            ProtoIndividualData::AstarteBinaryBlobArray(val) => {
+                Ok(AstarteType::BinaryBlobArray(val.values))
+            }
+            ProtoIndividualData::AstarteDateTime(val) => {
+                convert_timestamp(val).map(AstarteType::DateTime)
+            }
+            ProtoIndividualData::AstarteDateTimeArray(val) => val
+                .values
+                .into_iter()
+                .map(convert_timestamp)
+                .try_collect()
+                .map(AstarteType::DateTimeArray),
         }
     }
 }
 
-impl_individual_data_to_astarte_type_conversion_traits!(
-    scalar
-    AstarteDouble, Double,
-    AstarteInteger,  Integer,
-    AstarteBoolean, Boolean,
-    AstarteLongInteger,LongInteger,
-    AstarteString, String,
-    AstarteBinaryBlob, BinaryBlob;
-    vector
-    AstarteDoubleArray, DoubleArray,
-    AstarteIntegerArray, IntegerArray,
-    AstarteBooleanArray, BooleanArray,
-    AstarteLongIntegerArray, LongIntegerArray,
-    AstarteStringArray, StringArray,
-    AstarteBinaryBlobArray, BinaryBlobArray
-);
+/// Converts a [`pbjson_types::Timestamp`] into a [`chrono::DateTime<Utc>`]
+fn convert_timestamp(
+    val: pbjson_types::Timestamp,
+) -> Result<crate::Timestamp, MessageHubProtoError> {
+    let nanos = val
+        .nanos
+        .try_into()
+        .map_err(|err: TryFromIntError| MessageHubProtoError::DateConversion(err.to_string()))?;
+
+    chrono::Utc
+        .timestamp_opt(val.seconds, nanos)
+        .earliest()
+        .ok_or_else(|| MessageHubProtoError::DateConversion(format!("{val:?}")))
+}
 
 impl TryFrom<astarte_message_hub_proto::AstarteDataTypeIndividual> for AstarteType {
     type Error = MessageHubProtoError;
@@ -171,274 +128,265 @@ impl TryFrom<astarte_message_hub_proto::AstarteDataTypeIndividual> for AstarteTy
     fn try_from(
         value: astarte_message_hub_proto::AstarteDataTypeIndividual,
     ) -> Result<Self, Self::Error> {
-        optional_chain!(value.individual_data).and_then(TryInto::try_into)
+        value
+            .individual_data
+            .ok_or(MessageHubProtoError::ExpectedField("individual_data"))
+            .and_then(TryInto::try_into)
     }
 }
 
 /// Implements the TryFrom trait for the AstarteDataTypeIndividual for any AstarteType.
-macro_rules! impl_astarte_type_to_individual_data_conversion_traits {
-    ($($typ:ident),*) => {
-        impl TryFrom<AstarteType> for astarte_message_hub_proto::AstarteDataTypeIndividual {
-            type Error = MessageHubProtoError;
+impl From<AstarteType> for ProtoIndividualData {
+    fn from(value: AstarteType) -> Self {
+        use astarte_message_hub_proto::{
+            AstarteBinaryBlobArray, AstarteBooleanArray, AstarteDateTimeArray, AstarteDoubleArray,
+            AstarteIntegerArray, AstarteLongIntegerArray, AstarteStringArray,
+        };
 
-            fn try_from(d: AstarteType) -> Result<Self, Self::Error> {
-                match d {
-                    $(
-                    AstarteType::$typ(val) => Ok(val.into()),
-                    )*
-                    AstarteType::Unset => Err(MessageHubProtoError::UnsetConversion),
-                }
+        match value {
+            AstarteType::Double(value) => ProtoIndividualData::AstarteDouble(value),
+            AstarteType::Integer(value) => ProtoIndividualData::AstarteInteger(value),
+            AstarteType::Boolean(value) => ProtoIndividualData::AstarteBoolean(value),
+            AstarteType::LongInteger(value) => ProtoIndividualData::AstarteLongInteger(value),
+            AstarteType::String(value) => ProtoIndividualData::AstarteString(value),
+            AstarteType::BinaryBlob(value) => ProtoIndividualData::AstarteBinaryBlob(value),
+            AstarteType::DateTime(value) => ProtoIndividualData::AstarteDateTime(value.into()),
+            AstarteType::DoubleArray(values) => {
+                ProtoIndividualData::AstarteDoubleArray(AstarteDoubleArray { values })
+            }
+            AstarteType::IntegerArray(values) => {
+                ProtoIndividualData::AstarteIntegerArray(AstarteIntegerArray { values })
+            }
+            AstarteType::BooleanArray(values) => {
+                ProtoIndividualData::AstarteBooleanArray(AstarteBooleanArray { values })
+            }
+            AstarteType::LongIntegerArray(values) => {
+                ProtoIndividualData::AstarteLongIntegerArray(AstarteLongIntegerArray { values })
+            }
+            AstarteType::StringArray(values) => {
+                ProtoIndividualData::AstarteStringArray(AstarteStringArray { values })
+            }
+            AstarteType::BinaryBlobArray(values) => {
+                ProtoIndividualData::AstarteBinaryBlobArray(AstarteBinaryBlobArray { values })
+            }
+            AstarteType::DateTimeArray(values) => {
+                ProtoIndividualData::AstarteDateTimeArray(AstarteDateTimeArray {
+                    values: values
+                        .into_iter()
+                        .map(pbjson_types::Timestamp::from)
+                        .collect(),
+                })
             }
         }
     }
 }
 
-impl_astarte_type_to_individual_data_conversion_traits!(
-    Double,
-    Integer,
-    Boolean,
-    LongInteger,
-    String,
-    BinaryBlob,
-    DateTime,
-    DoubleArray,
-    IntegerArray,
-    BooleanArray,
-    LongIntegerArray,
-    StringArray,
-    BinaryBlobArray,
-    DateTimeArray
-);
-
-impl TryFrom<astarte_message_hub_proto::AstarteMessage> for AstarteDeviceDataEvent {
-    type Error = MessageHubProtoError;
-
-    fn try_from(
-        astarte_message: astarte_message_hub_proto::AstarteMessage,
-    ) -> Result<Self, Self::Error> {
-        let astarte_sdk_aggregation = match optional_chain!(astarte_message.payload)? {
-            ProtoPayload::AstarteData(astarte_data_type) => {
-                match optional_chain!(astarte_data_type.data)? {
-                    astarte_message_hub_proto::astarte_data_type::Data::AstarteIndividual(
-                        astarte_individual,
-                    ) => Aggregation::Individual(
-                        optional_chain!(astarte_individual.individual_data)?.try_into()?,
-                    ),
-                    astarte_message_hub_proto::astarte_data_type::Data::AstarteObject(
-                        astarte_object,
-                    ) => map_values_to_astarte_type(astarte_object.object_data)
-                        .map(Aggregation::Object)?,
-                }
-            }
-            ProtoPayload::AstarteUnset(_) => Aggregation::Individual(AstarteType::Unset),
-        };
-
-        Ok(AstarteDeviceDataEvent {
-            interface: astarte_message.interface_name,
-            path: astarte_message.path,
-            data: astarte_sdk_aggregation,
-        })
+impl From<AstarteType> for astarte_message_hub_proto::AstarteDataTypeIndividual {
+    fn from(value: AstarteType) -> Self {
+        Self {
+            individual_data: Some(value.into()),
+        }
     }
 }
 
-impl TryFrom<astarte_message_hub_proto::types::InterfaceJson> for crate::Interface {
+impl TryFrom<InterfaceJson> for Interface {
     type Error = crate::Error;
 
-    fn try_from(
-        interface: astarte_message_hub_proto::types::InterfaceJson,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(interface: InterfaceJson) -> Result<Self, Self::Error> {
         let interface_str = std::str::from_utf8(&interface.0).map_err(|err| {
             GrpcError::MessageHubProtoConversion(MessageHubProtoError::ByteToUtf8StringConversion(
                 err,
             ))
         })?;
 
-        crate::Interface::from_str(interface_str).map_err(Self::Error::Interface)
+        Interface::from_str(interface_str).map_err(Self::Error::Interface)
     }
 }
 
-impl TryFrom<AstarteDeviceDataEvent> for astarte_message_hub_proto::AstarteMessage {
-    type Error = MessageHubProtoError;
-
-    fn try_from(value: AstarteDeviceDataEvent) -> Result<Self, Self::Error> {
-        let payload: ProtoPayload = value.data.try_into()?;
-
-        Ok(astarte_message_hub_proto::AstarteMessage {
-            interface_name: value.interface.clone(),
-            path: value.path.clone(),
-            timestamp: None,
-            payload: Some(payload),
+impl From<AstarteType> for ProtoPayload {
+    fn from(value: AstarteType) -> Self {
+        ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
+            data: Some(ProtoData::AstarteIndividual(value.into())),
         })
     }
 }
 
-impl TryFrom<astarte_message_hub_proto::AstarteMessage> for ReceivedEvent<GrpcReceivePayload> {
+impl TryFrom<astarte_message_hub_proto::AstarteMessage> for ReceivedEvent<GrpcPayload> {
     type Error = MessageHubProtoError;
 
     fn try_from(message: astarte_message_hub_proto::AstarteMessage) -> Result<Self, Self::Error> {
-        let interface = message.interface_name;
-        let path = message.path;
-
-        let data = message
+        let payload = message
             .payload
             .ok_or(MessageHubProtoError::ExpectedField("payload"))?;
 
-        let timestamp: Option<Timestamp> =
-            message
-                .timestamp
-                .map(Timestamp::try_from)
-                .transpose()
-                .map_err(|e| MessageHubProtoError::DateConversion(e.to_owned()))?;
+        let timestamp = message.timestamp.map(convert_timestamp).transpose()?;
 
         Ok(ReceivedEvent {
-            interface,
-            path,
-            payload: GrpcReceivePayload::new(data, timestamp),
+            interface: message.interface_name,
+            path: message.path,
+            payload: GrpcPayload::new(payload, timestamp),
         })
     }
 }
 
-impl<'a> TryFrom<ValidatedIndividual<'a>> for astarte_message_hub_proto::AstarteMessage {
-    type Error = MessageHubProtoError;
-
-    fn try_from(value: ValidatedIndividual<'a>) -> Result<Self, Self::Error> {
+impl<'a> From<ValidatedIndividual<'a>> for astarte_message_hub_proto::AstarteMessage {
+    fn from(value: ValidatedIndividual<'a>) -> Self {
         let interface_name = value.mapping().interface().interface_name().to_owned();
         let path = value.path().as_str().to_owned();
-        let timestamp: Option<pbjson_types::Timestamp> = value.timestamp().map(|t| t.into());
-        let payload: Option<ProtoPayload> = Some(value.into_data().try_into()?);
 
-        Ok(astarte_message_hub_proto::AstarteMessage {
-            interface_name,
-            path,
-            timestamp,
-            payload,
-        })
-    }
-}
-
-impl<'a> TryFrom<ValidatedObject<'a>> for astarte_message_hub_proto::AstarteMessage {
-    type Error = MessageHubProtoError;
-
-    fn try_from(value: ValidatedObject<'a>) -> Result<Self, Self::Error> {
-        let interface_name = value.object().interface.interface_name().to_owned();
-        let path = value.path().as_str().to_owned();
         let timestamp = value.timestamp().map(|t| t.into());
-        let astarte_data: astarte_message_hub_proto::AstarteDataType = value.into_data()
-            .into_iter()
-            .map(|(k, v)| v.try_into().map(|t| (k, t)))
-            .collect::<Result<HashMap<String, astarte_message_hub_proto::AstarteDataTypeIndividual>, _>>()?
-            .into();
 
-        let payload = Some(ProtoPayload::AstarteData(astarte_data));
+        let payload = Some(value.into_data().into());
 
-        Ok(astarte_message_hub_proto::AstarteMessage {
+        astarte_message_hub_proto::AstarteMessage {
             interface_name,
             path,
             timestamp,
             payload,
-        })
+        }
     }
 }
 
-impl TryFrom<Aggregation> for ProtoPayload {
-    type Error = MessageHubProtoError;
+impl<'a> From<ValidatedObject<'a>> for astarte_message_hub_proto::AstarteMessage {
+    fn from(value: ValidatedObject<'a>) -> Self {
+        let interface_name = value.interface().interface_name().to_string();
+        let path = value.path().to_string();
+        let timestamp = value.timestamp().map(|t| t.into());
 
-    fn try_from(value: Aggregation) -> Result<Self, Self::Error> {
-        use astarte_message_hub_proto::astarte_data_type::Data;
+        let object_data = value
+            .into_data()
+            .into_iter()
+            .map(|(k, v)| (k, v.into()))
+            .collect();
 
-        let payload = match value {
-            Aggregation::Individual(astarte_type) => {
-                if let AstarteType::Unset = astarte_type {
-                    ProtoPayload::AstarteUnset(astarte_message_hub_proto::AstarteUnset {})
-                } else {
-                    let individual_type = astarte_type.try_into()?;
+        let payload = Some(ProtoPayload::AstarteData(
+            astarte_message_hub_proto::AstarteDataType {
+                data: Some(
+                    astarte_message_hub_proto::astarte_data_type::Data::AstarteObject(
+                        astarte_message_hub_proto::AstarteDataTypeObject { object_data },
+                    ),
+                ),
+            },
+        ));
 
-                    ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
-                        data: Some(Data::AstarteIndividual(individual_type)),
-                    })
-                }
-            }
-            Aggregation::Object(astarte_map) => {
-                let astarte_data = astarte_map
-                    .into_iter()
-                    .map(|(k, v)| (k, v.try_into().unwrap()))
-                    .collect::<HashMap<String, astarte_message_hub_proto::AstarteDataTypeIndividual>>()
-                    .into();
-
-                ProtoPayload::AstarteData(astarte_data)
-            }
-        };
-
-        Ok(payload)
+        astarte_message_hub_proto::AstarteMessage {
+            interface_name,
+            path,
+            timestamp,
+            payload,
+        }
     }
 }
 
-impl TryFrom<AstarteType> for ProtoPayload {
-    type Error = MessageHubProtoError;
-
-    fn try_from(astarte_device_sdk_type: AstarteType) -> Result<Self, Self::Error> {
-        use astarte_message_hub_proto::astarte_data_type::Data;
-        use astarte_message_hub_proto::AstarteDataType;
-
-        let payload = match astarte_device_sdk_type {
-            AstarteType::Unset => {
-                ProtoPayload::AstarteUnset(astarte_message_hub_proto::AstarteUnset {})
-            }
-            astarte_device_sdk_type => ProtoPayload::AstarteData(AstarteDataType {
-                data: Some(Data::AstarteIndividual(astarte_device_sdk_type.try_into()?)),
-            }),
-        };
-
-        Ok(payload)
+impl<'a> From<ValidatedUnset<'a>> for astarte_message_hub_proto::AstarteMessage {
+    fn from(value: ValidatedUnset<'a>) -> Self {
+        Self {
+            interface_name: value.prop().interface_name().to_string(),
+            path: value.path().to_string(),
+            timestamp: None,
+            payload: Some(ProtoPayload::AstarteUnset(
+                astarte_message_hub_proto::AstarteUnset {},
+            )),
+        }
     }
-}
-
-/// This function can be used to convert a map of (String, crate:types::AstarteType) into a
-/// map of (String,  AstarteDataTypeIndividual).
-pub fn map_values_to_astarte_data_type_individual(
-    value: HashMap<String, AstarteType>,
-) -> Result<
-    HashMap<String, astarte_message_hub_proto::AstarteDataTypeIndividual>,
-    MessageHubProtoError,
-> {
-    value
-        .into_iter()
-        .map(|(k, astarte_type)| astarte_type.try_into().map(|v| (k, v)))
-        .collect()
 }
 
 /// This function can be used to convert a map of (String, AstarteDataTypeIndividual) into a
 /// map of (String, AstarteType).
 /// It can be useful when a method accept an astarte_device_sdk::AstarteAggregate.
-pub fn map_values_to_astarte_type(
-    value: HashMap<String, astarte_message_hub_proto::AstarteDataTypeIndividual>,
+pub(crate) fn map_values_to_astarte_type(
+    value: AstarteDataTypeObject,
 ) -> Result<HashMap<String, AstarteType>, MessageHubProtoError> {
     value
+        .object_data
         .into_iter()
-        .map(|(k, astarte_data)| {
-            optional_chain!(astarte_data.individual_data)
-                .and_then(AstarteType::try_from)
-                .map(|v| (k, v))
-        })
+        .map(|(k, value)| AstarteType::try_from(value).map(|v| (k, v)))
         .collect()
 }
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
     use astarte_message_hub_proto::{
-        astarte_message::Payload as ProtoPayload,
-        pbjson_types, {AstarteDataTypeIndividual, AstarteMessage},
+        astarte_data_type_individual::IndividualData, astarte_message::Payload as ProtoPayload,
+        AstarteMessage,
     };
     use chrono::{DateTime, Utc};
 
     use crate::{Aggregation, AstarteDeviceDataEvent};
 
-    use super::map_values_to_astarte_data_type_individual;
-    use super::AstarteType;
-    use super::IndividualData;
-    use super::MessageHubProtoError;
+    use super::*;
+
+    impl TryFrom<astarte_message_hub_proto::AstarteMessage> for AstarteDeviceDataEvent {
+        type Error = MessageHubProtoError;
+
+        fn try_from(value: astarte_message_hub_proto::AstarteMessage) -> Result<Self, Self::Error> {
+            let payload = value
+                .payload
+                .ok_or(MessageHubProtoError::ExpectedField("payload"))?;
+
+            let data = match payload {
+                // Unset
+                ProtoPayload::AstarteUnset(astarte_message_hub_proto::AstarteUnset {}) => {
+                    Aggregation::Unset
+                }
+                // Individual
+                ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
+                    data: Some(ProtoData::AstarteIndividual(individual)),
+                }) => Aggregation::Individual(individual.try_into()?),
+                // Object
+                ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
+                    data: Some(ProtoData::AstarteObject(obj)),
+                }) => Aggregation::Object(map_values_to_astarte_type(obj)?),
+                // Error case
+                ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
+                    data: None,
+                }) => return Err(MessageHubProtoError::ExpectedField("data")),
+            };
+
+            Ok(Self {
+                interface: value.interface_name,
+                path: value.path,
+                data,
+            })
+        }
+    }
+
+    impl From<AstarteDeviceDataEvent> for astarte_message_hub_proto::AstarteMessage {
+        fn from(value: AstarteDeviceDataEvent) -> Self {
+            let payload: ProtoPayload = value.data.into();
+
+            astarte_message_hub_proto::AstarteMessage {
+                interface_name: value.interface,
+                path: value.path,
+                timestamp: None,
+                payload: Some(payload),
+            }
+        }
+    }
+
+    impl From<Aggregation> for ProtoPayload {
+        fn from(value: Aggregation) -> Self {
+            use astarte_message_hub_proto::astarte_data_type::Data;
+
+            match value {
+                Aggregation::Individual(val) => {
+                    ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
+                        data: Some(Data::AstarteIndividual(val.into())),
+                    })
+                }
+                Aggregation::Object(val) => {
+                    let object_data = val.into_iter().map(|(k, v)| (k, v.into())).collect();
+
+                    ProtoPayload::AstarteData(astarte_message_hub_proto::AstarteDataType {
+                        data: Some(Data::AstarteObject(AstarteDataTypeObject { object_data })),
+                    })
+                }
+                Aggregation::Unset => {
+                    ProtoPayload::AstarteUnset(astarte_message_hub_proto::AstarteUnset {})
+                }
+            }
+        }
+    }
 
     #[test]
     fn proto_astarte_double_into_astarte_device_sdk_type_success() {
@@ -661,7 +609,7 @@ mod test {
         let interface_path = "test".to_string();
 
         let astarte_type: AstarteType = expected_data.try_into().unwrap();
-        let payload: ProtoPayload = astarte_type.try_into().unwrap();
+        let payload: ProtoPayload = astarte_type.into();
 
         let astarte_message = AstarteMessage {
             interface_name: interface_name.clone(),
@@ -675,14 +623,7 @@ mod test {
         assert_eq!(interface_name, astarte_device_data_event.interface);
         assert_eq!(interface_path, astarte_device_data_event.path);
 
-        match astarte_device_data_event.data {
-            Aggregation::Individual(value) => {
-                assert_eq!(value, expected_data)
-            }
-            Aggregation::Object(_) => {
-                panic!()
-            }
-        }
+        astarte_device_data_event.data.as_individual().unwrap();
     }
 
     #[test]
@@ -709,21 +650,16 @@ mod test {
         assert_eq!(interface_name, astarte_device_data_event.interface);
         assert_eq!(interface_path, astarte_device_data_event.path);
 
-        match astarte_device_data_event.data {
-            Aggregation::Individual(_) => {
-                panic!()
-            }
-            Aggregation::Object(object_map) => {
-                assert_eq!(
-                    object_map.get("1").unwrap().clone(),
-                    AstarteType::try_from(expected_data_f64).unwrap()
-                );
-                assert_eq!(
-                    object_map.get("2").unwrap().clone(),
-                    AstarteType::from(expected_data_i32)
-                );
-            }
-        }
+        let object_map = astarte_device_data_event.data.as_object().unwrap();
+
+        assert_eq!(
+            object_map.get("1").unwrap().clone(),
+            AstarteType::try_from(expected_data_f64).unwrap()
+        );
+        assert_eq!(
+            object_map.get("2").unwrap().clone(),
+            AstarteType::from(expected_data_i32)
+        );
     }
 
     #[test]
@@ -731,8 +667,8 @@ mod test {
         let interface_name = "test.name.json".to_string();
         let interface_path = "test".to_string();
 
-        let astarte_type: AstarteType = AstarteType::Unset;
-        let payload: ProtoPayload = astarte_type.try_into().unwrap();
+        let astarte_type = Aggregation::Unset;
+        let payload: ProtoPayload = astarte_type.into();
 
         let astarte_message = AstarteMessage {
             interface_name: interface_name.clone(),
@@ -746,47 +682,29 @@ mod test {
         assert_eq!(interface_name, astarte_device_data_event.interface);
         assert_eq!(interface_path, astarte_device_data_event.path);
 
-        match astarte_device_data_event.data {
-            Aggregation::Individual(value) => {
-                assert_eq!(AstarteType::Unset, value)
-            }
-            Aggregation::Object(_) => {
-                panic!()
-            }
-        }
+        assert_eq!(Aggregation::Unset, astarte_device_data_event.data);
     }
 
     #[test]
     fn convert_map_values_to_astarte_astarte_data_type_individual_success() {
         let expected_data: f64 = 15.5;
-        use std::collections::HashMap;
         let astarte_type_map =
             HashMap::from([("key1".to_string(), AstarteType::Double(expected_data))]);
 
-        let conversion_map_result = map_values_to_astarte_data_type_individual(astarte_type_map);
-        assert!(conversion_map_result.is_ok());
+        let conversion_map_result: HashMap<String, ProtoIndividualData> = astarte_type_map
+            .into_iter()
+            .map(|(k, v)| (k, v.into()))
+            .collect();
 
-        let astarte_individual_map = conversion_map_result.unwrap();
-
-        if let IndividualData::AstarteDouble(double_data) = astarte_individual_map
-            .get("key1")
-            .unwrap()
-            .individual_data
-            .clone()
-            .unwrap()
-        {
-            assert_eq!(expected_data, double_data)
-        } else {
-            panic!()
-        }
+        let individual_data = conversion_map_result.get("key1").unwrap();
+        assert_eq!(
+            ProtoIndividualData::AstarteDouble(expected_data),
+            *individual_data
+        );
     }
 
     #[test]
     fn convert_proto_interface_to_astarte_interface() {
-        use crate::Interface;
-
-        use astarte_message_hub_proto::types::InterfaceJson;
-
         const SERV_PROPS_IFACE: &str = r#"
         {
             "interface_name": "org.astarte-platform.test.test",
@@ -822,10 +740,6 @@ mod test {
 
     #[tokio::test]
     async fn convert_proto_interface_with_special_chars_to_astarte_interface() {
-        use crate::Interface;
-
-        use astarte_message_hub_proto::types::InterfaceJson;
-
         const IFACE_SPECIAL_CHARS: &str = r#"
         {
             "interface_name": "org.astarte-platform.test.test",
@@ -857,10 +771,6 @@ mod test {
 
     #[tokio::test]
     async fn convert_bad_proto_interface_to_astarte_interface() {
-        use crate::Interface;
-
-        use astarte_message_hub_proto::types::InterfaceJson;
-
         const IFACE_BAD: &str = r#"{"#;
 
         let interface = InterfaceJson(IFACE_BAD.into());
@@ -872,30 +782,14 @@ mod test {
     }
 
     #[test]
-    fn convert_astarte_type_unset_give_conversion_error() {
-        let expected_data = AstarteType::Unset;
-
-        let result: Result<AstarteDataTypeIndividual, MessageHubProtoError> =
-            expected_data.try_into();
-
-        assert!(result.is_err());
-        assert!(matches!(
-            result.err().unwrap(),
-            MessageHubProtoError::UnsetConversion
-        ));
-    }
-
-    #[test]
     fn convert_astarte_device_data_event_unset_to_astarte_message() {
-        let expected_data = AstarteType::Unset;
-
         let astarte_device_data_event = AstarteDeviceDataEvent {
             interface: "test.name.json".to_owned(),
             path: "test".to_owned(),
-            data: Aggregation::Individual(expected_data),
+            data: Aggregation::Unset,
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -910,7 +804,14 @@ mod test {
     fn get_individual_data_from_payload(
         payload: ProtoPayload,
     ) -> Result<AstarteType, MessageHubProtoError> {
-        optional_chain!(payload.take_data().take_individual().individual_data)?.try_into()
+        payload
+            .take_data()
+            .expect("data")
+            .take_individual()
+            .expect("individual")
+            .individual_data
+            .expect("individual_data")
+            .try_into()
     }
 
     #[test]
@@ -923,7 +824,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -946,7 +847,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -969,7 +870,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -991,7 +892,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1014,7 +915,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1037,7 +938,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1060,7 +961,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1083,7 +984,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1106,7 +1007,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1129,7 +1030,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1152,7 +1053,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1176,7 +1077,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1199,7 +1100,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1222,7 +1123,7 @@ mod test {
             data: Aggregation::Individual(expected_data.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1249,7 +1150,7 @@ mod test {
             data: Aggregation::Object(expected_map.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1290,7 +1191,7 @@ mod test {
             data: Aggregation::Object(expected_map.clone()),
         };
 
-        let astarte_message: AstarteMessage = astarte_device_data_event.clone().try_into().unwrap();
+        let astarte_message: AstarteMessage = astarte_device_data_event.clone().into();
         assert_eq!(
             astarte_device_data_event.interface,
             astarte_message.interface_name
@@ -1318,7 +1219,7 @@ mod test {
         let expected_double_value: f64 = 15.5;
         let astarte_sdk_type_double = AstarteType::Double(expected_double_value);
 
-        let payload: ProtoPayload = astarte_sdk_type_double.try_into().unwrap();
+        let payload: ProtoPayload = astarte_sdk_type_double.into();
 
         let double_value = payload
             .take_data()
@@ -1341,14 +1242,10 @@ mod test {
             AstarteType::Double(expected_data),
         )]));
 
-        let payload_result: Result<ProtoPayload, MessageHubProtoError> =
-            astarte_type_map.try_into();
-        assert!(payload_result.is_ok());
+        let mut payload_result: ProtoPayload = astarte_type_map.into();
 
         let double_data = payload_result
-            .ok()
-            .as_mut()
-            .and_then(ProtoPayload::data_mut)
+            .data_mut()
             .and_then(astarte_message_hub_proto::AstarteDataType::object_mut)
             .and_then(|data| data.object_data.remove("key1"))
             .and_then(|data| data.individual_data)

--- a/src/transport/grpc/mod.rs
+++ b/src/transport/grpc/mod.rs
@@ -473,7 +473,7 @@ mod test {
     use crate::{
         error,
         transport::test::{mock_shared_device, mock_validate_individual, mock_validate_object},
-        Aggregation, AstarteAggregate, AstarteDeviceDataEvent,
+        AstarteAggregate, AstarteDeviceDataEvent, Value,
     };
 
     use super::*;
@@ -910,7 +910,7 @@ mod test {
             => data_event = AstarteDeviceDataEvent::try_from(m).expect("Malformed message");
                 if data_event.interface == "org.astarte-platform.rust.examples.individual-properties.DeviceProperties"
                 && data_event.path == "/1/name"
-                && matches!(data_event.data, Aggregation::Individual(AstarteType::String(v)) if v == STRING_VALUE),
+                && matches!(data_event.data, Value::Individual(AstarteType::String(v)) if v == STRING_VALUE),
             ServerReceivedRequest::Detach(d) if d.uuid == ID.to_string()
         );
     }
@@ -975,7 +975,7 @@ mod test {
             => data_event = AstarteDeviceDataEvent::try_from(m).expect("Malformed message");
                 if data_event.interface == "org.astarte-platform.rust.examples.object-datastream.DeviceDatastream"
                     && data_event.path == "/1",
-            => object_value = {  let Aggregation::Object(v) = data_event.data else { panic!("Expected object") }; v };
+            => object_value = {  let Value::Object(v) = data_event.data else { panic!("Expected object") }; v };
                 if object_value["endpoint1"] == AstarteType::Double(4.2)
                     && object_value["endpoint2"] == AstarteType::String("obj".to_string())
                     && object_value["endpoint3"] == AstarteType::BooleanArray(vec![true])
@@ -989,7 +989,7 @@ mod test {
             .await
             .expect("Could not construct test client and server");
 
-        let expected_object = Aggregation::Object((MockObject {}).astarte_aggregate().unwrap());
+        let expected_object = Value::Object((MockObject {}).astarte_aggregate().unwrap());
 
         let proto_payload: astarte_message_hub_proto::astarte_message::Payload =
             expected_object.into();

--- a/src/transport/grpc/mod.rs
+++ b/src/transport/grpc/mod.rs
@@ -34,11 +34,12 @@ use astarte_message_hub_proto::tonic::service::Interceptor;
 use astarte_message_hub_proto::tonic::transport::Channel;
 use astarte_message_hub_proto::tonic::{Request, Status};
 use astarte_message_hub_proto::{
-    astarte_message::Payload, message_hub_client::MessageHubClient, tonic, AstarteMessage, Node,
+    astarte_message::Payload as ProtoPayload, message_hub_client::MessageHubClient, tonic,
+    AstarteMessage, Node,
 };
 use async_trait::async_trait;
 use itertools::Itertools;
-use log::trace;
+use log::{debug, trace};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
@@ -51,14 +52,15 @@ use crate::{
     interfaces::{self, Interfaces},
     shared::SharedDevice,
     store::PropertyStore,
+    transport::grpc::convert::map_values_to_astarte_type,
     types::AstarteType,
-    validate::{ValidatedIndividual, ValidatedObject},
+    validate::{ValidatedIndividual, ValidatedObject, ValidatedUnset},
     Interface, Timestamp,
 };
 
 use super::{Disconnect, Publish, Receive, ReceivedEvent, Register};
 
-use self::convert::{map_values_to_astarte_type, MessageHubProtoError};
+use self::convert::MessageHubProtoError;
 
 /// Errors raised while using the [`Grpc`] transport
 #[non_exhaustive]
@@ -198,9 +200,7 @@ impl Publish for Grpc {
         self.client
             .lock()
             .await
-            .send(tonic::Request::new(
-                data.try_into().map_err(GrpcError::from)?,
-            ))
+            .send(tonic::Request::new(data.into()))
             .await
             .map(|_| ())
             .map_err(|e| GrpcError::from(e).into())
@@ -210,9 +210,17 @@ impl Publish for Grpc {
         self.client
             .lock()
             .await
-            .send(tonic::Request::new(
-                data.try_into().map_err(GrpcError::from)?,
-            ))
+            .send(tonic::Request::new(data.into()))
+            .await
+            .map(|_| ())
+            .map_err(|e| GrpcError::from(e).into())
+    }
+
+    async fn unset(&self, data: ValidatedUnset<'_>) -> Result<(), crate::Error> {
+        self.client
+            .lock()
+            .await
+            .send(tonic::Request::new(data.into()))
             .await
             .map(|_| ())
             .map_err(|e| GrpcError::from(e).into())
@@ -229,7 +237,7 @@ impl Deref for Grpc {
 
 #[async_trait]
 impl Receive for Grpc {
-    type Payload = GrpcReceivePayload;
+    type Payload = GrpcPayload;
 
     async fn next_event<S>(
         &self,
@@ -241,8 +249,9 @@ impl Receive for Grpc {
         loop {
             match self.next_message().await {
                 Ok(Some(message)) => {
-                    let event: ReceivedEvent<Self::Payload> =
-                        message.try_into().map_err(GrpcError::from)?;
+                    let event: ReceivedEvent<Self::Payload> = message
+                        .try_into()
+                        .map_err(GrpcError::MessageHubProtoConversion)?;
 
                     return Ok(event);
                 }
@@ -270,15 +279,15 @@ impl Receive for Grpc {
 
     fn deserialize_individual(
         &self,
-        _mapping: MappingRef<'_, &Interface>,
+        _mapping: &MappingRef<'_, &Interface>,
         payload: Self::Payload,
-    ) -> Result<(AstarteType, Option<Timestamp>), crate::Error> {
+    ) -> Result<Option<(AstarteType, Option<Timestamp>)>, crate::Error> {
         let data = match payload.data {
-            Payload::AstarteData(data) => data,
-            Payload::AstarteUnset(astarte_message_hub_proto::AstarteUnset {}) => {
-                trace!("unset received");
+            ProtoPayload::AstarteData(data) => data,
+            ProtoPayload::AstarteUnset(astarte_message_hub_proto::AstarteUnset {}) => {
+                debug!("unset received");
 
-                return Ok((AstarteType::Unset, payload.timestamp));
+                return Ok(None);
             }
         };
 
@@ -293,12 +302,12 @@ impl Receive for Grpc {
 
         trace!("received {}", data.display_type());
 
-        Ok((data, payload.timestamp))
+        Ok(Some((data, payload.timestamp)))
     }
 
     fn deserialize_object(
         &self,
-        _object: ObjectRef,
+        _object: &ObjectRef,
         _path: &MappingPath<'_>,
         payload: Self::Payload,
     ) -> Result<(HashMap<String, AstarteType>, Option<Timestamp>), crate::Error> {
@@ -308,8 +317,8 @@ impl Receive for Grpc {
             .and_then(|d| d.take_object())
             .ok_or(GrpcError::DeserializationExpectedObject)?;
 
-        let data = map_values_to_astarte_type(object.object_data)
-            .map_err(GrpcError::MessageHubProtoConversion)?;
+        let data =
+            map_values_to_astarte_type(object).map_err(GrpcError::MessageHubProtoConversion)?;
 
         trace!("object received");
 
@@ -372,13 +381,13 @@ impl Disconnect for Grpc {
 
 /// Internal struct holding the received grpc message
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct GrpcReceivePayload {
-    data: Payload,
+pub(crate) struct GrpcPayload {
+    data: ProtoPayload,
     timestamp: Option<Timestamp>,
 }
 
-impl GrpcReceivePayload {
-    pub(crate) fn new(data: Payload, timestamp: Option<Timestamp>) -> Self {
+impl GrpcPayload {
+    pub(crate) fn new(data: ProtoPayload, timestamp: Option<Timestamp>) -> Self {
         Self { data, timestamp }
     }
 }
@@ -455,7 +464,7 @@ mod test {
 
     use astarte_message_hub_proto::{
         message_hub_server::{MessageHub, MessageHubServer},
-        pbjson_types,
+        pbjson_types, AstarteUnset,
     };
     use async_trait::async_trait;
     use tokio::{net::TcpListener, sync::mpsc};
@@ -983,7 +992,7 @@ mod test {
         let expected_object = Aggregation::Object((MockObject {}).astarte_aggregate().unwrap());
 
         let proto_payload: astarte_message_hub_proto::astarte_message::Payload =
-            expected_object.try_into().unwrap();
+            expected_object.into();
 
         let astarte_message = AstarteMessage {
             interface_name: "org.astarte-platform.rust.examples.object-datastream.DeviceDatastream"
@@ -1026,7 +1035,7 @@ mod test {
             ReceivedEvent {
                 ref interface,
                 ref path,
-                payload: GrpcReceivePayload {
+                payload: GrpcPayload {
                     data,
                     timestamp: None,
                 },
@@ -1043,8 +1052,7 @@ mod test {
             .await
             .expect("Could not construct test client and server");
 
-        let proto_payload: astarte_message_hub_proto::astarte_message::Payload =
-            AstarteType::Unset.try_into().unwrap();
+        let proto_payload = ProtoPayload::AstarteUnset(AstarteUnset {});
 
         let exp_interface =
             "org.astarte-platform.rust.examples.individual-properties.ServerProperties";
@@ -1087,7 +1095,7 @@ mod test {
             ReceivedEvent {
                 ref interface,
                 ref path,
-                payload: GrpcReceivePayload {
+                payload: GrpcPayload {
                     data,
                     timestamp: None,
                 },

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     shared::SharedDevice,
     store::PropertyStore,
     types::AstarteType,
-    validate::{ValidatedIndividual, ValidatedObject},
+    validate::{ValidatedIndividual, ValidatedObject, ValidatedUnset},
     Interface, Timestamp,
 };
 
@@ -64,6 +64,9 @@ pub(crate) trait Publish {
 
     /// Sends validated objects values over this connection
     async fn send_object(&self, data: ValidatedObject<'_>) -> Result<(), crate::Error>;
+
+    /// Unset a property value over this connection
+    async fn unset(&self, data: ValidatedUnset<'_>) -> Result<(), crate::Error>;
 }
 
 #[async_trait]
@@ -85,14 +88,14 @@ pub(crate) trait Receive {
     /// Deserializes a received payload to an individual astarte value
     fn deserialize_individual(
         &self,
-        mapping: MappingRef<'_, &Interface>,
+        mapping: &MappingRef<'_, &Interface>,
         payload: Self::Payload,
-    ) -> Result<(AstarteType, Option<Timestamp>), crate::Error>;
+    ) -> Result<Option<(AstarteType, Option<Timestamp>)>, crate::Error>;
 
     /// Deserializes a received payload to an aggregate object
     fn deserialize_object(
         &self,
-        object: ObjectRef,
+        object: &ObjectRef,
         path: &MappingPath<'_>,
         payload: Self::Payload,
     ) -> Result<(HashMap<String, AstarteType>, Option<Timestamp>), crate::Error>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,7 +21,6 @@
 //! [AstarteDeviceSdk][crate::AstarteDeviceSdk] to transmit/receive data to/from the Astarte cluster.
 
 use bson::{Binary, Bson};
-use log::debug;
 use serde::Serialize;
 
 use crate::{interface::MappingType, Timestamp};
@@ -86,8 +85,6 @@ pub enum AstarteType {
     StringArray(Vec<String>),
     BinaryBlobArray(Vec<Vec<u8>>),
     DateTimeArray(Vec<Timestamp>),
-
-    Unset,
 }
 
 macro_rules! check_astype_match {
@@ -309,7 +306,6 @@ impl From<AstarteType> for Bson {
                 })
                 .collect(),
             AstarteType::DateTimeArray(d) => d.into_iter().collect(),
-            AstarteType::Unset => Bson::Null,
         }
     }
 }
@@ -327,11 +323,6 @@ where
 }
 
 impl AstarteType {
-    /// Check if the variant is [`AstarteType::Unset`].
-    pub fn is_unset(&self) -> bool {
-        matches!(self, AstarteType::Unset)
-    }
-
     /// Convert a non empty BSON array to astarte array with all the elements of the same type.
     pub(crate) fn try_from_array(
         array: Vec<Bson>,
@@ -395,7 +386,6 @@ impl AstarteType {
             AstarteType::StringArray(_) => "string array",
             AstarteType::BinaryBlobArray(_) => "binary blob array",
             AstarteType::DateTimeArray(_) => "datetime array",
-            AstarteType::Unset => "unset",
         }
     }
 }
@@ -461,12 +451,6 @@ impl TryFrom<BsonConverter> for AstarteType {
     type Error = TypeError;
 
     fn try_from(value: BsonConverter) -> Result<Self, Self::Error> {
-        if value.bson == Bson::Null {
-            debug!("bson null returning unset");
-
-            return Ok(AstarteType::Unset);
-        }
-
         match value.mapping_type {
             MappingType::Double => value
                 .bson

--- a/src/types.rs
+++ b/src/types.rs
@@ -501,7 +501,7 @@ impl TryFrom<BsonConverter> for AstarteType {
 mod test {
     use chrono::{DateTime, TimeZone, Utc};
 
-    use crate::Aggregation;
+    use crate::Value;
 
     use super::*;
 
@@ -688,9 +688,9 @@ mod test {
     #[test]
     fn test_conversion_from_astarte_integer_to_f64() {
         let astarte_type_double = AstarteType::Integer(5);
-        let astarte_ind = Aggregation::Individual(astarte_type_double);
+        let astarte_ind = Value::Individual(astarte_type_double);
 
-        if let Aggregation::Individual(var) = astarte_ind {
+        if let Value::Individual(var) = astarte_ind {
             let value: f64 = var.try_into().unwrap();
             assert_eq!(5.0, value);
         } else {
@@ -701,9 +701,9 @@ mod test {
     #[test]
     fn test_conversion_from_astarte_integer_to_i64() {
         let astarte_type_double = AstarteType::Integer(5);
-        let astarte_ind = Aggregation::Individual(astarte_type_double);
+        let astarte_ind = Value::Individual(astarte_type_double);
 
-        if let Aggregation::Individual(var) = astarte_ind {
+        if let Value::Individual(var) = astarte_ind {
             let value: i64 = var.try_into().unwrap();
             assert_eq!(5, value);
         } else {


### PR DESCRIPTION
Move the Unset to the `Aggregation` enum and introduce a new `unset` method. This simplify the checks since you can only unset a property and the AstarteType::Unset is not needed in the others code paths. Also this simplifies the conversions in the gRPC code that now in infallible.