### PR TITLE
fix(cargo): update exclude and includes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ version = { workspace = true }
 categories = ["embedded", "api-bindings"]
 documentation = "https://docs.rs/astarte-device-sdk"
 edition = { workspace = true }
-exclude = { workspace = true }
+exclude = ["/.github", "/.reuse"]
 homepage = { workspace = true }
+include = ["/.sqlx"]
 keywords = ["sdk", "iot", "astarte"]
 license = { workspace = true }
 readme = "README.md"
@@ -31,7 +32,6 @@ members = [
 [workspace.package]
 version = "0.7.2"
 edition = "2021"
-exclude = [".github"]
 homepage = "https://astarte.cloud/"
 license = "Apache-2.0"
 repository = "https://github.com/astarte-platform/astarte-device-sdk-rust"

--- a/astarte-device-sdk-derive/Cargo.toml
+++ b/astarte-device-sdk-derive/Cargo.toml
@@ -10,7 +10,6 @@ version = { workspace = true }
 categories = ["embedded", "api-bindings", "development-tools::procedural-macro-helpers"]
 documentation = "https://docs.rs/astarte-device-sdk-derive"
 edition = { workspace = true }
-exclude = { workspace = true }
 homepage = { workspace = true }
 keywords = ["sdk", "iot", "astarte", "derive"]
 license = { workspace = true }


### PR DESCRIPTION
Update the includes and exclude in the Cargo manifest to add the `.sqlx/` directory. This fixes a bug in the cargo vendoring process that would exclude those files that are actually required to build the crate.