### PR TITLE
fix(store): remove interface's properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Delete all interface's properties, using the correct mapping, when an
+  interface is removed
+  [#313](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/313)
+
 ## [0.6.4] - 2024-03-20
 
 ## [0.5.3] - 2024-03-20

--- a/examples/object_datastream/README.md
+++ b/examples/object_datastream/README.md
@@ -33,5 +33,5 @@ devices get-samples <DEVICE_NAME>
 org.astarte-platform.rust.examples.object-datastream.DeviceDatastream <COMM_ENDPOINT> -c 1
 ```
 Where `<REALM>` is your realm's name, `<DEVICE_ID>` is the device ID from which the data has
-been received and `<COMM_ENDPOINT>` is the common part of the aggegate endpoints.
+been received and `<COMM_ENDPOINT>` is the common part of the aggregate endpoints.
 For this example `<COMM_ENDPOINT>` is fixed to `/23`.

--- a/examples/registration/README.md
+++ b/examples/registration/README.md
@@ -17,5 +17,5 @@ If you have not already done so, make sure that you satisfy the
 
 Once the example has been started it will automatically attempt to register the device to the remote
 instance of Astarte.
-The retreived credential secret will be displayed in the terminal. Make sure to copy and store it
-somewhere safe as there is no way to retreive it later.
+The retrieved credential secret will be displayed in the terminal. Make sure to copy and store it
+somewhere safe as there is no way to retrieve it later.

--- a/queries/delete_interface.sql
+++ b/queries/delete_interface.sql
@@ -1,0 +1,1 @@
+DELETE FROM propcache WHERE interface = ?

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -20,6 +20,16 @@
     },
     "query": "DELETE FROM propcache WHERE interface = ? AND path = ?\n"
   },
+  "5c53a781263f71fd7aa603bbbd63d15316a3f916286577885a1a6d1eb3d790ed": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "DELETE FROM propcache WHERE interface = ?\n"
+  },
   "baddb61f1e374ef6ebc7ff926a78e210bc4023b9079426bfdff6e73dde5a6a63": {
     "describe": {
       "columns": [],

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -198,7 +198,7 @@ impl Interface {
     }
 
     /// Getter function for the interface name.
-    #[deprecated = "Use `interface_name` instead, and manualy convert it to `String` if needed"]
+    #[deprecated = "Use `interface_name` instead, and manually convert it to `String` if needed"]
     pub fn get_name(&self) -> String {
         self.interface_name.clone()
     }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -49,7 +49,7 @@ pub enum PayloadError {
     #[error("couldn't convert the value to AstarteType")]
     AstarteType(#[from] TypeError),
     /// Expected object, individual data deserialized
-    #[error("expected object, individual data deserialized intead {0}")]
+    #[error("expected object, individual data deserialized instead {0}")]
     Object(Bson),
     /// Missing mapping in payload
     #[error["missing mappings in the payload"]]
@@ -58,7 +58,7 @@ pub enum PayloadError {
     #[error("couldn't parse the mapping")]
     Mapping(#[from] MappingError),
     /// Mismatching type while serializing
-    #[error("mimatching type while serializing, expected {expected} but got {got}")]
+    #[error("mismatching type while serializing, expected {expected} but got {got}")]
     SerializeType { expected: String, got: String },
     /// Couldn't accept unset for mapping without `allow_unset`
     #[error("couldn't accept unset if the mapping isn't a property with `allow_unset`")]

--- a/src/store/error.rs
+++ b/src/store/error.rs
@@ -40,6 +40,9 @@ pub enum StoreError {
     /// Could not load all properties.
     #[error("could not load all properties")]
     LoadAll(#[source] DynError),
+    /// Could not delete all the interface properties.
+    #[error("could not delete all the interface properties")]
+    DeleteInterface(#[source] DynError),
 }
 
 impl StoreError {
@@ -61,5 +64,9 @@ impl StoreError {
 
     pub(crate) fn load_all(err: impl Into<DynError>) -> Self {
         Self::LoadAll(err.into())
+    }
+
+    pub(crate) fn delete_interface(err: impl Into<DynError>) -> Self {
+        Self::DeleteInterface(err.into())
     }
 }

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -140,6 +140,15 @@ impl PropertyStore for MemoryStore {
 
         Ok(props)
     }
+
+    async fn delete_interface(&self, interface: &str) -> Result<(), Self::Err> {
+        self.store
+            .write()
+            .await
+            .retain(|k, _v| k.interface != interface);
+
+        Ok(())
+    }
 }
 
 /// Key for the in memory store, this let us customize the hash and equality, and use (&str, &str)

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -71,6 +71,8 @@ where
     /// Retrieves all property values in the database, together with their interface name, path
     /// and major version.
     async fn load_all_props(&self) -> Result<Vec<StoredProp>, Self::Err>;
+    /// Deletes all the properties of the interface from the database.
+    async fn delete_interface(&self, interface: &str) -> Result<(), Self::Err>;
 }
 
 /// Data structure used to return stored properties by a database implementing the AstarteDatabase
@@ -195,6 +197,12 @@ mod tests {
 
         assert_eq!(props, expected);
 
+        // delete interface properties
+        store.delete_interface("com.test").await.unwrap();
+        let prop = store.load_prop("com.test", "/test", 1).await.unwrap();
+
+        assert_eq!(prop, None);
+
         // test all types
         let all_types = [
             AstarteType::Double(4.5),
@@ -229,7 +237,7 @@ mod tests {
 
     /// Test that the error is Send + Sync + 'static to be send across task boundaries.
     #[tokio::test]
-    async fn erro_should_compatible_with_tokio() {
+    async fn error_should_compatible_with_tokio() {
         let mem = StoreWrapper::new(MemoryStore::new());
 
         let exp = AstarteType::Integer(1);

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -314,6 +314,14 @@ impl PropertyStore for SqliteStore {
 
         Ok(res)
     }
+
+    async fn delete_interface(&self, interface: &str) -> Result<(), Self::Err> {
+        sqlx::query_file!("queries/delete_interface.sql", interface)
+            .execute(&self.db_conn)
+            .await?;
+
+        Ok(())
+    }
 }
 
 /// Deserialize a property from the store.

--- a/src/store/wrapper.rs
+++ b/src/store/wrapper.rs
@@ -88,6 +88,13 @@ where
             .await
             .map_err(StoreError::load_all)
     }
+
+    async fn delete_interface(&self, interface: &str) -> Result<(), Self::Err> {
+        self.store
+            .delete_interface(interface)
+            .await
+            .map_err(StoreError::delete_interface)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implement in the store a way to remove all the properties for an interface. This fixes the deletion of the properties when an interface is removed, since before it was using the mapping without the parameter.

Closes #312