### PR TITLE
chore: prepare release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.5] - 2024-04-08
 ### Fixed
 - Delete all interface's properties, using the correct mapping, when an
   interface is removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "astarte-device-sdk"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "astarte-device-sdk-derive",
  "async-trait",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "astarte-device-sdk"
-version = "0.6.4"
+version = "0.6.5"
 documentation = "https://docs.rs/astarte-device-sdk"
 edition = "2021"
 homepage = "https://astarte.cloud/"
@@ -24,7 +24,7 @@ name = "benchmark"
 harness = false
 
 [dependencies]
-astarte-device-sdk-derive = { version = "=0.6.4", optional = true, path = "./astarte-device-sdk-derive" }
+astarte-device-sdk-derive = { version = "=0.6.5", optional = true, path = "./astarte-device-sdk-derive" }
 async-trait = "0.1.2"
 base64 = "0.21.0"
 bson = { version = "2.1.0", features = ["chrono-0_4"] }

--- a/astarte-device-sdk-derive/CHANGELOG.md
+++ b/astarte-device-sdk-derive/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - 2024-04-08
+
 ## [0.6.4] - 2024-03-20
 
 ## [0.5.3] - 2024-03-20

--- a/astarte-device-sdk-derive/Cargo.lock
+++ b/astarte-device-sdk-derive/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "quote",
  "syn",

--- a/astarte-device-sdk-derive/Cargo.toml
+++ b/astarte-device-sdk-derive/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "astarte-device-sdk-derive"
-version = "0.6.4"
+version = "0.6.5"
 documentation = "https://docs.rs/astarte-device-sdk-derive"
 edition = "2021"
 homepage = "https://astarte.cloud/"


### PR DESCRIPTION
## [0.6.5] - 2024-04-08
### Fixed
- Delete all interface's properties, using the correct mapping, when an
  interface is removed