### PR TITLE
fix(interfaces): correct the iteration logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Correct the interfaces iterator logic to send the correct device
+  introspection [#334](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/334)
+
 ## [0.8.0] - 2024-04-29
 ### Added
 - Introduce Node ID into gRPC metadata.

--- a/src/transport/grpc/mod.rs
+++ b/src/transport/grpc/mod.rs
@@ -322,7 +322,7 @@ impl Register for Grpc {
         interfaces: &Interfaces,
         removed: &Interface,
     ) -> Result<(), crate::Error> {
-        let iter = interfaces.iter_with_removed(removed);
+        let iter = interfaces.iter_without_removed(removed);
 
         let data = NodeData::try_from_iter(&self.uuid, iter)?;
 

--- a/src/transport/mqtt/mod.rs
+++ b/src/transport/mqtt/mod.rs
@@ -560,7 +560,7 @@ impl Register for Mqtt {
         interfaces: &Interfaces,
         removed: &Interface,
     ) -> Result<(), Error> {
-        let iter = interfaces.iter_with_removed(removed);
+        let iter = interfaces.iter_without_removed(removed);
         let introspection = Introspection::new(iter).to_string();
 
         self.send_introspection(introspection).await?;


### PR DESCRIPTION
There was a bug in the iteration that would iterate only on the single added interface in the method Interfaces::iter_with_added. This will generate an incorrect introspection for MQTT connection.