### PR TITLE
chore(release): prepare release v0.8.1

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -54,10 +54,6 @@ Files: Cargo.lock
 Copyright: 2023 SECO Mind Srl
 License: CC0-1.0
 
-Files: CHANGELOG.md
-Copyright: 2023 SECO Mind Srl
-License: CC0-1.0
-
-Files: astarte-device-sdk-derive/CHANGELOG.md
-Copyright: 2023 SECO Mind Srl
+Files: CHANGELOG.md */CHANGELOG.md
+Copyright: 2023-2024 SECO Mind Srl
 License: CC0-1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.1] - 2024-05-03
 ### Fixed
 - Correct the interfaces iterator logic to send the correct device
   introspection [#334](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/334)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "astarte-device-sdk-derive",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-mock"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "astarte-device-sdk",
  "async-trait",
@@ -778,7 +778,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "e2e-test"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "astarte-device-sdk",
  "base64 0.22.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 homepage = "https://astarte.cloud/"
 license = "Apache-2.0"
@@ -110,8 +110,8 @@ interface-doc = []
 interface-strict = []
 
 [workspace.dependencies]
-astarte-device-sdk = { path = "./", version = "=0.8.0" }
-astarte-device-sdk-derive = { version = "=0.8.0", path = "./astarte-device-sdk-derive" }
+astarte-device-sdk = { path = "./", version = "=0.8.1" }
+astarte-device-sdk-derive = { version = "=0.8.1", path = "./astarte-device-sdk-derive" }
 astarte-message-hub-proto = "0.6.2"
 async-trait = "0.1.50"
 base64 = "0.22.0"

--- a/astarte-device-sdk-derive/CHANGELOG.md
+++ b/astarte-device-sdk-derive/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2024-05-03
+
 ## [0.8.0] - 2024-04-29
 
 ## [0.7.3] - 2024-04-09

--- a/astarte-device-sdk-mock/CHANGELOG.md
+++ b/astarte-device-sdk-mock/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.8.1] - 2024-05-03


### PR DESCRIPTION
## 0.8.1

### Fixed

- Correct the interfaces iterator logic to send the correct device introspection [#334](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/334)