### PR TITLE
chore(coverage): upload to codecove from master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,9 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
 jobs:
   dco:
     uses: ./.github/workflows/dco.yaml

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,63 @@
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: coverage
+defaults:
+  run:
+    shell: bash
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types: [completed]
+permissions:
+  contents: read
+  actions: read
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    # Run only if originated from a PR
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      # Checkout codecov.yaml config from master
+      - uses: actions/checkout@v4
+        with:
+          path: master
+          sparse-checkout: |
+            .github/codecov.yaml
+          sparse-checkout-cone-mode: false
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Get PR number
+        run: |
+          echo "PR_NUMBER=$(cat ./pr_number)" >> "$GITHUB_ENV"
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v4
+        with:
+          codecov_yml_path: master/.github/codecov.yaml
+          token: ${{secrets.CODECOV_TOKEN}}
+          fail_ci_if_error: true
+          override_branch: ${{ github.event.workflow_run.head_branch }}
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_pr: ${{ env.PR_NUMBER }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,8 +98,25 @@ jobs:
         run: cargo generate-lockfile
       - name: Run cargo-tarpaulin with xml output
         run: cargo tarpaulin --engine llvm --locked --all-features --ignore-tests --lib --out xml -- --test-threads 1
+      # Upload the coverage if we are not a PR from a fork, see ".github/workflows/coverage.yaml"
       - name: Upload to codecov.io
+        if: ${{ github.event_name == 'push' }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true
+      # Save data to use in workflow_run
+      - name: Save PR number
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo "$PR_NUMBER" > ./pr_number
+      - name: Upload coverage artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            pr_number
+            cobertura.xml


### PR DESCRIPTION
Use the workflow_run to upload the coverage report, since it's run on base and has access to the repository secrets.