### PR TITLE
chore(deps): pin message hub proto version for dynamic introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "astarte-message-hub-proto"
 version = "0.6.2"
-source = "git+https://github.com/astarte-platform/astarte-message-hub-proto#474c1433846562af6d3bf0fd1d8d7561ff44cee2"
+source = "git+https://github.com/astarte-platform/astarte-message-hub-proto?rev=474c1433846562af6d3bf0fd1d8d7561ff44cee2#474c1433846562af6d3bf0fd1d8d7561ff44cee2"
 dependencies = [
  "chrono",
  "pbjson-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ interface-strict = []
 [workspace.dependencies]
 astarte-device-sdk = { path = "./", version = "=0.8.2" }
 astarte-device-sdk-derive = { version = "=0.8.2", path = "./astarte-device-sdk-derive" }
-astarte-message-hub-proto = { git = "https://github.com/astarte-platform/astarte-message-hub-proto" }
+astarte-message-hub-proto = { git = "https://github.com/astarte-platform/astarte-message-hub-proto", rev = "474c1433846562af6d3bf0fd1d8d7561ff44cee2" }
 async-trait = "0.1.50"
 base64 = "0.22.0"
 bson = "2.7.0"


### PR DESCRIPTION
This is necessary to avoid deps conflicts in the Message Hub