### PR TITLE
fix(deps): pin to newer minimal-versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ dependencies = [
  "sync_wrapper 1.0.0",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2262,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "rumqttc"
 version = "0.24.0"
-source = "git+https://github.com/joshuachp/rumqtt?rev=146962ee07861b7e187b040ba92d482248294f8c#146962ee07861b7e187b040ba92d482248294f8c"
+source = "git+https://github.com/joshuachp/rumqtt?rev=9109f874ec10e1660448616e7054a887672dfd07#9109f874ec10e1660448616e7054a887672dfd07"
 dependencies = [
  "bytes",
  "flume",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,11 +80,12 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["parking_lot", "macros"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
-uuid = { workspace = true, features = ["v5", "v4"] }
+uuid = { workspace = true, features = ["v4", "v5"] }
 x509-cert = { workspace = true, features = ["builder"] }
 
 # Transitive dependency
 ahash = { workspace = true }
+time = { workspace = true }
 
 [dev-dependencies]
 astarte-device-sdk-derive = { workspace = true }
@@ -130,13 +131,14 @@ proc-macro2 = "1.0.63"
 quote = "1.0.28"
 rand_core = "0.6.4"
 reqwest = "0.12.0"
-rumqttc = { git = "https://github.com/joshuachp/rumqtt", rev = "146962ee07861b7e187b040ba92d482248294f8c" }
+rumqttc = { git = "https://github.com/joshuachp/rumqtt", rev = "9109f874ec10e1660448616e7054a887672dfd07" }
 rustls = "0.22.2"
 rustls-native-certs = "0.7.0"
 rustls-pemfile = "2.1.0"
-serde = "1.0.145"
+serde = "1.0.184"
 serde_json = "1.0.85"
-sqlx = "0.7.0"
+# The version 0.7.4 is incompatible with MSRV 1.72
+sqlx = "0.7.0, < 0.7.4"
 structopt = "0.3.26"
 syn = "2.0.31"
 sync_wrapper = "1.0.0"
@@ -152,3 +154,4 @@ x509-cert = "0.2.2"
 
 # Transitive dependencies
 ahash = "0.8.8"
+time = "0.3.35"


### PR DESCRIPTION
Update the requirements for the version on the times, serde and sqlx crates.