### PR TITLE
feat(disconnect): move disconnect to the client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ env_logger = { workspace = true }
 mockall = { workspace = true }
 mockito = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "signal"] }
 tokio-stream = { workspace = true, features = ["net"] }
 
 [features]

--- a/astarte-device-sdk-mock/src/lib.rs
+++ b/astarte-device-sdk-mock/src/lib.rs
@@ -19,8 +19,8 @@
 use std::path::Path;
 
 use astarte_device_sdk::{
-    properties::PropAccess, store::StoredProp, AstarteAggregate, AstarteType, DeviceEvent, Error,
-    Interface,
+    client::ClientDisconnect, properties::PropAccess, store::StoredProp, AstarteAggregate,
+    AstarteType, DeviceEvent, Error, Interface,
 };
 use async_trait::async_trait;
 use mockall::mock;
@@ -203,6 +203,11 @@ mock! {
         async fn server_props(&self) -> Result<Vec<StoredProp>, Error>;
     }
 
+    #[async_trait]
+    impl<S: Send> ClientDisconnect for DeviceClient<S> {
+        async fn disconnect(self);
+    }
+
     impl<S> Clone for DeviceClient<S> {
         fn clone(&self) -> Self {}
     }
@@ -214,11 +219,6 @@ mock! {
     #[async_trait]
     impl<S: Send, C: Send> astarte_device_sdk::EventLoop for DeviceConnection<S,C> {
         async fn handle_events(self) -> Result<(), crate::Error>;
-    }
-
-    #[async_trait]
-    impl<S: Send, C: Send> astarte_device_sdk::connection::ClientDisconnect for DeviceConnection<S,C> {
-        async fn disconnect(self);
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -24,7 +24,7 @@
 /// Device module that exports trait commonly used when sending or receiving data.
 pub mod device {
     pub use crate::client::Client;
-    pub use crate::connection::ClientDisconnect;
+    pub use crate::client::ClientDisconnect;
     pub use crate::connection::EventLoop;
     pub use crate::introspection::DynamicIntrospection;
     pub use crate::AstarteAggregate;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -196,7 +196,7 @@ pub(crate) trait Register {
 /// Gracefully close the connection.
 #[async_trait]
 pub trait Disconnect {
-    /// User callable api to gracefully disconnect from the transport
+    /// Gracefully disconnect from the transport
     async fn disconnect(self) -> Result<(), crate::Error>;
 }
 

--- a/src/transport/mqtt/client.rs
+++ b/src/transport/mqtt/client.rs
@@ -42,6 +42,7 @@ pub(crate) mod mock {
             pub async fn publish<S, V>(&self, topic: S, qos: QoS, retain: bool, payload: V,) -> Result<NoticeFuture, ClientError> where S: Into<String> + 'static, V: Into<Vec<u8>> + 'static;
             pub async fn unsubscribe<S: Into<String> + 'static>(&self, topic: S) -> Result<NoticeFuture, ClientError>;
             pub async fn subscribe_many<T>(&self, topics: T) -> Result<NoticeFuture, ClientError> where T: IntoIterator<Item = SubscribeFilter> + 'static;
+            pub async fn disconnect(&self) -> Result<NoticeFuture, ClientError>;
         }
         impl Clone for AsyncClient {
             fn clone(&self) -> Self;

--- a/src/transport/mqtt/error.rs
+++ b/src/transport/mqtt/error.rs
@@ -60,6 +60,9 @@ pub enum MqttError {
     /// See the [`ParingToken`](super::Credential::ParingToken) for more information.
     #[error("missing writable directory to store credentials to use the pairing token")]
     NoStorePairintToken,
+    /// Couldn't send the disconnect
+    #[error("couldn't send the disconnect")]
+    Disconnect(#[source] ClientError),
 }
 
 impl MqttError {


### PR DESCRIPTION
Implement the `DisconnectClient` trait on the `DeviceClient`, because after the `handle_events` takes ownership of the connection. The client needs to send the disconnect over the connection and then the connection will handle it and both tasks will exit.

Depends on #363 