### PR TITLE
chore(release): prepare release v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.3] - 2024-08-22
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ahash",
  "astarte-device-sdk-derive",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-mock"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "astarte-device-sdk",
  "async-trait",
@@ -653,7 +653,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "e2e-test"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "astarte-device-sdk",
  "base64 0.22.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 homepage = "https://astarte.cloud/"
 license = "Apache-2.0"
@@ -105,8 +105,8 @@ interface-doc = []
 interface-strict = []
 
 [workspace.dependencies]
-astarte-device-sdk = { path = "./", version = "=0.8.2" }
-astarte-device-sdk-derive = { version = "=0.8.2", path = "./astarte-device-sdk-derive" }
+astarte-device-sdk = { path = "./", version = "=0.8.3" }
+astarte-device-sdk-derive = { version = "=0.8.3", path = "./astarte-device-sdk-derive" }
 astarte-message-hub-proto = "0.6.2"
 async-trait = "0.1.50"
 base64 = "0.22.0"

--- a/astarte-device-sdk-derive/CHANGELOG.md
+++ b/astarte-device-sdk-derive/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.8.3] - 2024-08-22
 
 ## [0.8.2] - 2024-05-29
 
@@ -27,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.3] - 2024-03-20
 
 ## [0.7.1] - 2024-02-16
+
 - Bump MSRV to 1.72.0.
 
 ## [0.6.3] - 2024-02-13
@@ -34,10 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.2] - 2024-01-30
 
 ## [0.7.0] - 2024-01-22
+
 ### Added
+
 - Macro to implement the `FromEvent` trait on a generic struct.
 
 ### Changed
+
 - Update the `AstarteAggregate` derive macro to syn `2`, see
   [#236](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/236).
 
@@ -50,5 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.1] - 2023-02-06
 
 ## [0.5.0] - 2023-02-01
+
 ### Added
+
 - Initial Astarte Device SDK Derive release

--- a/astarte-device-sdk-mock/CHANGELOG.md
+++ b/astarte-device-sdk-mock/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2024-08-22
+
 ## [0.8.2] - 2024-05-29
 
 ## [0.8.1] - 2024-05-03


### PR DESCRIPTION
Bump version in Cargo.toml and update the CHANGELOG.md.