### PR TITLE
Use node id metedata in the attach rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Use Empty type rather than Node to detach a Node [#340](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/340/).
 - Handle the new return type of the Attach rpc, `MessageHubEvent`, which can either be an error or an Astarte 
   message [#362](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/362)
+- Retrieve the Node ID information from the grpc metadata also for the Attach rpc [#372](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/372).
 
 ## [0.8.2] - 2024-05-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,8 +191,9 @@ dependencies = [
 
 [[package]]
 name = "astarte-message-hub-proto"
-version = "0.6.2"
-source = "git+https://github.com/astarte-platform/astarte-message-hub-proto?rev=908e34d232a23c81419c962f07705a358642a520#908e34d232a23c81419c962f07705a358642a520"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e11715d99fa49328a6216432b8374dbbab38ec2c80d6ddb06cc8003231eb727"
 dependencies = [
  "chrono",
  "pbjson-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ interface-strict = []
 [workspace.dependencies]
 astarte-device-sdk = { path = "./", version = "=0.8.3" }
 astarte-device-sdk-derive = { version = "=0.8.3", path = "./astarte-device-sdk-derive" }
-astarte-message-hub-proto = { git = "https://github.com/astarte-platform/astarte-message-hub-proto", rev = "908e34d232a23c81419c962f07705a358642a520" }
+astarte-message-hub-proto =  "0.7.0"
 async-trait = "0.1.67"
 base64 = "0.22.0"
 bson = "2.7.0"


### PR DESCRIPTION
Reflect the astarte-message-hub-proto changes: the node id information has been removed from the attach rpc parameter, which now contains only the introspection.