### PR TITLE
fix(disconnect): rework the disconnect for gRPC

### DIFF
--- a/astarte-device-sdk-mock/src/lib.rs
+++ b/astarte-device-sdk-mock/src/lib.rs
@@ -206,8 +206,8 @@ mock! {
     }
 
     #[async_trait]
-    impl<S: Send> ClientDisconnect for DeviceClient<S> {
-        async fn disconnect(self);
+    impl<S: Send + Sync> ClientDisconnect for DeviceClient<S> {
+        async fn disconnect(&self) -> Result<(), Error>;
     }
 
     impl<S> Clone for DeviceClient<S> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,7 +31,6 @@ use crate::error::{AggregateError, DynError};
 use crate::interface::mapping::path::MappingError;
 use crate::{
     connection::ClientMessage,
-    error::Report,
     event::DeviceEvent,
     interface::{
         mapping::path::MappingPath,
@@ -240,7 +239,7 @@ pub trait Client {
 #[async_trait]
 pub trait ClientDisconnect {
     /// Cleanly disconnects the client consuming it.
-    async fn disconnect(self);
+    async fn disconnect(&self) -> Result<(), Error>;
 }
 
 /// Client to send and receive message to and form Astarte or access the Device properties.
@@ -658,9 +657,7 @@ impl<S> ClientDisconnect for DeviceClient<S>
 where
     S: Send + Sync,
 {
-    async fn disconnect(self) {
-        if let Err(e) = self.send_msg(ClientMessage::Disconnect).await {
-            error!(error = %Report::new(e), "Could not close the connection gracefully");
-        }
+    async fn disconnect(&self) -> Result<(), Error> {
+        self.send_msg(ClientMessage::Disconnect).await
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -208,7 +208,7 @@ pub(crate) trait Register {
 #[async_trait]
 pub trait Disconnect {
     /// Gracefully disconnect from the transport
-    async fn disconnect(self) -> Result<(), crate::Error>;
+    async fn disconnect(&mut self) -> Result<(), crate::Error>;
 }
 
 #[cfg(test)]

--- a/src/transport/mqtt/mod.rs
+++ b/src/transport/mqtt/mod.rs
@@ -531,7 +531,7 @@ impl<S> Disconnect for MqttClient<S>
 where
     S: Send,
 {
-    async fn disconnect(self) -> Result<(), crate::Error> {
+    async fn disconnect(&mut self) -> Result<(), crate::Error> {
         self.client
             .disconnect()
             .await


### PR DESCRIPTION
Make the disconnect usable with the gRPC connection, before the trait was implemented for the wrong struct and the error was not returned. Now the call to disconnect can fail but it only takes a reference, so you can retry it multiple times.