### PR TITLE
chore(release): prepare release v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] - 2024-09-11
+
+### Changed
+
+- Improve the rendering of the documentation on docs.rs, showing all the features and which one
+  needs to be activated for a specific item.
+
 ## [0.8.3] - 2024-08-22
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "ahash",
  "astarte-device-sdk-derive",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-mock"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "astarte-device-sdk",
  "async-trait",
@@ -653,7 +653,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "e2e-test"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "astarte-device-sdk",
  "base64 0.22.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 homepage = "https://astarte.cloud/"
 license = "Apache-2.0"
@@ -109,8 +109,8 @@ all-features = true
 rustc-args = ["--cfg=docsrs"]
 
 [workspace.dependencies]
-astarte-device-sdk = { path = "./", version = "=0.8.3" }
-astarte-device-sdk-derive = { version = "=0.8.3", path = "./astarte-device-sdk-derive" }
+astarte-device-sdk = { path = "./", version = "=0.8.4" }
+astarte-device-sdk-derive = { version = "=0.8.4", path = "./astarte-device-sdk-derive" }
 astarte-message-hub-proto = "0.6.2"
 async-trait = "0.1.50"
 base64 = "0.22.0"

--- a/astarte-device-sdk-derive/CHANGELOG.md
+++ b/astarte-device-sdk-derive/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] - 2024-09-11
+
 ## [0.8.3] - 2024-08-22
 
 ## [0.8.2] - 2024-05-29

--- a/astarte-device-sdk-mock/CHANGELOG.md
+++ b/astarte-device-sdk-mock/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] - 2024-09-11
+
 ## [0.8.3] - 2024-08-22
 
 ## [0.8.2] - 2024-05-29


### PR DESCRIPTION
Update the CHANGELOG and bump the version in the Cargo.toml