### PR TITLE
feat(prop): handle properties when offline 

### DIFF
--- a/migrations/0002_unset_property.sql
+++ b/migrations/0002_unset_property.sql
@@ -1,0 +1,30 @@
+-- Make the blob nullable
+CREATE TABLE IF NOT EXISTS propcache_v2 (
+    interface TEXT NOT NULL,
+    path TEXT NOT NULL,
+    -- Nullable for unset
+    value BLOB,
+    type INTEGER NOT NULL,
+    interface_major INTEGER NOT NULL,
+    -- Ownership of the interface
+    -- 0: Server owned
+    -- 1: Device owned
+    ownership INTEGER NOT NULL,
+    PRIMARY KEY (interface, path)
+);
+
+INSERT OR REPLACE INTO propcache_v2 (
+    interface, path, value, type, interface_major, ownership
+)
+SELECT
+    interface,
+    path,
+    value,
+    type,
+    interface_major,
+    ownership
+FROM propcache;
+
+DROP TABLE propcache;
+
+ALTER TABLE propcache_v2 RENAME TO propcache;

--- a/queries/properties/read/interface_props.sql
+++ b/queries/properties/read/interface_props.sql
@@ -7,4 +7,5 @@ SELECT
     ownership
 FROM propcache
 WHERE
-    interface = ?;
+    interface = ?
+    AND value IS NOT NULL;

--- a/queries/properties/read/load_all_props.sql
+++ b/queries/properties/read/load_all_props.sql
@@ -5,4 +5,6 @@ SELECT
     type,
     interface_major,
     ownership
-FROM propcache;
+FROM propcache
+WHERE
+    value IS NOT NULL;

--- a/queries/properties/read/load_prop.sql
+++ b/queries/properties/read/load_prop.sql
@@ -5,4 +5,5 @@ SELECT
 FROM propcache
 WHERE
     interface = ?
-    AND path = ?;
+    AND path = ?
+    AND value IS NOT NULL;

--- a/queries/properties/read/props_with_unset.sql
+++ b/queries/properties/read/props_with_unset.sql
@@ -7,5 +7,4 @@ SELECT
     ownership
 FROM propcache
 WHERE
-    ownership = ?
-    AND value IS NOT NULL;
+    ownership = ?;

--- a/queries/properties/write/unset_prop.sql
+++ b/queries/properties/write/unset_prop.sql
@@ -1,0 +1,5 @@
+UPDATE propcache
+SET value = NULL
+WHERE
+    interface = ?
+    AND path = ?;

--- a/src/store/error.rs
+++ b/src/store/error.rs
@@ -33,6 +33,9 @@ pub enum StoreError {
     /// Could not delete a property.
     #[error("could not delete property")]
     Delete(#[source] DynError),
+    /// Could not unset a property.
+    #[error("could not delete property")]
+    Unset(#[source] DynError),
     /// Could not clear the database.
     #[error("could not clear database")]
     Clear(#[source] DynError),
@@ -60,6 +63,10 @@ impl StoreError {
 
     pub(crate) fn load(err: impl Into<DynError>) -> Self {
         Self::Load(err.into())
+    }
+
+    pub(crate) fn unset(err: impl Into<DynError>) -> Self {
+        Self::Unset(err.into())
     }
 
     pub(crate) fn delete(err: impl Into<DynError>) -> Self {

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 use tokio::sync::RwLock;
 use tracing::error;
 
-use super::{MaybeStoredProp, PropertyStore, StoreCapabilities, StoredProp};
+use super::{OptStoredProp, PropertyStore, StoreCapabilities, StoredProp};
 use crate::{interface::Ownership, retention::Missing, types::AstarteType};
 
 /// Error from the memory store.
@@ -210,13 +210,13 @@ impl PropertyStore for MemoryStore {
         Ok(())
     }
 
-    async fn device_props_with_unset(&self) -> Result<Vec<MaybeStoredProp>, Self::Err> {
+    async fn device_props_with_unset(&self) -> Result<Vec<OptStoredProp>, Self::Err> {
         let store = self.store.read().await;
 
         let props = store
             .iter()
             .filter_map(|(k, v)| match v.ownership {
-                Ownership::Device => Some(MaybeStoredProp::from((k, v))),
+                Ownership::Device => Some(OptStoredProp::from((k, v))),
                 Ownership::Server => None,
             })
             .collect();
@@ -269,7 +269,7 @@ impl Value {
     }
 }
 
-impl From<(&Key, &Value)> for MaybeStoredProp {
+impl From<(&Key, &Value)> for OptStoredProp {
     fn from((key, value): (&Key, &Value)) -> Self {
         Self {
             interface: key.interface.clone(),

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -100,7 +100,7 @@ where
     /// Deletes all the properties of the interface from the database.
     async fn delete_interface(&self, interface: &str) -> Result<(), Self::Err>;
     /// Retrieves all the device properties, including the one that were unset but not deleted.
-    async fn device_props_with_unset(&self) -> Result<Vec<MaybeStoredProp>, Self::Err>;
+    async fn device_props_with_unset(&self) -> Result<Vec<OptStoredProp>, Self::Err>;
 }
 
 /// Data structure used to return stored properties by a database implementing the [`PropertyStore`]
@@ -129,7 +129,7 @@ pub struct StoredProp<S = String, V = AstarteType> {
 ///
 /// This is returned by getting all the properties (`load_all_props`) that have not been deleted
 /// yet, since they where not sent to Astarte.
-pub type MaybeStoredProp = StoredProp<String, Option<AstarteType>>;
+pub type OptStoredProp = StoredProp<String, Option<AstarteType>>;
 
 impl StoredProp {
     /// Coverts the stored property into a reference to its values.

--- a/src/store/sqlite/mod.rs
+++ b/src/store/sqlite/mod.rs
@@ -29,7 +29,7 @@ use rusqlite::{
 use statements::{include_query, ReadConnection, WriteConnection};
 use tracing::{debug, error, trace};
 
-use super::{MaybeStoredProp, PropertyStore, StoreCapabilities, StoredProp};
+use super::{OptStoredProp, PropertyStore, StoreCapabilities, StoredProp};
 use crate::{
     interface::{MappingType, Ownership},
     transport::mqtt::payload::{Payload, PayloadError},
@@ -219,7 +219,7 @@ impl StoredRecord {
     }
 }
 
-impl TryFrom<StoredRecord> for MaybeStoredProp {
+impl TryFrom<StoredRecord> for OptStoredProp {
     type Error = SqliteError;
 
     fn try_from(record: StoredRecord) -> Result<Self, Self::Error> {
@@ -536,7 +536,7 @@ impl PropertyStore for SqliteStore {
         Ok(())
     }
 
-    async fn device_props_with_unset(&self) -> Result<Vec<MaybeStoredProp>, Self::Err> {
+    async fn device_props_with_unset(&self) -> Result<Vec<OptStoredProp>, Self::Err> {
         self.with_reader(|reader| reader.props_with_unset(Ownership::Device))
     }
 }

--- a/src/store/sqlite/mod.rs
+++ b/src/store/sqlite/mod.rs
@@ -22,11 +22,14 @@ use std::{cell::Cell, fmt::Debug, path::Path, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::lock::Mutex;
-use rusqlite::OptionalExtension;
+use rusqlite::{
+    types::{FromSql, FromSqlError},
+    OptionalExtension, ToSql,
+};
 use statements::{include_query, ReadConnection, WriteConnection};
 use tracing::{debug, error, trace};
 
-use super::{PropertyStore, StoreCapabilities, StoredProp};
+use super::{MaybeStoredProp, PropertyStore, StoreCapabilities, StoredProp};
 use crate::{
     interface::{MappingType, Ownership},
     transport::mqtt::payload::{Payload, PayloadError},
@@ -90,18 +93,6 @@ enum RecordOwnership {
     Server = 1,
 }
 
-impl TryFrom<u8> for RecordOwnership {
-    type Error = OwnershipError;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(RecordOwnership::Device),
-            1 => Ok(RecordOwnership::Server),
-            _ => Err(OwnershipError { value }),
-        }
-    }
-}
-
 impl From<RecordOwnership> for Ownership {
     fn from(value: RecordOwnership) -> Self {
         match value {
@@ -116,6 +107,24 @@ impl From<Ownership> for RecordOwnership {
         match value {
             Ownership::Device => RecordOwnership::Device,
             Ownership::Server => RecordOwnership::Server,
+        }
+    }
+}
+
+impl ToSql for RecordOwnership {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok((*self as u8).into())
+    }
+}
+
+impl FromSql for RecordOwnership {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        let value = u8::column_result(value)?;
+
+        match value {
+            0 => Ok(RecordOwnership::Device),
+            1 => Ok(RecordOwnership::Server),
+            _ => Err(FromSqlError::Other(OwnershipError { value }.into())),
         }
     }
 }
@@ -144,9 +153,17 @@ pub enum ValueError {
 /// Result of the load_prop query
 #[derive(Clone)]
 struct PropRecord {
-    value: Vec<u8>,
+    value: Option<Vec<u8>>,
     stored_type: u8,
     interface_major: i32,
+}
+
+impl PropRecord {
+    fn try_into_value(self) -> Result<Option<AstarteType>, ValueError> {
+        self.value
+            .map(|value| deserialize_prop(self.stored_type, &value))
+            .transpose()
+    }
 }
 
 impl Debug for PropRecord {
@@ -154,23 +171,22 @@ impl Debug for PropRecord {
         use itertools::Itertools;
 
         // Print the value as an hex string instead of an array of numbers
-        let hex_value = self
-            .value
-            .iter()
-            .format_with("", |element, f| f(&format_args!("{element:x}")));
 
-        f.debug_struct("PropRecord")
-            .field("interface_major", &self.interface_major)
-            .field("value", &format_args!("{}", hex_value))
-            .finish()
-    }
-}
+        let mut d = f.debug_struct("PropRecord");
 
-impl TryFrom<PropRecord> for AstarteType {
-    type Error = ValueError;
+        d.field("interface_major", &self.interface_major);
 
-    fn try_from(record: PropRecord) -> Result<Self, Self::Error> {
-        deserialize_prop(record.stored_type, &record.value)
+        match &self.value {
+            Some(value) => {
+                let hex_value = value
+                    .iter()
+                    .format_with("", |element, f| f(&format_args!("Some({element:x})")));
+
+                d.field("value", &format_args!("{hex_value}"))
+            }
+            None => d.field("value", &self.value),
+        }
+        .finish()
     }
 }
 
@@ -179,10 +195,47 @@ impl TryFrom<PropRecord> for AstarteType {
 struct StoredRecord {
     interface: String,
     path: String,
-    value: Vec<u8>,
+    value: Option<Vec<u8>>,
     stored_type: u8,
     interface_major: i32,
-    ownership: u8,
+    ownership: RecordOwnership,
+}
+
+impl StoredRecord {
+    pub(crate) fn try_into_prop(self) -> Result<Option<StoredProp>, SqliteError> {
+        let Some(value) = self.value else {
+            return Ok(None);
+        };
+
+        let value = deserialize_prop(self.stored_type, &value)?;
+
+        Ok(Some(StoredProp {
+            interface: self.interface,
+            path: self.path,
+            value,
+            interface_major: self.interface_major,
+            ownership: self.ownership.into(),
+        }))
+    }
+}
+
+impl TryFrom<StoredRecord> for MaybeStoredProp {
+    type Error = SqliteError;
+
+    fn try_from(record: StoredRecord) -> Result<Self, Self::Error> {
+        let value = record
+            .value
+            .map(|value| deserialize_prop(record.stored_type, &value))
+            .transpose()?;
+
+        Ok(Self {
+            interface: record.interface,
+            path: record.path,
+            value,
+            interface_major: record.interface_major,
+            ownership: record.ownership.into(),
+        })
+    }
 }
 
 fn into_stored_type(value: &AstarteType) -> Result<u8, ValueError> {
@@ -228,22 +281,6 @@ fn from_stored_type(value: u8) -> Result<MappingType, ValueError> {
     };
 
     Ok(mapping_type)
-}
-
-impl TryFrom<StoredRecord> for StoredProp {
-    type Error = SqliteError;
-
-    fn try_from(record: StoredRecord) -> Result<Self, Self::Error> {
-        let value = deserialize_prop(record.stored_type, &record.value)?;
-
-        Ok(StoredProp {
-            interface: record.interface,
-            path: record.path,
-            value,
-            interface_major: record.interface_major,
-            ownership: RecordOwnership::try_from(record.ownership)?.into(),
-        })
-    }
 }
 
 thread_local! {
@@ -369,7 +406,10 @@ impl SqliteStore {
     }
 
     async fn migrate(&self) -> Result<(), SqliteError> {
-        const MIGRATIONS: &[&str] = &[include_query!("migrations/0001_init.sql")];
+        const MIGRATIONS: &[&str] = &[
+            include_query!("migrations/0001_init.sql"),
+            include_query!("migrations/0002_unset_property.sql"),
+        ];
 
         let writer = self.writer.lock().await;
 
@@ -450,12 +490,16 @@ impl PropertyStore for SqliteStore {
                     return Ok(None);
                 }
 
-                let ast_ty = record.try_into()?;
-
-                Ok(Some(ast_ty))
+                record.try_into_value().map_err(SqliteError::Value)
             }
             None => Ok(None),
         }
+    }
+
+    async fn unset_prop(&self, interface: &str, path: &str) -> Result<(), Self::Err> {
+        self.writer.lock().await.unset_prop(interface, path)?;
+
+        Ok(())
     }
 
     async fn delete_prop(&self, interface: &str, path: &str) -> Result<(), Self::Err> {
@@ -490,6 +534,10 @@ impl PropertyStore for SqliteStore {
         self.writer.lock().await.delete_interface_props(interface)?;
 
         Ok(())
+    }
+
+    async fn device_props_with_unset(&self) -> Result<Vec<MaybeStoredProp>, Self::Err> {
+        self.with_reader(|reader| reader.props_with_unset(Ownership::Device))
     }
 }
 

--- a/src/store/sqlite/statements.rs
+++ b/src/store/sqlite/statements.rs
@@ -23,7 +23,11 @@ use std::{
 
 use rusqlite::{Connection, OpenFlags, OptionalExtension, ToSql};
 
-use crate::{interface::Ownership, store::StoredProp, AstarteType};
+use crate::{
+    interface::Ownership,
+    store::{MaybeStoredProp, StoredProp},
+    AstarteType,
+};
 
 use super::{
     into_stored_type, wrap_sync_call, PropRecord, RecordOwnership, SqliteError, StoredRecord,
@@ -91,7 +95,7 @@ impl WriteConnection {
     ) -> Result<(), SqliteError> {
         let mapping_type = into_stored_type(prop.value)?;
 
-        let ownership = RecordOwnership::from(prop.ownership) as u8;
+        let ownership = RecordOwnership::from(prop.ownership);
 
         wrap_sync_call(|| {
             let mut statement = self
@@ -108,6 +112,22 @@ impl WriteConnection {
                     ownership,
                 ))
                 .map_err(SqliteError::Query)?;
+
+            Ok(())
+        })
+    }
+
+    pub(super) fn unset_prop(&self, interface: &str, path: &str) -> Result<(), SqliteError> {
+        wrap_sync_call(|| {
+            let mut statement = self
+                .prepare_cached(include_query!("queries/properties/write/unset_prop.sql"))
+                .map_err(SqliteError::Prepare)?;
+
+            let updated = statement
+                .execute((interface, path))
+                .map_err(SqliteError::Query)?;
+
+            debug_assert!((0..=1).contains(&updated));
 
             Ok(())
         })
@@ -227,7 +247,11 @@ impl ReadConnection {
                     })
                 })
                 .map_err(SqliteError::Query)?
-                .map(|e| e.map_err(SqliteError::Query).and_then(StoredProp::try_from))
+                .filter_map(|e| {
+                    e.map_err(SqliteError::Query)
+                        .and_then(StoredRecord::try_into_prop)
+                        .transpose()
+                })
                 .collect::<Result<Vec<StoredProp>, SqliteError>>()?;
 
             Ok(v)
@@ -238,7 +262,7 @@ impl ReadConnection {
         &self,
         ownership: Ownership,
     ) -> Result<Vec<StoredProp>, SqliteError> {
-        let ownership_par = RecordOwnership::from(ownership) as u8;
+        let ownership_par = RecordOwnership::from(ownership);
 
         wrap_sync_call(|| {
             let mut statement = self
@@ -259,16 +283,63 @@ impl ReadConnection {
                     })
                 })
                 .map_err(SqliteError::Query)?
+                .filter_map(|res| {
+                    let record = match res {
+                        Ok(record) => record,
+                        Err(err) => return Some(Err(SqliteError::Query(err))),
+                    };
+
+                    match record.try_into_prop() {
+                        Ok(Some(prop)) => {
+                            debug_assert_eq!(prop.ownership, ownership);
+
+                            Some(Ok(prop))
+                        }
+                        Ok(None) => None,
+                        Err(err) => Some(Err(err)),
+                    }
+                })
+                .collect::<Result<Vec<StoredProp>, SqliteError>>()?;
+
+            Ok(v)
+        })
+    }
+
+    pub(super) fn props_with_unset(
+        &self,
+        ownership: Ownership,
+    ) -> Result<Vec<MaybeStoredProp>, SqliteError> {
+        let ownership_par = RecordOwnership::from(ownership);
+
+        wrap_sync_call(|| {
+            let mut statement = self
+                .prepare_cached(include_query!(
+                    "queries/properties/read/props_with_unset.sql"
+                ))
+                .map_err(SqliteError::Prepare)?;
+
+            let v = statement
+                .query_map([ownership_par], |row| {
+                    Ok(StoredRecord {
+                        interface: row.get(0)?,
+                        path: row.get(1)?,
+                        value: row.get(2)?,
+                        stored_type: row.get(3)?,
+                        interface_major: row.get(4)?,
+                        ownership: row.get(5)?,
+                    })
+                })
+                .map_err(SqliteError::Query)?
                 .map(|e| {
                     e.map_err(SqliteError::Query).and_then(|record| {
-                        let prop = StoredProp::try_from(record)?;
+                        let prop = MaybeStoredProp::try_from(record)?;
 
                         debug_assert_eq!(prop.ownership, ownership);
 
                         Ok(prop)
                     })
                 })
-                .collect::<Result<Vec<StoredProp>, SqliteError>>()?;
+                .collect::<Result<Vec<MaybeStoredProp>, SqliteError>>()?;
 
             Ok(v)
         })
@@ -294,7 +365,11 @@ impl ReadConnection {
                     })
                 })
                 .map_err(SqliteError::Query)?
-                .map(|e| e.map_err(SqliteError::Query).and_then(StoredProp::try_from))
+                .filter_map(|e| {
+                    e.map_err(SqliteError::Query)
+                        .and_then(StoredRecord::try_into_prop)
+                        .transpose()
+                })
                 .collect::<Result<Vec<StoredProp>, SqliteError>>()?;
 
             Ok(v)

--- a/src/store/sqlite/statements.rs
+++ b/src/store/sqlite/statements.rs
@@ -25,7 +25,7 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, ToSql};
 
 use crate::{
     interface::Ownership,
-    store::{MaybeStoredProp, StoredProp},
+    store::{OptStoredProp, StoredProp},
     AstarteType,
 };
 
@@ -308,7 +308,7 @@ impl ReadConnection {
     pub(super) fn props_with_unset(
         &self,
         ownership: Ownership,
-    ) -> Result<Vec<MaybeStoredProp>, SqliteError> {
+    ) -> Result<Vec<OptStoredProp>, SqliteError> {
         let ownership_par = RecordOwnership::from(ownership);
 
         wrap_sync_call(|| {
@@ -332,14 +332,14 @@ impl ReadConnection {
                 .map_err(SqliteError::Query)?
                 .map(|e| {
                     e.map_err(SqliteError::Query).and_then(|record| {
-                        let prop = MaybeStoredProp::try_from(record)?;
+                        let prop = OptStoredProp::try_from(record)?;
 
                         debug_assert_eq!(prop.ownership, ownership);
 
                         Ok(prop)
                     })
                 })
-                .collect::<Result<Vec<MaybeStoredProp>, SqliteError>>()?;
+                .collect::<Result<Vec<OptStoredProp>, SqliteError>>()?;
 
             Ok(v)
         })

--- a/src/store/wrapper.rs
+++ b/src/store/wrapper.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 
 use crate::types::AstarteType;
 
-use super::{error::StoreError, MaybeStoredProp, PropertyStore, StoreCapabilities, StoredProp};
+use super::{error::StoreError, OptStoredProp, PropertyStore, StoreCapabilities, StoredProp};
 
 /// Wrapper for a generic [`AstarteDatabase`] to convert the error in [`Error`].
 #[derive(Debug, Clone)]
@@ -123,7 +123,7 @@ where
             .map_err(StoreError::delete_interface)
     }
 
-    async fn device_props_with_unset(&self) -> Result<Vec<MaybeStoredProp>, Self::Err> {
+    async fn device_props_with_unset(&self) -> Result<Vec<OptStoredProp>, Self::Err> {
         self.store
             .device_props_with_unset()
             .await

--- a/src/store/wrapper.rs
+++ b/src/store/wrapper.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 
 use crate::types::AstarteType;
 
-use super::{error::StoreError, PropertyStore, StoreCapabilities, StoredProp};
+use super::{error::StoreError, MaybeStoredProp, PropertyStore, StoreCapabilities, StoredProp};
 
 /// Wrapper for a generic [`AstarteDatabase`] to convert the error in [`Error`].
 #[derive(Debug, Clone)]
@@ -70,6 +70,13 @@ where
             .map_err(StoreError::load)
     }
 
+    async fn unset_prop(&self, interface: &str, path: &str) -> Result<(), Self::Err> {
+        self.store
+            .unset_prop(interface, path)
+            .await
+            .map_err(StoreError::unset)
+    }
+
     async fn delete_prop(&self, interface: &str, path: &str) -> Result<(), Self::Err> {
         self.store
             .delete_prop(interface, path)
@@ -114,6 +121,13 @@ where
             .delete_interface(interface)
             .await
             .map_err(StoreError::delete_interface)
+    }
+
+    async fn device_props_with_unset(&self) -> Result<Vec<MaybeStoredProp>, Self::Err> {
+        self.store
+            .device_props_with_unset()
+            .await
+            .map_err(StoreError::device_props)
     }
 }
 

--- a/src/transport/mqtt/mod.rs
+++ b/src/transport/mqtt/mod.rs
@@ -57,7 +57,6 @@ pub use self::config::Credential;
 pub use self::config::MqttConfig;
 pub use self::pairing::PairingError;
 pub use self::payload::PayloadError;
-use crate::retention::RetentionError;
 use crate::{
     client::RecvError,
     error::Report,
@@ -71,12 +70,11 @@ use crate::{
     retention::{
         memory::SharedVolatileStore, PublishInfo, RetentionId, StoredRetention, StoredRetentionExt,
     },
-    store::{
-        error::StoreError, wrapper::StoreWrapper, PropertyStore, StoreCapabilities, StoredProp,
-    },
+    store::{error::StoreError, wrapper::StoreWrapper, PropertyStore, StoreCapabilities},
     validate::{ValidatedIndividual, ValidatedObject, ValidatedUnset},
     AstarteType, Error, Interface, Timestamp,
 };
+use crate::{retention::RetentionError, store::OptStoredProp};
 
 use self::{
     client::AsyncClient,
@@ -759,7 +757,7 @@ where
 pub(crate) struct SessionData {
     interfaces: String,
     server_interfaces: Vec<String>,
-    device_properties: Vec<StoredProp>,
+    device_properties: Vec<OptStoredProp>,
 }
 
 impl SessionData {
@@ -778,7 +776,7 @@ impl SessionData {
     where
         S: PropertyStore<Err = StoreError>,
     {
-        let device_properties = store.device_props().await?;
+        let device_properties = store.device_props_with_unset().await?;
         let server_interfaces = Self::filter_server_interfaces(interfaces);
 
         Ok(Self {


### PR DESCRIPTION
Do not send properties when we are offline, also unset the property
before sending it. This will let us, if offline, resend the unset when
re-connected and delete the property only if actually sent.
