### PR TITLE
feat(derive): add allow unset for Optional values

### DIFF
--- a/astarte-device-sdk-derive/CHANGELOG.md
+++ b/astarte-device-sdk-derive/CHANGELOG.md
@@ -11,6 +11,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Implement the FromEvent derive macro for individual interfaces, via the `aggregation` attribute to
   the macro [#375](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/375)
+- Add the `allow_unset` attribute to permit `Option` values for `Value::Unset`
+  [#378](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/378)
 
 ## [0.8.3] - 2024-08-22
 

--- a/astarte-device-sdk-derive/src/event.rs
+++ b/astarte-device-sdk-derive/src/event.rs
@@ -172,7 +172,7 @@ impl FromEventDerive {
             impl #impl_generics astarte_device_sdk::FromEvent for #name #ty_generics #where_clause {
                 type Err = astarte_device_sdk::event::FromEventError;
 
-                fn from_event(event: astarte_device_sdk::DeviceEvent) -> Result<Self, Self::Err> {
+                fn from_event(event: astarte_device_sdk::DeviceEvent) -> ::std::result::Result<Self, Self::Err> {
                     use astarte_device_sdk::Value;
                     use astarte_device_sdk::event::FromEventError;
                     use astarte_device_sdk::interface::mapping::endpoint::Endpoint;
@@ -276,7 +276,7 @@ impl FromEventDerive {
             impl #impl_generics astarte_device_sdk::FromEvent for #name #ty_generics #where_clause {
                 type Err = astarte_device_sdk::event::FromEventError;
 
-                fn from_event(event: astarte_device_sdk::DeviceEvent) -> Result<Self, Self::Err> {
+                fn from_event(event: astarte_device_sdk::DeviceEvent) -> ::std::result::Result<Self, Self::Err> {
                     use astarte_device_sdk::Value;
                     use astarte_device_sdk::AstarteType;
                     use astarte_device_sdk::event::FromEventError;

--- a/astarte-device-sdk-derive/src/lib.rs
+++ b/astarte-device-sdk-derive/src/lib.rs
@@ -169,7 +169,7 @@ impl AggregateDerive {
             impl #impl_generics astarte_device_sdk::AstarteAggregate for #name #ty_generics #where_clause {
                 fn astarte_aggregate(
                     self,
-                ) -> Result<
+                ) -> ::std::result::Result<
                     std::collections::HashMap<String, astarte_device_sdk::types::AstarteType>,
                     astarte_device_sdk::error::Error,
                 > {

--- a/astarte-device-sdk-derive/src/lib.rs
+++ b/astarte-device-sdk-derive/src/lib.rs
@@ -116,6 +116,20 @@ fn parse_str_lit(expr: &Expr) -> syn::Result<String> {
     }
 }
 
+/// Parses a [`syn::Lit::Bool`] into a [`bool`].
+fn parse_bool_lit(expr: &Expr) -> syn::Result<bool> {
+    match expr {
+        Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Bool(lit),
+            ..
+        }) => Ok(lit.value()),
+        _ => Err(syn::Error::new(
+            expr.span(),
+            "expression must be a bool literal",
+        )),
+    }
+}
+
 /// Handle for the `#[derive(AstarteAggregate)]` derive macro.
 ///
 /// ### Example
@@ -305,8 +319,8 @@ pub fn astarte_aggregate_derive(input: TokenStream) -> TokenStream {
 /// enum Sensor {
 ///     #[mapping(endpoint = "/sensor/luminosity")]
 ///     Luminosity(i32),
-///     #[mapping(endpoint = "/sensor/temerature")]
-///     Temperature(f32),
+///     #[mapping(endpoint = "/sensor/temerature", allow_unset = true)]
+///     Temperature(Option<f64>),
 /// }
 /// ```
 #[proc_macro_derive(FromEvent, attributes(from_event, mapping))]

--- a/src/event.rs
+++ b/src/event.rs
@@ -41,8 +41,8 @@ pub enum FromEventError {
     /// couldn't parse request from interface
     #[error("couldn't parse request from interface {0}")]
     Interface(String),
-    /// object has wrong base path
-    #[error("object {interface} has wrong base path {base_path}")]
+    /// couldn't parse the event path
+    #[error("the interface {interface} has wrong path {base_path}")]
     Path {
         /// Interface that generated the error
         interface: &'static str,


### PR DESCRIPTION
Add the attribute `allow_unset` to make the value of an individual property be wrapped in an `Option` when the value is un `Value::Unset`.