### PR TITLE
chore(release): prepare release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.1] - 2024-09-25
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "astarte-device-sdk-derive",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-mock"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astarte-device-sdk",
  "async-trait",
@@ -511,7 +511,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "e2e-test"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astarte-device-sdk",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 homepage = "https://astarte.cloud/"
 license = "Apache-2.0"
@@ -107,8 +107,8 @@ all-features = true
 rustc-args = ["--cfg=docsrs"]
 
 [workspace.dependencies]
-astarte-device-sdk = { path = "./", version = "=0.9.0" }
-astarte-device-sdk-derive = { version = "=0.9.0", path = "./astarte-device-sdk-derive" }
+astarte-device-sdk = { path = "./", version = "=0.9.1" }
+astarte-device-sdk-derive = { version = "=0.9.1", path = "./astarte-device-sdk-derive" }
 astarte-message-hub-proto = "0.7.0"
 async-trait = "0.1.67"
 base64 = "0.22.0"

--- a/astarte-device-sdk-derive/CHANGELOG.md
+++ b/astarte-device-sdk-derive/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2024-09-25
+
 ## [0.9.0] - 2024-09-24
 
 ### Changed

--- a/astarte-device-sdk-mock/CHANGELOG.md
+++ b/astarte-device-sdk-mock/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2024-09-25
+
 ## [0.9.0] - 2024-09-24
 
 ## [0.8.4] - 2024-09-11


### PR DESCRIPTION
Bump versions in Cargo.toml and update the CHANGELOGs.