### PR TITLE
chore(release): prepare for release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.3] - Unreleased
+## [0.9.3] - 2025-01-24
 
 ### Fixed
 
-- Update `rumqttc` to fix a bug in the MQTT unsubscribe
-  [#403](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/403)
+- Update `rumqttc` to fix a bug in the MQTT unsubscribe [#403]
+
+### Changed
+
+- Bump `rustls` and related dependencies to version `0.23` [#403]
+
+[#403]: https://github.com/astarte-platform/astarte-device-sdk-rust/pull/403
 
 ## [0.9.2] - 2024-11-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "ahash",
  "astarte-device-sdk-derive",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-mock"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astarte-device-sdk",
  "async-trait",
@@ -619,7 +619,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e2e-test"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astarte-device-sdk",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 # This file is part of Astarte.
 #
-# Copyright 2022 SECO Mind Srl
+# Copyright 2022 - 2025 SECO Mind Srl
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -40,7 +40,7 @@ members = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 homepage = "https://astarte.cloud/"
 license = "Apache-2.0"
@@ -109,8 +109,8 @@ all-features = true
 rustc-args = ["--cfg=docsrs"]
 
 [workspace.dependencies]
-astarte-device-sdk = { path = "./", version = "=0.9.2" }
-astarte-device-sdk-derive = { version = "=0.9.2", path = "./astarte-device-sdk-derive" }
+astarte-device-sdk = { path = "./", version = "=0.9.3" }
+astarte-device-sdk-derive = { version = "=0.9.3", path = "./astarte-device-sdk-derive" }
 astarte-message-hub-proto = "0.7.0"
 async-trait = "0.1.67"
 base64 = "0.22.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -53,7 +53,7 @@ SPDX-License-Identifier = "CC0-1.0"
 [[annotations]]
 path = ["CHANGELOG.md", "**/CHANGELOG.md"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023-2024 SECO Mind Srl"
+SPDX-FileCopyrightText = "SECO Mind Srl"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]

--- a/astarte-device-sdk-derive/CHANGELOG.md
+++ b/astarte-device-sdk-derive/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2025-01-24
+
 ## [0.9.2] - 2024-11-04
 
 ## [0.9.1] - 2024-09-25

--- a/astarte-device-sdk-mock/CHANGELOG.md
+++ b/astarte-device-sdk-mock/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2025-01-24
+
 ## [0.9.2] - 2024-11-04
 
 ## [0.9.1] - 2024-09-25


### PR DESCRIPTION
Bump version in Cargo.toml and update CHANGELOGs.