### PR TITLE
fix(error): add source macro to backtrace

### DIFF
--- a/src/interface/error.rs
+++ b/src/interface/error.rs
@@ -86,6 +86,7 @@ pub enum InterfaceFileError {
     #[error("invalid interface file {}", .path.display())]
     Interface {
         path: PathBuf,
+        #[source]
         backtrace: InterfaceError,
     },
 }


### PR DESCRIPTION
The error why an interface couldn't be added was not showing the full
backtrace.