### PR TITLE
refactor!(validation): make it stricter to reflect the new API

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -404,7 +404,7 @@ pub trait ConnectionConfig<S> {
         S: PropertyStore;
 
     /// This method allows the connection config to modify the retention capacity.
-    /// The default implmenetation returns a [`None`] to avoid editing the default
+    /// The default implementation returns a [`None`] to avoid editing the default
     /// retention config.
     // NOTE: Used by the GrpcConfig to disable retention of messages.
     fn volatile_capacity_override() -> Option<usize> {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -32,7 +32,7 @@ use tokio::{
 };
 use tracing::{debug, error, info, trace, warn};
 
-use crate::error::AggregateError;
+use crate::error::AggregationError;
 use crate::store::PropertyMapping;
 use crate::transport::TransportError;
 use crate::{
@@ -929,8 +929,8 @@ impl<S, C> DeviceReceiver<S, C> {
         C: Receive + Sync,
     {
         let Some(object) = interface.as_object_ref() else {
-            let aggr_err = AggregateError::for_interface(
-                interface.interface_name(),
+            let aggr_err = AggregationError::new(
+                interface.interface_name().to_string(),
                 path.to_string(),
                 InterfaceAggregation::Object,
                 InterfaceAggregation::Individual,

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -27,11 +27,14 @@ use itertools::Itertools;
 use tracing::{debug, trace};
 
 use crate::{
+    error::InterfaceTypeError,
     interface::{
         error::InterfaceError,
         mapping::path::MappingPath,
         reference::{MappingRef, PropertyRef},
+        InterfaceTypeDef,
     },
+    validate::UserValidationError,
     Error, Interface,
 };
 
@@ -162,9 +165,12 @@ impl Interfaces {
                 name: interface_name.to_string(),
             })
             .and_then(|interface| {
-                interface.as_prop_ref().ok_or_else(|| Error::InterfaceType {
-                    exp: crate::interface::InterfaceTypeDef::Properties,
-                    got: interface.interface_type(),
+                interface.as_prop_ref().ok_or_else(|| {
+                    Error::Validation(UserValidationError::InterfaceType(InterfaceTypeError::new(
+                        interface_name,
+                        InterfaceTypeDef::Properties,
+                        interface.interface_type(),
+                    )))
                 })
             })
             .and_then(|interface| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,19 @@ mod test {
         "../e2e-test/interfaces/additional/org.astarte-platform.rust.e2etest.DeviceProperty.json"
     );
 
+    pub(crate) const DEVICE_PROPERTIES_NO_UNSET: &str = r#"{
+    "interface_name": "org.astarte-platform.rust.examples.individual-properties.DevicePropertyNoUnset",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "properties",
+    "ownership": "device",
+    "mappings": [{
+        "endpoint": "/%{sensor_id}/enable",
+        "type": "boolean",
+        "allow_unset": false
+    }]
+}"#;
+
     pub(crate) async fn mock_astarte_device<I>(
         client: AsyncClient,
         eventloop: MqttEventLoop,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -216,7 +216,7 @@ pub trait Disconnect {
 #[cfg(test)]
 mod test {
     use crate::aggregate::AstarteObject;
-    use crate::error::AggregateError;
+    use crate::error::AggregationError;
     use crate::{
         interface::{mapping::path::MappingPath, reference::MappingRef},
         types::{AstarteType, TypeError},
@@ -231,8 +231,8 @@ mod test {
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<ValidatedObject, crate::Error> {
         let object = interface.as_object_ref().ok_or_else(|| {
-            let aggr_err = AggregateError::for_interface(
-                interface.interface_name(),
+            let aggr_err = AggregationError::new(
+                interface.interface_name().to_string(),
                 path.to_string(),
                 crate::interface::Aggregation::Object,
                 interface.aggregation(),
@@ -245,7 +245,6 @@ mod test {
 
     pub(crate) fn mock_validate_individual<'a, D>(
         mapping_ref: MappingRef<'a, &'a Interface>,
-        path: &'a MappingPath<'a>,
         data: D,
         timestamp: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<ValidatedIndividual, crate::Error>
@@ -254,7 +253,6 @@ mod test {
     {
         let individual = data.try_into().map_err(|_| TypeError::Conversion)?;
 
-        ValidatedIndividual::validate(mapping_ref, path, individual, timestamp)
-            .map_err(|uve| uve.into())
+        ValidatedIndividual::validate(mapping_ref, individual, timestamp).map_err(|uve| uve.into())
     }
 }

--- a/src/transport/mqtt/pairing.rs
+++ b/src/transport/mqtt/pairing.rs
@@ -310,7 +310,7 @@ pub(crate) mod tests {
                 let client_crt = self_sign_csr_to_pem(&csr);
 
                 serde_json::to_vec(&ApiData::new(MqttV1Certificate { client_crt }))
-                    .expect("couldn't serialize reposonse")
+                    .expect("couldn't serialize response")
             })
             .match_header("authorization", "Bearer secret")
     }

--- a/src/transport/mqtt/payload.rs
+++ b/src/transport/mqtt/payload.rs
@@ -208,7 +208,8 @@ pub(super) fn deserialize_object(
 
 #[cfg(test)]
 mod test {
-    use chrono::Utc;
+    use chrono::{DateTime, Utc};
+    use pretty_assertions::assert_eq;
     use std::str::FromStr;
 
     use chrono::TimeZone;
@@ -276,7 +277,12 @@ mod test {
             let path = mapping(endpoint.as_str());
             let mapping = interface.as_mapping_ref(&path).unwrap();
 
-            let validated = mock_validate_individual(mapping, &path, ty.clone(), None).unwrap();
+            let validated = mock_validate_individual(
+                mapping,
+                ty.clone(),
+                Some(TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap()),
+            )
+            .unwrap();
             let buf = serialize_individual(&validated.data, validated.timestamp).unwrap();
 
             let (res, _) = deserialize_individual(&mapping, &buf)
@@ -326,7 +332,13 @@ mod test {
 
         let path = mapping(base_path);
 
-        let validated = mock_validate_object(&interface, &path, data.clone(), None).unwrap();
+        let validated = mock_validate_object(
+            &interface,
+            &path,
+            data.clone(),
+            Some(TimeZone::timestamp_opt(&Utc, 1627580809, 0).unwrap()),
+        )
+        .unwrap();
         let buf = serialize_object(&validated.data, validated.timestamp).unwrap();
 
         let (mut res, _) =
@@ -361,11 +373,19 @@ mod test {
         let mapping = interface.as_mapping_ref(&path).unwrap();
 
         let og_value = AstarteType::LongInteger(3600);
-        let validated =
-            ValidatedIndividual::validate(mapping, &path, og_value.clone(), None).unwrap();
+        let validated = ValidatedIndividual::validate(
+            mapping,
+            og_value.clone(),
+            Some(DateTime::from_timestamp_millis(42).unwrap()),
+        )
+        .unwrap();
         let buf = serialize_individual(&validated.data, validated.timestamp).unwrap();
 
-        let expected = [16, 0, 0, 0, 18, 118, 0, 16, 14, 0, 0, 0, 0, 0, 0, 0];
+        let expected = [
+            48, 0, 0, 0, 18, 118, 0, 16, 14, 0, 0, 0, 0, 0, 0, 2, 116, 0, 25, 0, 0, 0, 49, 57, 55,
+            48, 45, 48, 49, 45, 48, 49, 84, 48, 48, 58, 48, 48, 58, 48, 48, 46, 48, 52, 50, 90, 0,
+            0,
+        ];
 
         assert_eq!(buf, expected);
 


### PR DESCRIPTION
Check the interface type, ownership and aggregation in the user
validation. Return an hard error if one is incorrect.