### PR TITLE
Reflect proto changes after `AstarteDatastreamIndividual` typo fix 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "astarte-message-hub-proto"
 version = "0.7.0"
-source = "git+https://github.com/astarte-platform/astarte-message-hub-proto?rev=20ba40215172613bfab149676adf0dbd9f3ccc92#20ba40215172613bfab149676adf0dbd9f3ccc92"
+source = "git+https://github.com/astarte-platform/astarte-message-hub-proto?rev=29c9d6f99c2c1fa004a53d51f287d7e0ba342137#29c9d6f99c2c1fa004a53d51f287d7e0ba342137"
 dependencies = [
  "chrono",
  "pbjson-types",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "astarte-message-hub-proto-mock"
 version = "0.7.0"
-source = "git+https://github.com/astarte-platform/astarte-message-hub-proto?rev=20ba40215172613bfab149676adf0dbd9f3ccc92#20ba40215172613bfab149676adf0dbd9f3ccc92"
+source = "git+https://github.com/astarte-platform/astarte-message-hub-proto?rev=29c9d6f99c2c1fa004a53d51f287d7e0ba342137#29c9d6f99c2c1fa004a53d51f287d7e0ba342137"
 dependencies = [
  "astarte-message-hub-proto",
  "mockall 0.13.1",
@@ -414,7 +414,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -1368,27 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1990,7 +1972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -2010,7 +1992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,8 +134,8 @@ rustc-args = ["--cfg=docsrs"]
 [workspace.dependencies]
 astarte-device-sdk = { path = "./", version = "=0.9.6" }
 astarte-device-sdk-derive = { version = "=0.9.6", path = "./astarte-device-sdk-derive" }
-astarte-message-hub-proto = { git = "https://github.com/astarte-platform/astarte-message-hub-proto", rev = "20ba40215172613bfab149676adf0dbd9f3ccc92" }
-astarte-message-hub-proto-mock = { git = "https://github.com/astarte-platform/astarte-message-hub-proto", rev = "20ba40215172613bfab149676adf0dbd9f3ccc92" }
+astarte-message-hub-proto = { git = "https://github.com/astarte-platform/astarte-message-hub-proto", rev = "29c9d6f99c2c1fa004a53d51f287d7e0ba342137" }
+astarte-message-hub-proto-mock = { git = "https://github.com/astarte-platform/astarte-message-hub-proto", rev = "29c9d6f99c2c1fa004a53d51f287d7e0ba342137" }
 async-trait = "0.1.67"
 base64 = "0.22.0"
 bson = "2.7.0"

--- a/src/transport/grpc/convert.rs
+++ b/src/transport/grpc/convert.rs
@@ -26,8 +26,7 @@ use std::num::TryFromIntError;
 use astarte_message_hub_proto::message_hub_event::Event;
 use astarte_message_hub_proto::{astarte_message::Payload as ProtoPayload, pbjson_types};
 use astarte_message_hub_proto::{
-    AstarteDatastreamIndividual, AstarteDatastreamObject, MessageHubEvent,
-};
+    AstarteDatastreamIndividual, AstarteDatastreamObject, MessageHubEvent};
 use chrono::TimeZone;
 use itertools::Itertools;
 

--- a/src/transport/grpc/convert.rs
+++ b/src/transport/grpc/convert.rs
@@ -23,10 +23,12 @@
 
 use std::num::TryFromIntError;
 
+use astarte_message_hub_proto::astarte_data::AstarteData as ProtoData;
 use astarte_message_hub_proto::message_hub_event::Event;
 use astarte_message_hub_proto::{astarte_message::Payload as ProtoPayload, pbjson_types};
 use astarte_message_hub_proto::{
-    AstarteDatastreamIndividual, AstarteDatastreamObject, MessageHubEvent};
+    AstarteDatastreamIndividual, AstarteDatastreamObject, MessageHubEvent,
+};
 use chrono::TimeZone;
 use itertools::Itertools;
 
@@ -119,36 +121,25 @@ impl TryFrom<astarte_message_hub_proto::AstarteData> for AstarteType {
     type Error = MessageHubProtoError;
 
     fn try_from(value: astarte_message_hub_proto::AstarteData) -> Result<Self, Self::Error> {
-        value
+        let astarte_data = value
             .astarte_data
-            .ok_or(MessageHubProtoError::ExpectedField("astarte_data"))?
-            .try_into()
-    }
-}
+            .ok_or(MessageHubProtoError::ExpectedField("astarte_data"))?;
 
-impl TryFrom<astarte_message_hub_proto::astarte_data::AstarteData> for AstarteType {
-    type Error = MessageHubProtoError;
-
-    fn try_from(
-        value: astarte_message_hub_proto::astarte_data::AstarteData,
-    ) -> Result<Self, Self::Error> {
-        use astarte_message_hub_proto::astarte_data::AstarteData::*;
-
-        match value {
-            DateTime(v) => convert_timestamp(v).map(AstarteType::DateTime),
-            Double(v) => Ok(AstarteType::Double(v)),
-            Integer(v) => Ok(AstarteType::Integer(v)),
-            Boolean(v) => Ok(AstarteType::Boolean(v)),
-            LongInteger(v) => Ok(AstarteType::LongInteger(v)),
-            String(v) => Ok(AstarteType::String(v)),
-            BinaryBlob(v) => Ok(AstarteType::BinaryBlob(v)),
-            DoubleArray(arr) => Ok(AstarteType::DoubleArray(arr.values)),
-            IntegerArray(arr) => Ok(AstarteType::IntegerArray(arr.values)),
-            BooleanArray(arr) => Ok(AstarteType::BooleanArray(arr.values)),
-            LongIntegerArray(arr) => Ok(AstarteType::LongIntegerArray(arr.values)),
-            StringArray(arr) => Ok(AstarteType::StringArray(arr.values)),
-            BinaryBlobArray(arr) => Ok(AstarteType::BinaryBlobArray(arr.values)),
-            DateTimeArray(arr) => arr
+        match astarte_data {
+            ProtoData::DateTime(v) => convert_timestamp(v).map(AstarteType::DateTime),
+            ProtoData::Double(v) => Ok(AstarteType::Double(v)),
+            ProtoData::Integer(v) => Ok(AstarteType::Integer(v)),
+            ProtoData::Boolean(v) => Ok(AstarteType::Boolean(v)),
+            ProtoData::LongInteger(v) => Ok(AstarteType::LongInteger(v)),
+            ProtoData::String(v) => Ok(AstarteType::String(v)),
+            ProtoData::BinaryBlob(v) => Ok(AstarteType::BinaryBlob(v)),
+            ProtoData::DoubleArray(arr) => Ok(AstarteType::DoubleArray(arr.values)),
+            ProtoData::IntegerArray(arr) => Ok(AstarteType::IntegerArray(arr.values)),
+            ProtoData::BooleanArray(arr) => Ok(AstarteType::BooleanArray(arr.values)),
+            ProtoData::LongIntegerArray(arr) => Ok(AstarteType::LongIntegerArray(arr.values)),
+            ProtoData::StringArray(arr) => Ok(AstarteType::StringArray(arr.values)),
+            ProtoData::BinaryBlobArray(arr) => Ok(AstarteType::BinaryBlobArray(arr.values)),
+            ProtoData::DateTimeArray(arr) => arr
                 .values
                 .into_iter()
                 .map(convert_timestamp)
@@ -173,82 +164,50 @@ fn convert_timestamp(
         .ok_or_else(|| MessageHubProtoError::DateConversion(format!("{val:?}")))
 }
 
-impl TryFrom<astarte_message_hub_proto::AstarteDatastreamIndividual> for AstarteType {
-    type Error = MessageHubProtoError;
-
-    fn try_from(
-        value: astarte_message_hub_proto::AstarteDatastreamIndividual,
-    ) -> Result<Self, Self::Error> {
-        value
-            .data
-            .ok_or(MessageHubProtoError::ExpectedField("data"))?
-            .try_into()
-    }
-}
-
-impl TryFrom<astarte_message_hub_proto::AstartePropertyIndividual> for AstarteType {
-    type Error = MessageHubProtoError;
-
-    fn try_from(
-        value: astarte_message_hub_proto::AstartePropertyIndividual,
-    ) -> Result<Self, Self::Error> {
-        value
-            .data
-            .ok_or(MessageHubProtoError::ExpectedField("data"))?
-            .try_into()
-    }
-}
-
 impl From<AstarteType> for astarte_message_hub_proto::AstarteData {
     fn from(value: AstarteType) -> Self {
-        Self {
-            astarte_data: Some(value.into()),
-        }
-    }
-}
-
-impl From<AstarteType> for astarte_message_hub_proto::astarte_data::AstarteData {
-    fn from(value: AstarteType) -> Self {
-        use astarte_message_hub_proto::{
-            astarte_data::AstarteData, AstarteBinaryBlobArray, AstarteBooleanArray,
-            AstarteDateTimeArray, AstarteDoubleArray, AstarteIntegerArray, AstarteLongIntegerArray,
-            AstarteStringArray,
-        };
-
-        match value {
-            AstarteType::Double(value) => AstarteData::Double(value),
-            AstarteType::Integer(value) => AstarteData::Integer(value),
-            AstarteType::Boolean(value) => AstarteData::Boolean(value),
-            AstarteType::LongInteger(value) => AstarteData::LongInteger(value),
-            AstarteType::String(value) => AstarteData::String(value),
-            AstarteType::BinaryBlob(value) => AstarteData::BinaryBlob(value),
-            AstarteType::DateTime(value) => AstarteData::DateTime(value.into()),
+        let astarte_data = match value {
+            AstarteType::Double(value) => ProtoData::Double(value),
+            AstarteType::Integer(value) => ProtoData::Integer(value),
+            AstarteType::Boolean(value) => ProtoData::Boolean(value),
+            AstarteType::LongInteger(value) => ProtoData::LongInteger(value),
+            AstarteType::String(value) => ProtoData::String(value),
+            AstarteType::BinaryBlob(value) => ProtoData::BinaryBlob(value),
+            AstarteType::DateTime(value) => ProtoData::DateTime(value.into()),
             AstarteType::DoubleArray(values) => {
-                AstarteData::DoubleArray(AstarteDoubleArray { values })
+                ProtoData::DoubleArray(astarte_message_hub_proto::AstarteDoubleArray { values })
             }
             AstarteType::IntegerArray(values) => {
-                AstarteData::IntegerArray(AstarteIntegerArray { values })
+                ProtoData::IntegerArray(astarte_message_hub_proto::AstarteIntegerArray { values })
             }
             AstarteType::BooleanArray(values) => {
-                AstarteData::BooleanArray(AstarteBooleanArray { values })
+                ProtoData::BooleanArray(astarte_message_hub_proto::AstarteBooleanArray { values })
             }
             AstarteType::LongIntegerArray(values) => {
-                AstarteData::LongIntegerArray(AstarteLongIntegerArray { values })
-            }
-            AstarteType::StringArray(values) => {
-                AstarteData::StringArray(AstarteStringArray { values })
-            }
-            AstarteType::BinaryBlobArray(values) => {
-                AstarteData::BinaryBlobArray(AstarteBinaryBlobArray { values })
-            }
-            AstarteType::DateTimeArray(values) => {
-                AstarteData::DateTimeArray(AstarteDateTimeArray {
-                    values: values
-                        .into_iter()
-                        .map(pbjson_types::Timestamp::from)
-                        .collect(),
+                ProtoData::LongIntegerArray(astarte_message_hub_proto::AstarteLongIntegerArray {
+                    values,
                 })
             }
+            AstarteType::StringArray(values) => {
+                ProtoData::StringArray(astarte_message_hub_proto::AstarteStringArray { values })
+            }
+            AstarteType::BinaryBlobArray(values) => {
+                ProtoData::BinaryBlobArray(astarte_message_hub_proto::AstarteBinaryBlobArray {
+                    values,
+                })
+            }
+            AstarteType::DateTimeArray(values) => {
+                let values = values
+                    .into_iter()
+                    .map(pbjson_types::Timestamp::from)
+                    .collect();
+
+                ProtoData::DateTimeArray(astarte_message_hub_proto::AstarteDateTimeArray { values })
+            }
+        };
+
+        Self {
+            astarte_data: Some(astarte_data),
         }
     }
 }
@@ -261,17 +220,11 @@ impl TryFrom<MessageHubEvent> for ReceivedEvent<GrpcPayload> {
             .event
             .ok_or(MessageHubProtoError::ExpectedField("event"))?;
 
-        match event {
-            Event::Message(msg) => msg.try_into().map_err(GrpcError::MessageHubProtoConversion),
-            Event::Error(err) => Err(GrpcError::Server(err)),
-        }
-    }
-}
+        let message = match event {
+            Event::Message(msg) => msg,
+            Event::Error(err) => return Err(GrpcError::Server(err)),
+        };
 
-impl TryFrom<astarte_message_hub_proto::AstarteMessage> for ReceivedEvent<GrpcPayload> {
-    type Error = MessageHubProtoError;
-
-    fn try_from(message: astarte_message_hub_proto::AstarteMessage) -> Result<Self, Self::Error> {
         let payload = message
             .payload
             .ok_or(MessageHubProtoError::ExpectedField("payload"))?;
@@ -455,10 +408,11 @@ impl From<Value> for ProtoPayload {
 #[cfg(test)]
 pub(crate) mod test {
     use astarte_message_hub_proto::{
-        astarte_data::AstarteData, AstarteDatastreamObject, AstarteMessage,
-        AstartePropertyIndividual, InterfaceProperties,
+        AstarteData, AstarteDatastreamObject, AstarteMessage, AstartePropertyIndividual,
+        InterfaceProperties,
     };
-    use chrono::{DateTime, Utc};
+    use chrono::Utc;
+    use pretty_assertions::assert_eq;
 
     use crate::Timestamp;
 
@@ -489,213 +443,32 @@ pub(crate) mod test {
     }
 
     #[test]
-    fn proto_astarte_double_into_astarte_device_sdk_type_success() {
-        let value = 15.5;
-        let expected_double_value = AstarteData::Double(value);
-        let astarte_type = expected_double_value.try_into().unwrap();
+    fn proto_conversions_success() {
+        let cases = [
+            AstarteType::Double(12.21),
+            AstarteType::Integer(12),
+            AstarteType::Boolean(false),
+            AstarteType::LongInteger(42),
+            AstarteType::String("hello".to_string()),
+            AstarteType::BinaryBlob(vec![1, 2, 3, 4]),
+            AstarteType::DateTime(TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap()),
+            AstarteType::DoubleArray(vec![1.3, 2.6, 3.1, 4.0]),
+            AstarteType::IntegerArray(vec![1, 2, 3, 4]),
+            AstarteType::BooleanArray(vec![true, false, true, true]),
+            AstarteType::LongIntegerArray(vec![32, 11, 33, 1]),
+            AstarteType::StringArray(vec!["Hello".to_string(), " world!".to_string()]),
+            AstarteType::BinaryBlobArray(vec![vec![1, 2, 3, 4], vec![4, 4, 1, 4]]),
+            AstarteType::DateTimeArray(vec![
+                TimeZone::timestamp_opt(&Utc, 1627580808, 0).unwrap(),
+                TimeZone::timestamp_opt(&Utc, 1611580808, 0).unwrap(),
+            ]),
+        ];
 
-        if let AstarteType::Double(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
+        for exp in cases {
+            let proto = AstarteData::from(exp.clone());
+            let astarte_type = AstarteType::try_from(proto).unwrap();
 
-    #[test]
-    fn proto_astarte_integer_into_astarte_device_sdk_type_success() {
-        let value: i32 = 15;
-        let expected_integer_value = AstarteData::Integer(value);
-        let astarte_type: AstarteType = expected_integer_value.try_into().unwrap();
-
-        if let AstarteType::Integer(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_boolean_into_astarte_device_sdk_type_success() {
-        let value: bool = true;
-        let expected_boolean_value = AstarteData::Boolean(value);
-        let astarte_type: AstarteType = expected_boolean_value.try_into().unwrap();
-
-        if let AstarteType::Boolean(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_long_integer_into_astarte_device_sdk_type_success() {
-        let value: i64 = 154;
-        let expected_long_integer_value = AstarteData::LongInteger(value);
-        let astarte_type: AstarteType = expected_long_integer_value.try_into().unwrap();
-
-        if let AstarteType::LongInteger(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_string_into_astarte_device_sdk_type_success() {
-        let value: String = "test".to_owned();
-        let expected_string_value = AstarteData::String(value.clone());
-        let astarte_type: AstarteType = expected_string_value.try_into().unwrap();
-
-        if let AstarteType::String(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_binary_blob_into_astarte_device_sdk_type_success() {
-        let value: Vec<u8> = vec![10, 34];
-        let expected_binary_blob_value = AstarteData::BinaryBlob(value.clone());
-        let astarte_type: AstarteType = expected_binary_blob_value.try_into().unwrap();
-
-        if let AstarteType::BinaryBlob(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_date_time_into_astarte_device_sdk_type_success() {
-        let value: DateTime<Utc> = Utc::now();
-        let expected_date_time_value = AstarteData::DateTime(value.into());
-        let astarte_type: AstarteType = expected_date_time_value.try_into().unwrap();
-
-        if let AstarteType::DateTime(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_double_array_into_astarte_device_sdk_type_success() {
-        let value: Vec<f64> = vec![15.5, 18.7];
-        use astarte_message_hub_proto::AstarteDoubleArray;
-        let expected_double_array_value = AstarteData::DoubleArray(AstarteDoubleArray {
-            values: value.clone(),
-        });
-        let astarte_type: AstarteType = expected_double_array_value.try_into().unwrap();
-
-        if let AstarteType::DoubleArray(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_integer_array_into_astarte_device_sdk_type_success() {
-        let value: Vec<i32> = vec![15, 18];
-        use astarte_message_hub_proto::AstarteIntegerArray;
-        let expected_integer_array_value = AstarteData::IntegerArray(AstarteIntegerArray {
-            values: value.clone(),
-        });
-        let astarte_type: AstarteType = expected_integer_array_value.try_into().unwrap();
-
-        if let AstarteType::IntegerArray(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_boolean_array_into_astarte_device_sdk_type_success() {
-        let value: Vec<bool> = vec![false, true];
-        use astarte_message_hub_proto::AstarteBooleanArray;
-        let expected_boolean_array_value = AstarteData::BooleanArray(AstarteBooleanArray {
-            values: value.clone(),
-        });
-        let astarte_type: AstarteType = expected_boolean_array_value.try_into().unwrap();
-
-        if let AstarteType::BooleanArray(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_long_integer_array_into_astarte_device_sdk_type_success() {
-        let value: Vec<i64> = vec![1543, 18];
-        use astarte_message_hub_proto::AstarteLongIntegerArray;
-        let expected_long_integer_array_value =
-            AstarteData::LongIntegerArray(AstarteLongIntegerArray {
-                values: value.clone(),
-            });
-        let astarte_type: AstarteType = expected_long_integer_array_value.try_into().unwrap();
-
-        if let AstarteType::LongIntegerArray(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_string_array_into_astarte_device_sdk_type_success() {
-        let value: Vec<String> = vec!["test1".to_owned(), "test2".to_owned()];
-        use astarte_message_hub_proto::AstarteStringArray;
-        let expected_string_array_value = AstarteData::StringArray(AstarteStringArray {
-            values: value.clone(),
-        });
-        let astarte_type: AstarteType = expected_string_array_value.try_into().unwrap();
-
-        if let AstarteType::StringArray(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_binary_blob_array_into_astarte_device_sdk_type_success() {
-        let value: Vec<Vec<u8>> = vec![vec![11, 201], vec![1, 241]];
-        use astarte_message_hub_proto::AstarteBinaryBlobArray;
-        let expected_binary_blob_array_value =
-            AstarteData::BinaryBlobArray(AstarteBinaryBlobArray {
-                values: value.clone(),
-            });
-        let astarte_type: AstarteType = expected_binary_blob_array_value.try_into().unwrap();
-
-        if let AstarteType::BinaryBlobArray(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
-        }
-    }
-
-    #[test]
-    fn proto_astarte_date_time_array_into_astarte_device_sdk_type_success() {
-        use astarte_message_hub_proto::AstarteDateTimeArray;
-        use pbjson_types::Timestamp;
-
-        let value: Vec<DateTime<Utc>> = vec![Utc::now(), Utc::now()];
-        let expected_date_time_array_value = AstarteData::DateTimeArray(AstarteDateTimeArray {
-            values: value
-                .clone()
-                .into_iter()
-                .map(|it| it.into())
-                .collect::<Vec<Timestamp>>(),
-        });
-        let astarte_type: AstarteType = expected_date_time_array_value.try_into().unwrap();
-
-        if let AstarteType::DateTimeArray(astarte_value) = astarte_type {
-            assert_eq!(value, astarte_value);
-        } else {
-            panic!();
+            assert_eq!(exp, astarte_type);
         }
     }
 
@@ -706,7 +479,10 @@ pub(crate) mod test {
         let interface_path = "test".to_string();
 
         let astarte_type: AstarteType = expected_data.try_into().unwrap();
-        let payload: ProtoPayload = ProtoPayload::DatastreamIndividual(astarte_type.into());
+        let payload: ProtoPayload =
+            ProtoPayload::DatastreamIndividual(AstarteDatastreamIndividual {
+                data: Some(astarte_type.into()),
+            });
 
         let astarte_message = AstarteMessage {
             interface_name: interface_name.clone(),
@@ -769,13 +545,17 @@ pub(crate) mod test {
     fn get_astarte_data_from_payload(
         payload: ProtoPayload,
     ) -> Result<AstarteType, MessageHubProtoError> {
-        take_individual(payload)
+        let astarte_data = take_individual(payload)
             .expect("individual")
             .data
             .expect("data")
             .astarte_data
-            .expect("astarte_data")
-            .try_into()
+            .expect("astarte_data");
+
+        AstarteData {
+            astarte_data: Some(astarte_data),
+        }
+        .try_into()
     }
 
     #[test]
@@ -1127,7 +907,13 @@ pub(crate) mod test {
             let astarte_type: AstarteType = object_data
                 .get(&k)
                 .and_then(|data| data.astarte_data.as_ref())
-                .and_then(|data| data.clone().try_into().ok())
+                .and_then(|data| {
+                    AstarteData {
+                        astarte_data: Some(data.clone()),
+                    }
+                    .try_into()
+                    .ok()
+                })
                 .unwrap();
 
             assert_eq!(v, astarte_type);
@@ -1164,7 +950,13 @@ pub(crate) mod test {
             let astarte_type: AstarteType = object_data
                 .get(&k)
                 .and_then(|data| data.astarte_data.as_ref())
-                .and_then(|data| data.clone().try_into().ok())
+                .and_then(|data| {
+                    AstarteData {
+                        astarte_data: Some(data.clone()),
+                    }
+                    .try_into()
+                    .ok()
+                })
                 .unwrap();
 
             assert_eq!(v, astarte_type);
@@ -1186,7 +978,7 @@ pub(crate) mod test {
             .and_then(|data| data.astarte_data)
             .unwrap();
 
-        assert_eq!(AstarteData::Double(expected_double_value), double_value);
+        assert_eq!(ProtoData::Double(expected_double_value), double_value);
     }
 
     fn take_object(payload: ProtoPayload) -> Option<AstarteDatastreamObject> {
@@ -1218,7 +1010,7 @@ pub(crate) mod test {
             .and_then(|data| data.astarte_data)
             .unwrap();
 
-        assert_eq!(AstarteData::Double(expected_data), double_data);
+        assert_eq!(ProtoData::Double(expected_data), double_data);
     }
 
     fn make_messagehub_property(


### PR DESCRIPTION
requires [#74](https://github.com/astarte-platform/astarte-message-hub-proto/pull/74) to be merged first