### PR TITLE
chore(rust-toolchain): update to stable 1.86.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -17,6 +17,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [toolchain]
-channel = "1.87.0-beta.1"
+channel = "1.86.0"
 components = ["rust-analyzer", "llvm-tools"]
 profile = "default"


### PR DESCRIPTION
Before, we were using beta for an error with rust-analyzer and the new release was still not out. Now we can move to the stable channel, since the bug was fixed upstream.