### PR TITLE
chore(proc-macro2): update to build with latest nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
See rust-lang/rust PR 139671 and dtolnay/proc-macro2 PR 497 for more information.