### PR TITLE
refactor(retry): improve the retry logic 

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -26,6 +26,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::error::Report;
+use crate::retry::ExponentialIter;
 use crate::state::{SharedState, Status};
 use crate::transport::TransportError;
 use crate::Timestamp;
@@ -87,6 +88,7 @@ where
     sender: C::Sender,
     state: Arc<SharedState>,
     resend: Option<JoinHandle<()>>,
+    backoff: ExponentialIter,
 }
 
 impl<C> DeviceConnection<C>
@@ -107,6 +109,7 @@ where
             connection,
             sender,
             resend: None,
+            backoff: ExponentialIter::default(),
         }
     }
 


### PR DESCRIPTION
Keep track of the instant the last value was generated in the
ExponentialIterator and a max reset duration. This will prevent infinite
loops on immediate reconnection.