### PR TITLE
feat(sqlite): set max db size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Introduce `webpki` feature to use Mozilla webpki root certificates rather than the native ones
   [#396](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/396).
 - Add the AstarteObject struct for Object Datastream [#430].
+- Allow setting the sqlite database size
+  [#455](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/455).
 
 ### Changed
 


### PR DESCRIPTION
Allow setting the sqlite database size by providing either the maximum number of db pages or a size in KB, KiB, MB or MiB. Give also the possibility to set the journal size when building an `SQLiteStore`. Also set default pragma when connecting to an sqlite store.

Closes #450 