### PR TITLE
ci(coverage): fixes the upload from master

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -161,3 +161,8 @@ for p in "${list[@]}"; do
         cp -v "$COVERAGE_OUT_DIR/$p/lcov" "$PWD/coverage-$p.info"
     fi
 done
+
+# Fixes the profraw being detected by codecov
+if [[ -n "${EXPORT_FOR_CI:-}" ]]; then
+    rm -rf "$CARGO_TARGET_DIR"
+fi


### PR DESCRIPTION
When uploading directly (push on master), we still have the `target/` directory containing all the `*.profraw` and `coverage.profdata` inside. Code cove then uploads these files since contain coverage information. The files will skew the coverage result since they are not filtering the test lines.