### PR TITLE
fix(sqlite): Set autocheckpoint size to limit the size of the WAL

### DIFF
--- a/src/store/sqlite/options.rs
+++ b/src/store/sqlite/options.rs
@@ -28,21 +28,33 @@ use super::{
     SQLITE_DEFAULT_DB_MAX_SIZE, SQLITE_JOURNAL_SIZE_LIMIT, SQLITE_WAL_AUTOCHECKPOINT,
 };
 
+/// Choices of limit of the size of the sqlite database
+#[derive(Clone, Debug, Copy)]
+pub enum SizeLimit {
+    /// Set a size limit based on the number of pages
+    Pages(u32),
+    /// Set a size limit based on the actual size of the db file
+    ///
+    /// This value will be approxymated if it's not a multiple of the databse page size
+    Size(Size),
+}
+
 /// Sqlite options that can be set externally to tweak the behaviour of sqlite.
+#[derive(Clone, Debug)]
 pub struct SqliteStoreOptions {
     // Maximum number of pages in the sqlite db file
-    db_size_limit: Size,
+    pub(crate) db_size_limit: SizeLimit,
     /// Since we use WAL mode the size of our journal controls the size of the WAL
     /// Without the autocheckpoint set the journal still grows until an autocheckpoint is performed.
     /// The size limit only applies when the WAL journal is truncated. We set both options to
     /// correctly limit the size of the WAL file.
-    journal_size_limit: Size,
+    pub(crate) journal_size_limit: Size,
 }
 
 impl Default for SqliteStoreOptions {
     fn default() -> Self {
         Self {
-            db_size_limit: SQLITE_DEFAULT_DB_MAX_SIZE,
+            db_size_limit: SizeLimit::Size(SQLITE_DEFAULT_DB_MAX_SIZE),
             journal_size_limit: SQLITE_JOURNAL_SIZE_LIMIT,
         }
     }
@@ -65,9 +77,14 @@ pub(crate) struct SqlitePragmas {
 impl SqlitePragmas {
     pub(crate) fn try_from_options(
         connection: &Connection,
-        options: SqliteStoreOptions,
+        options: &SqliteStoreOptions,
     ) -> Result<Self, SqliteError> {
-        let max_page_count = Self::compute_max_page_count(connection, options.db_size_limit)?;
+        let max_page_count = match options.db_size_limit {
+            SizeLimit::Pages(pages) => pages,
+            SizeLimit::Size(size) => Self::compute_max_page_count(connection, size)?,
+        };
+        Self::validate_max_page_count(connection, max_page_count)?;
+
         let wal_autocheckpoint =
             Self::compute_autocheckpoint_pages(connection, options.journal_size_limit)?;
 
@@ -78,44 +95,21 @@ impl SqlitePragmas {
         })
     }
 
-    pub(crate) fn compute_max_page_count(
-        connection: &Connection,
-        max_size: Size,
-    ) -> Result<u32, SqliteError> {
+    fn compute_max_page_count(connection: &Connection, max_size: Size) -> Result<u32, SqliteError> {
         let page_size: u64 = get_pragma(connection, "page_size")?;
 
         // perform euclidean division to retrieve the correct number of pages
         // no need to perform checked div since the minimum page size is 512 bytes
         // <https://www.sqlite.org/pragma.html#pragma_page_size>
-        Ok(max_size.calculate_max_page_count(page_size))
+        // we limit the lower bound to 1 page since we don't want a 0 page db
+        Ok(max_size.calculate_max_page_count(page_size).max(1))
     }
 
-    /// Applites max pages database limit to the passsed connection
-    ///
-    /// <https://www.sqlite.org/pragma.html#pragma_max_page_count>
-    fn apply_max_page_count(
-        connection: &Connection,
-        max_page_count: u32,
-    ) -> Result<(), SqliteError> {
-        set_pragma(connection, "max_page_count", max_page_count)
-    }
-
-    pub(crate) fn set_max_page_count(
-        &mut self,
-        connection: &Connection,
-        max: u32,
-    ) -> Result<(), SqliteError> {
+    fn validate_max_page_count(connection: &Connection, max: u32) -> Result<(), SqliteError> {
         if max == 0 {
             return Err(SqliteError::InvalidMaxSize {
                 ctx: "max page count cannot be 0",
             });
-        }
-
-        // check if the number of pages provided in input is the same as the maximum one
-        let current_max: u32 = get_pragma(connection, "max_page_count")?;
-
-        if max == current_max {
-            return Ok(());
         }
 
         // check if the new database size is lower than the actual one
@@ -126,9 +120,6 @@ impl SqlitePragmas {
                 ctx: "cannot shrink the database",
             });
         }
-
-        Self::apply_max_page_count(connection, max)?;
-        self.max_page_count = max;
 
         Ok(())
     }
@@ -141,54 +132,31 @@ impl SqlitePragmas {
         // we want a number of pages for autocheckpointing currently we divide by 10
         // to get a sensible number lower than the size limit
         // we also set a maximum of 1000 to avoid exceeding the default value for sqlite
+        // and a minimum of 1 page to avoid setting a 0 page autocheckpoint that would
+        // turn off the autocheckpoints
         Ok(journal_size_limit
             .calculate_max_page_count(page_size)
             .div_euclid(10)
-            .min(SQLITE_WAL_AUTOCHECKPOINT))
+            .clamp(1, SQLITE_WAL_AUTOCHECKPOINT))
     }
 
-    /// Applies journal size limit pragmas for the current database connection.
+    /// Applies default and configured pragmas to the passed connection.
     ///
-    /// Sets also the wal autocheckpoint to a value of pages lower than the
+    /// Set journal size limit to the limit configured.
+    /// Set also the wal autocheckpoint to a value of pages lower than the
     /// size limit (in pages) so that the commit happens before surpassing the size.
     ///
     /// <https://www.sqlite.org/pragma.html#pragma_journal_size_limit>
     /// <https://www.sqlite.org/pragma.html#pragma_wal_autocheckpoint>
-    fn apply_journal_size_limit(
-        connection: &Connection,
-        journal_size_limit: u64,
-        wal_autocheckpoint: u32,
-    ) -> Result<(), SqliteError> {
-        set_pragma(connection, "journal_size_limit", journal_size_limit)?;
-        set_pragma(connection, "wal_autocheckpoint", wal_autocheckpoint)?;
-
-        Ok(())
-    }
-
-    pub(crate) fn set_journal_size_limit(
-        &mut self,
-        connection: &Connection,
-        journal_size_limit: Size,
-    ) -> Result<(), SqliteError> {
-        let wal_autocheckpoint =
-            Self::compute_autocheckpoint_pages(connection, journal_size_limit)?;
-        let journal_size_limit = journal_size_limit.to_bytes();
-
-        Self::apply_journal_size_limit(connection, journal_size_limit, wal_autocheckpoint)?;
-
-        self.journal_size_limit = journal_size_limit;
-        self.wal_autocheckpoint = wal_autocheckpoint;
-
-        Ok(())
-    }
-
+    ///
+    /// Applies also max pages database limit to the passsed connection
+    ///
+    /// <https://www.sqlite.org/pragma.html#pragma_max_page_count>
     pub(crate) fn apply_pragmas(&self, connection: &Connection) -> Result<(), SqliteError> {
-        Self::apply_max_page_count(connection, self.max_page_count)?;
-        Self::apply_journal_size_limit(
-            connection,
-            self.journal_size_limit,
-            self.wal_autocheckpoint,
-        )?;
+        set_pragma(connection, "journal_mode", "WAL")?;
+        set_pragma(connection, "max_page_count", self.max_page_count)?;
+        set_pragma(connection, "journal_size_limit", self.journal_size_limit)?;
+        set_pragma(connection, "wal_autocheckpoint", self.wal_autocheckpoint)?;
         set_pragma(connection, "foreign_keys", true)?;
         set_pragma(connection, "busy_timeout", SQLITE_BUSY_TIMEOUT)?;
         set_pragma(connection, "synchronous", "NORMAL")?;
@@ -196,7 +164,6 @@ impl SqlitePragmas {
         set_pragma(connection, "auto_vacuum", "INCREMENTAL")?;
         set_pragma(connection, "temp_store", "MEMORY")?;
         set_pragma(connection, "cache_size", SQLITE_CACHE_SIZE)?;
-        set_pragma(connection, "journal_mode", "WAL")?;
 
         Ok(())
     }


### PR DESCRIPTION
The WAL size is not limited by the `journal_size_limit` pragma.
That value sets the size at which the journal will be truncated.
To correctly limit the size of a WAL in use we have to set the `wal_autocheckpoint` pragma to a value lower than the size limit.