### PR TITLE
refactor(sqlite): create a pool for the read connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - Unreleased
+
+### Changed
+
+- Use a pool for the SQLite connections instead of thread local variables
+  [#489](https://github.com/astarte-platform/astarte-device-sdk-rust/pull/489)
+
 ## [0.10.2] - 2025-07-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,12 +121,19 @@ zerofrom = { workspace = true }
 
 [features]
 default = ["interface-strict", "sqlite-trace", "tokio-multi-thread"]
+# Enable and exports the derive macros
 derive = ["dep:astarte-device-sdk-derive"]
+# Deprecated: Add the documentation and description to the interfaces
 interface-doc = []
+# Deprecated: Add stricter checks to the interfaces
 interface-strict = []
+# gRPC connection through the Astarte MessageHub
 message-hub = ["dep:astarte-message-hub-proto"]
+# Logs the SQLite queries and features
 sqlite-trace = ["rusqlite/trace"]
-tokio-multi-thread = ["tokio/rt-multi-thread"]
+# Deprecated: this features should be activated by the user
+tokio-multi-thread = []
+# Uses the webpki-roots the Mozilla CA bundle for TLS
 webpki = ["dep:webpki-roots"]
 
 [lints.rust]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -47,6 +47,7 @@ use crate::store::PropertyStore;
 use crate::store::SqliteStore;
 use crate::store::StoreCapabilities;
 use crate::transport::Connection;
+use crate::utils::const_conv::const_non_zero_usize;
 use crate::Error;
 
 /// Default capacity of the channels
@@ -61,15 +62,6 @@ pub const DEFAULT_VOLATILE_CAPACITY: usize = 1000;
 
 /// Default capacity for the number of packets w ith retention store to store in memory.
 pub const DEFAULT_STORE_CAPACITY: NonZeroUsize = const_non_zero_usize(1_000_000);
-
-/// Necessary for rust 1.78 const compatibility
-pub(crate) const fn const_non_zero_usize(v: usize) -> NonZeroUsize {
-    let Some(v) = NonZeroUsize::new(v) else {
-        panic!("value cannot be zero");
-    };
-
-    v
-}
 
 /// Astarte builder error.
 ///
@@ -604,11 +596,5 @@ mod test {
         .await
         .unwrap()
         .unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "value cannot be zero")]
-    fn const_non_zero_usize_should_panic() {
-        const_non_zero_usize(0);
     }
 }

--- a/src/connection/incoming.rs
+++ b/src/connection/incoming.rs
@@ -18,7 +18,7 @@
 
 use astarte_interfaces::interface::InterfaceTypeAggregation;
 use astarte_interfaces::{DatastreamIndividual, DatastreamObject, MappingPath, Properties, Schema};
-use tracing::{debug, error, instrument, warn};
+use tracing::{debug, error, warn};
 
 use crate::client::RecvError;
 use crate::interfaces::MappingRef;
@@ -33,7 +33,7 @@ where
     C: Connection,
 {
     // Solves https://github.com/rust-lang/rust/issues/110486
-    #[cfg_attr(not(__coverage), instrument(skip(self, payload)))]
+    #[cfg_attr(not(__coverage), tracing::instrument(skip(self, payload)))]
     pub(crate) async fn handle_event(
         &self,
         interface: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub(crate) mod state;
 pub mod store;
 pub mod transport;
 pub mod types;
+pub(crate) mod utils;
 mod validate;
 
 /// Re-exported internal structs

--- a/src/retention/mod.rs
+++ b/src/retention/mod.rs
@@ -35,6 +35,7 @@ use tracing::{error, warn};
 use crate::{
     error::{DynError, Report},
     interfaces::Interfaces,
+    store::sqlite::SqliteError,
     validate::{ValidatedIndividual, ValidatedObject},
 };
 
@@ -125,6 +126,9 @@ pub enum RetentionError {
         #[source]
         backtrace: DynError,
     },
+    /// Couldn't acquire the store connection
+    #[error("couldn't acquire store connection")]
+    Connection(#[source] DynError),
 }
 
 impl RetentionError {
@@ -190,6 +194,12 @@ impl RetentionError {
     }
 }
 
+impl From<SqliteError> for RetentionError {
+    fn from(value: SqliteError) -> Self {
+        RetentionError::Connection(value.into())
+    }
+}
+
 /// Publish information to be stored.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PublishInfo<'a> {
@@ -251,6 +261,19 @@ impl<'a> PublishInfo<'a> {
             sent,
             value,
         )
+    }
+
+    /// Returns an owned version of the PublishInfo
+    fn into_owned(self) -> PublishInfo<'static> {
+        PublishInfo {
+            interface: self.interface.into_owned().into(),
+            path: self.path.into_owned().into(),
+            version_major: self.version_major,
+            reliability: self.reliability,
+            expiry: self.expiry,
+            sent: self.sent,
+            value: self.value.into_owned().into(),
+        }
     }
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -103,6 +103,16 @@ impl From<&Interfaces> for Vec<IntrospectionInterface> {
     }
 }
 
+impl From<IntrospectionInterface<&str>> for IntrospectionInterface {
+    fn from(value: IntrospectionInterface<&str>) -> Self {
+        IntrospectionInterface {
+            name: value.name.to_string(),
+            version_major: value.version_major,
+            version_minor: value.version_minor,
+        }
+    }
+}
+
 /// Error returned by the retention.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -323,6 +323,18 @@ impl<'a> StoredProp<&'a str, &'a AstarteData> {
     }
 }
 
+impl<'a> From<StoredProp<&'a str, &'a AstarteData>> for StoredProp {
+    fn from(value: StoredProp<&'a str, &'a AstarteData>) -> Self {
+        Self {
+            interface: value.interface.to_string(),
+            path: value.path.to_string(),
+            value: value.value.clone(),
+            interface_major: value.interface_major,
+            ownership: value.ownership,
+        }
+    }
+}
+
 impl<'a> From<&'a StoredProp> for StoredProp<&'a str, &'a AstarteData> {
     fn from(value: &'a StoredProp) -> Self {
         Self {

--- a/src/store/sqlite/connection.rs
+++ b/src/store/sqlite/connection.rs
@@ -1,0 +1,231 @@
+// This file is part of Astarte.
+//
+// Copyright 2025 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Display;
+use std::num::NonZeroUsize;
+use std::ops::{Deref, DerefMut};
+use std::path::Path;
+
+use rusqlite::types::FromSql;
+use rusqlite::{Connection, OpenFlags, OptionalExtension, ToSql};
+use tracing::{debug, error, instrument, trace, warn};
+
+use crate::builder::DEFAULT_STORE_CAPACITY;
+use crate::error::Report;
+
+use super::options::{SqliteOptions, SqlitePragmas};
+use super::{SqliteError, SQLITE_BUSY_TIMEOUT, SQLITE_CACHE_SIZE};
+
+#[cfg(feature = "sqlite-trace")]
+/// Logs the execution of SQLite statements
+#[tracing::instrument(name = "statement", skip_all)]
+fn trace_sqlite(event: &str) {
+    tracing::trace!("{event}");
+}
+
+pub(crate) trait SqliteConnection: Sized + Deref<Target = Connection> {
+    const CONNECTION_TYPE: &'static str;
+
+    fn connect(db_file: &Path, options: &SqliteOptions) -> Result<Self, SqliteError>;
+
+    fn take_connection(self) -> Connection;
+
+    #[instrument(skip_all)]
+    fn close(self) {
+        trace!("closing writer connection");
+
+        if let Err((_, err)) = self.take_connection().close() {
+            error!(error = %Report::new(err), connection=Self::CONNECTION_TYPE,  "couldn't close the connection");
+        }
+    }
+
+    /// Queries a pragma value
+    fn get_pragma<T>(&self, pragma_name: &str) -> Result<T, SqliteError>
+    where
+        T: FromSql + Display,
+    {
+        self.pragma_query_value(None, pragma_name, |row| row.get::<_, T>(0))
+            .inspect(|value| trace!(pragma_name, %value, "pragma returned"))
+            .map_err(SqliteError::Option)
+    }
+
+    /// Sets a pragma value
+    #[instrument(skip_all, fields(connection = Self::CONNECTION_TYPE, %pragma_name, %pragma_value))]
+    fn set_pragma<V>(&self, pragma_name: &str, pragma_value: &V) -> Result<(), SqliteError>
+    where
+        V: ToSql + ToOwned + PartialEq<V::Owned> + Display + ToOwned + ?Sized,
+        V::Owned: FromSql + Display,
+    {
+        trace!("setting pragma");
+
+        self.pragma_update_and_check(None, pragma_name, pragma_value, |r| {
+            let Some(actual) = r.get::<_, V::Owned>(0).optional()? else {
+                debug!("no pragma returned");
+
+                return Ok(());
+            };
+
+            if *pragma_value != actual {
+                error!(%actual, "couldn't set pragam");
+            }
+
+            Ok(())
+        })
+        .optional()
+        .map_err(SqliteError::Option)?;
+
+        Ok(())
+    }
+
+    /// Applies default and configured pragmas to the passed connection.
+    ///
+    /// Set journal size limit to the limit configured.
+    /// Set also the wal autocheckpoint to a value of pages lower than the
+    /// size limit (in pages) so that the commit happens before surpassing the size.
+    ///
+    /// <https://www.sqlite.org/pragma.html#pragma_journal_size_limit>
+    /// <https://www.sqlite.org/pragma.html#pragma_wal_autocheckpoint>
+    ///
+    /// Applies also max pages database limit to the passsed connection
+    ///
+    /// <https://www.sqlite.org/pragma.html#pragma_max_page_count>
+    fn apply_pragmas(&self, options: &SqliteOptions) -> Result<(), SqliteError> {
+        let pragmas = SqlitePragmas::try_from_options(self, options)?;
+
+        self.set_pragma("journal_mode", "wal")?;
+        self.set_pragma("max_page_count", &pragmas.max_page_count)?;
+        self.set_pragma("journal_size_limit", &pragmas.journal_size_limit)?;
+        self.set_pragma("wal_autocheckpoint", &pragmas.wal_autocheckpoint)?;
+        self.set_pragma("foreign_keys", &true)?;
+        self.set_pragma("busy_timeout", &SQLITE_BUSY_TIMEOUT)?;
+        self.set_pragma("synchronous", "NORMAL")?;
+        self.set_pragma("auto_vacuum", "INCREMENTAL")?;
+        self.set_pragma("temp_store", "MEMORY")?;
+        self.set_pragma("cache_size", &SQLITE_CACHE_SIZE)?;
+
+        Ok(())
+    }
+
+    #[instrument(skip_all, fields(connection = Self::CONNECTION_TYPE))]
+    fn lazy(
+        value: Option<Self>,
+        db_file: &Path,
+        options: &SqliteOptions,
+    ) -> Result<Self, SqliteError> {
+        value
+            .map_or_else(
+                || {
+                    debug!("connection missing, creating it");
+
+                    Self::connect(db_file, options)
+                },
+                Ok,
+            )
+            .inspect_err(|err| error!(error = %Report::new(err), "couldn't create connection"))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct WriteConnection {
+    connection: Connection,
+    /// Maximum number of retention item to store
+    pub(crate) retention_capacity: NonZeroUsize,
+}
+
+impl Deref for WriteConnection {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.connection
+    }
+}
+
+impl DerefMut for WriteConnection {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.connection
+    }
+}
+
+impl SqliteConnection for WriteConnection {
+    const CONNECTION_TYPE: &'static str = "writer";
+
+    fn connect(db_file: &Path, options: &SqliteOptions) -> Result<Self, SqliteError> {
+        let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_CREATE
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+
+        let connection =
+            Connection::open_with_flags(db_file, flags).map_err(SqliteError::Connection)?;
+
+        #[cfg(feature = "sqlite-trace")]
+        let mut connection = connection;
+
+        #[cfg(feature = "sqlite-trace")]
+        connection.trace(Some(trace_sqlite));
+
+        let connection = Self {
+            connection,
+            retention_capacity: DEFAULT_STORE_CAPACITY,
+        };
+
+        connection.apply_pragmas(options)?;
+
+        Ok(connection)
+    }
+
+    fn take_connection(self) -> Connection {
+        self.connection
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ReadConnection(Connection);
+
+impl SqliteConnection for ReadConnection {
+    const CONNECTION_TYPE: &'static str = "reader";
+
+    fn connect(db_file: &Path, options: &SqliteOptions) -> Result<Self, SqliteError> {
+        let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+
+        let connection =
+            Connection::open_with_flags(db_file, flags).map_err(SqliteError::Connection)?;
+
+        #[cfg(feature = "sqlite-trace")]
+        let mut connection = connection;
+        #[cfg(feature = "sqlite-trace")]
+        connection.trace(Some(trace_sqlite));
+
+        let conn = Self(connection);
+
+        conn.apply_pragmas(options)?;
+
+        Ok(conn)
+    }
+
+    fn take_connection(self) -> Connection {
+        self.0
+    }
+}
+
+impl Deref for ReadConnection {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/store/sqlite/mod.rs
+++ b/src/store/sqlite/mod.rs
@@ -18,29 +18,38 @@
 
 //! Provides functionality for instantiating an Astarte sqlite database.
 
-use std::{cell::Cell, fmt::Debug, num::NonZeroU64, path::Path, sync::Arc, time::Duration};
+use std::{
+    fmt::Debug,
+    num::{NonZeroU32, NonZeroU64, NonZeroUsize},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use astarte_interfaces::{
     schema::{MappingType, Ownership},
     Properties, Schema,
 };
-use futures::lock::Mutex;
-use options::{SizeLimit, SqlitePragmas, SqliteStoreOptions};
 use rusqlite::{
     types::{FromSql, FromSqlError},
-    Connection, OptionalExtension, ToSql,
+    ToSql,
 };
 use serde::{Deserialize, Serialize};
-use statements::{include_query, ReadConnection, WriteConnection};
-use tracing::{debug, error, trace, warn};
+use statements::include_query;
+use tracing::{debug, error, info, instrument, trace};
 
+use self::pool::Connections;
+use self::{connection::SqliteConnection, options::SqliteOptions};
 use super::{OptStoredProp, PropertyMapping, PropertyStore, StoreCapabilities, StoredProp};
 use crate::{
     transport::mqtt::payload::{Payload, PayloadError},
     types::{de::BsonConverter, AstarteData, TypeError},
+    utils::const_conv::{const_non_zero_u32, const_non_zero_u64, const_non_zero_usize},
 };
 
+pub(crate) mod connection;
 pub(crate) mod options;
+pub(crate) mod pool;
 pub(crate) mod statements;
 
 /// Milliseconds for the busy timeout
@@ -51,16 +60,15 @@ pub const SQLITE_BUSY_TIMEOUT: u16 = Duration::from_secs(5).as_millis() as u16;
 /// Cache size in kibibytes
 ///
 /// <https://www.sqlite.org/pragma.html#pragma_cache_size>
-pub const SQLITE_CACHE_SIZE: i16 = -(Size::MiB(const_non_zero(2)).to_kibibytes_ceil() as i16);
-
+pub const SQLITE_CACHE_SIZE: i16 = -(Size::MiB(const_non_zero_u64(2)).to_kibibytes_ceil() as i16);
 /// Max journal size
 ///
 /// The default value specidfied in <https://www.sqlite.org/pragma.html#pragma_journal_size_limit> is -1
 /// which does not set an effective limit, therefore we assume a default size of 64 mebibytes
-pub const SQLITE_JOURNAL_SIZE_LIMIT: Size = Size::MiB(const_non_zero(64));
+pub const SQLITE_JOURNAL_SIZE_LIMIT: Size = Size::MiB(const_non_zero_u64(64));
 
 /// Default database size
-pub const SQLITE_DEFAULT_DB_MAX_SIZE: Size = Size::GiB(const_non_zero(1));
+pub const SQLITE_DEFAULT_DB_MAX_SIZE: Size = Size::GiB(const_non_zero_u64(1));
 
 /// SQLite maximum number of pages in the database.
 ///
@@ -73,6 +81,9 @@ pub const SQLITE_MAX_PAGE_COUNT: u32 = 4294967294;
 /// <https://www.sqlite.org/pragma.html#pragma_wal_autocheckpoint>
 pub const SQLITE_WAL_AUTOCHECKPOINT: u32 = 1000;
 
+/// Maximum number of reader connections to create.
+pub(crate) const DEFAULT_MAX_READERS: NonZeroUsize = const_non_zero_usize(4);
+
 /// Error returned by the [`SqliteStore`].
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
@@ -81,10 +92,10 @@ pub enum SqliteError {
     #[error("could not connect to database")]
     Connection(#[source] rusqlite::Error),
     /// Couldn't set SQLite option.
-    #[error("could not connect to database")]
+    #[error("couldn't set database option")]
     Option(#[source] rusqlite::Error),
     /// Couldn't prepare the SQLite statement.
-    #[error("could not connect to database")]
+    #[error("couldn't prepare sqlite statement")]
     Prepare(#[source] rusqlite::Error),
     /// Couldn't start a transaction.
     #[error("could not start a transaction database")]
@@ -107,6 +118,12 @@ pub enum SqliteError {
         /// Context of the error
         ctx: &'static str,
     },
+    /// Couldn't acquire a reader permit
+    #[error("couldn't acquire a reader permit")]
+    Reader,
+    /// Couldn't join the connection task
+    #[error("couldn't join the connection task")]
+    Join,
 }
 
 /// Error when converting a u8 into the [`Ownership`] struct.
@@ -211,28 +228,60 @@ pub enum Size {
 }
 
 impl Size {
+    const ONE: NonZeroU32 = const_non_zero_u32(1);
+
+    const KB: NonZeroU64 = const_non_zero_u64(1000);
+    const MB: NonZeroU64 = const_non_zero_u64(1000 * 1000);
+    const GB: NonZeroU64 = const_non_zero_u64(1000 * 1000 * 1000);
+    const KI_B: NonZeroU64 = const_non_zero_u64(1024);
+    const MI_B: NonZeroU64 = const_non_zero_u64(1024 * 1024);
+    const GI_B: NonZeroU64 = const_non_zero_u64(1024 * 1024 * 1024);
+
     /// Convert the size to bytes
-    const fn to_bytes(self) -> u64 {
+    const fn to_bytes(self) -> NonZeroU64 {
         match self {
-            Size::Kb(kb) => kb.get().saturating_mul(1000),
-            Size::Mb(mb) => mb.get().saturating_mul(1000 * 1000),
-            Size::Gb(gb) => gb.get().saturating_mul(1000 * 1000 * 1000),
-            Size::KiB(kib) => kib.get().saturating_mul(1024),
-            Size::MiB(mib) => mib.get().saturating_mul(1024 * 1024),
-            Size::GiB(gib) => gib.get().saturating_mul(1024 * 1024 * 1024),
+            Size::Kb(kb) => kb.saturating_mul(Self::KB),
+            Size::Mb(mb) => mb.saturating_mul(Self::MB),
+            Size::Gb(gb) => gb.saturating_mul(Self::GB),
+            Size::KiB(kib) => kib.saturating_mul(Self::KI_B),
+            Size::MiB(mib) => mib.saturating_mul(Self::MI_B),
+            Size::GiB(gib) => gib.saturating_mul(Self::GI_B),
         }
     }
 
     const fn to_kibibytes_ceil(self) -> u64 {
-        self.to_bytes().div_ceil(1024)
+        self.to_bytes().get().div_ceil(1024)
     }
 
-    fn calculate_max_page_count(&self, page_size: u64) -> u32 {
-        self.to_bytes()
-            .div_euclid(page_size)
-            .try_into()
-            .inspect_err(|_| warn!("max page count exceeded u32::MAX"))
-            .unwrap_or(SQLITE_MAX_PAGE_COUNT)
+    /// Approximate the max page count with the page size, with a minimum of 1 page
+    #[instrument]
+    fn into_page_count(self, page_size: NonZeroU64) -> NonZeroU32 {
+        let value = u32::try_from(self.to_bytes().get().div_euclid(page_size.get()))
+            // default value
+            .unwrap_or(SQLITE_MAX_PAGE_COUNT);
+
+        trace!(pages = value, "calculated pages");
+
+        // we must have at least one page
+        NonZeroU32::new(value).unwrap_or(Self::ONE)
+    }
+
+    /// Calculate the into_wall_autocheckpoint page count to be at 1/10 of the journal_size_limit
+    ///  if it's less than 1000 pages.
+    #[instrument]
+    fn into_wall_autocheckpoint(self, page_size: NonZeroU64) -> NonZeroU32 {
+        let journal_pages = self.into_page_count(page_size);
+
+        let pages = journal_pages
+            .get()
+            .div_euclid(10)
+            // upper bound
+            .min(SQLITE_WAL_AUTOCHECKPOINT);
+
+        trace!(pages, "calculated pages");
+
+        // we must have at least one page
+        NonZeroU32::new(pages).unwrap_or(Self::ONE)
     }
 }
 
@@ -369,40 +418,6 @@ fn from_stored_type(value: u8) -> Result<MappingType, ValueError> {
     Ok(mapping_type)
 }
 
-thread_local! {
-    /// Read only connection to the SQLite database.
-    ///
-    /// Since SQLite supports multiple readers concurrently to an exclusive writer, guarantied that
-    /// a connection is used by a single thread at a time. We create a thread local read only
-    /// connection and share the read handle behind a [`Mutex`].
-    ///
-    /// This is a [`Vec`] of connection to allow multiple connections with different paths.
-    static READER: Cell<Vec<ReadConnection>> = const { Cell::new(Vec::new()) };
-}
-
-/// Return db pages information
-///
-/// Useful to retrieve data assocuiated to PRAGMA page_size, page_count, max_page_count
-pub(crate) fn get_pragma<T>(connection: &Connection, pragma_name: &str) -> Result<T, SqliteError>
-where
-    T: FromSql,
-{
-    wrap_sync_call(|| connection.pragma_query_value(None, pragma_name, |row| row.get::<_, T>(0)))
-        .map_err(SqliteError::Query)
-}
-
-pub(crate) fn set_pragma<V>(
-    connection: &Connection,
-    pragma_name: &str,
-    pragma_value: V,
-) -> Result<(), SqliteError>
-where
-    V: ToSql,
-{
-    wrap_sync_call(|| connection.pragma_update(None, pragma_name, pragma_value))
-        .map_err(SqliteError::Option)
-}
-
 /// Data structure providing an implementation of a sqlite database.
 ///
 /// Can be used by an Astarte device to store permanently properties values and published with
@@ -414,25 +429,28 @@ where
 /// The retention is stored as a BLOB serialized by the connection.
 #[derive(Clone, Debug)]
 pub struct SqliteStore {
-    pub(crate) db_file: Arc<Path>,
-    pub(crate) writer: Arc<Mutex<WriteConnection>>,
-    pub(crate) options: SqliteStoreOptions,
+    pub(crate) pool: Arc<Connections>,
 }
 
 impl SqliteStore {
-    /// Creates a sqlite database for the Astarte device.
-    async fn new(
-        db_path: impl AsRef<Path>,
-        connection: WriteConnection,
-        options: SqliteStoreOptions,
-    ) -> Result<Self, SqliteError> {
+    /// Creates a SQLite database for the Astarte device.
+    async fn new(db_file: PathBuf, options: SqliteOptions) -> Result<Self, SqliteError> {
         let sqlite_store = SqliteStore {
-            db_file: db_path.as_ref().into(),
-            writer: Arc::new(Mutex::new(connection)),
-            options,
+            pool: Arc::new(Connections::new(db_file, options)),
         };
 
         sqlite_store.migrate().await?;
+
+        debug!("vacuum the database");
+
+        sqlite_store
+            .pool
+            .acquire_writer(|writer| {
+                writer
+                    .execute("PRAGMA incremental_vacuum", ())
+                    .map_err(SqliteError::Option)
+            })
+            .await?;
 
         Ok(sqlite_store)
     }
@@ -456,7 +474,8 @@ impl SqliteStore {
         // TODO: rename the database to store.db since it doesn't contain only  properties
         let db = writable_path.as_ref().join("prop-cache.db");
 
-        Self::connect_db(db).await
+        let options = SqliteOptions::default();
+        Self::new(db, options).await
     }
 
     /// Connect to the SQLite database give as a filename.
@@ -472,52 +491,11 @@ impl SqliteStore {
     /// }
     /// ```
     pub async fn connect_db(database_file: impl AsRef<Path>) -> Result<Self, SqliteError> {
-        let options = SqliteStoreOptions::default();
-        let connection = WriteConnection::connect(&database_file, &options).await?;
-        Self::new(database_file, connection, options).await
+        let options = SqliteOptions::default();
+        Self::new(database_file.as_ref().to_path_buf(), options).await
     }
 
-    /// Pass the thread local reference to the read only connection.
-    pub(crate) fn with_reader<F, O>(&self, f: F) -> Result<O, SqliteError>
-    where
-        F: FnOnce(&ReadConnection) -> Result<O, SqliteError>,
-    {
-        wrap_sync_call(|| {
-            READER.with(|tlv| {
-                let mut v = tlv.take();
-
-                let res = self.get_or_init_reader(&mut v).and_then(f);
-
-                tlv.set(v);
-
-                res
-            })
-        })
-    }
-
-    fn get_or_init_reader<'a: 'b, 'b>(
-        &self,
-        v: &'a mut Vec<ReadConnection>,
-    ) -> Result<&'b ReadConnection, SqliteError> {
-        // get the index instead of the element to solve NLL error
-        let idx = v.iter().enumerate().find_map(|(i, r)| {
-            r.path()
-                .is_some_and(|p| p == self.db_file.to_string_lossy())
-                .then_some(i)
-        });
-
-        if let Some(idx) = idx {
-            return Ok(&v[idx]);
-        }
-
-        let new_connection = ReadConnection::connect(&self.db_file, &self.options)?;
-
-        let idx = v.len();
-        v.push(new_connection);
-
-        Ok(&v[idx])
-    }
-
+    #[instrument(skip(self))]
     async fn migrate(&self) -> Result<(), SqliteError> {
         const MIGRATIONS: &[&str] = &[
             include_query!("migrations/0001_init.sql"),
@@ -525,41 +503,37 @@ impl SqliteStore {
             include_query!("migrations/0003_session.sql"),
         ];
 
-        let writer = self.writer.lock().await;
+        self.pool
+            .acquire_writer(|writer| -> Result<(), SqliteError> {
+                let version = writer.get_pragma("user_version").unwrap_or(0usize);
 
-        wrap_sync_call(|| -> Result<(), SqliteError> {
-            let version = writer
-                .query_row("PRAGMA user_version;", [], |row| row.get(0))
-                .optional()
-                .map_err(SqliteError::Query)?
-                .unwrap_or(0usize);
+                debug!(
+                    current = version,
+                    migrations = MIGRATIONS.len(),
+                    "checking migrations"
+                );
 
-            debug!(
-                current = version,
-                migrations = MIGRATIONS.len(),
-                "checking migrations"
-            );
+                if version >= MIGRATIONS.len() {
+                    info!("no migration to run");
 
-            if version >= MIGRATIONS.len() {
-                trace!("no migration to run");
+                    return Ok(());
+                }
 
-                return Ok(());
-            }
+                for migration in &MIGRATIONS[version..] {
+                    writer
+                        .execute_batch(migration)
+                        .map_err(SqliteError::Migration)?;
+                }
 
-            for migration in &MIGRATIONS[version..] {
-                writer
-                    .execute_batch(migration)
-                    .map_err(SqliteError::Migration)?;
-            }
+                debug!(version = MIGRATIONS.len(), "setting new database version");
 
-            debug!(version = MIGRATIONS.len(), "setting new database version");
+                writer.set_pragma("user_version", &MIGRATIONS.len())?;
 
-            writer
-                .pragma_update(None, "user_version", MIGRATIONS.len())
-                .map_err(SqliteError::Option)?;
+                info!("store migrated to new version");
 
-            Ok(())
-        })?;
+                Ok(())
+            })
+            .await?;
 
         Ok(())
     }
@@ -568,28 +542,14 @@ impl SqliteStore {
     ///
     /// The new database size cannot be lower than the actual one.
     // FIXME this method should be removed and this option should be configurable only during object construction
-    pub async fn set_max_pages(&mut self, max: u32) -> Result<(), SqliteError> {
-        let writer = self.writer.lock().await;
-
-        let mut modified_options = self.options.clone();
-        modified_options.db_size_limit = SizeLimit::Pages(max);
-        writer.apply_pragmas(&modified_options)?;
-        self.options = modified_options;
-
-        Ok(())
+    pub async fn set_max_pages(&mut self, max: NonZeroU32) -> Result<(), SqliteError> {
+        self.pool.set_max_page_count(max).await
     }
 
     /// Set the maximum number of pages based on the actual maximum size of the db file
     // FIXME this method should be removed and this option should be configurable only during object construction
     pub async fn set_db_max_size(&mut self, size: Size) -> Result<(), SqliteError> {
-        let writer = self.writer.lock().await;
-
-        let mut modified_options = self.options.clone();
-        modified_options.db_size_limit = SizeLimit::Size(size);
-        writer.apply_pragmas(&modified_options)?;
-        self.options = modified_options;
-
-        Ok(())
+        self.pool.set_db_max_size(size).await
     }
 
     /// Set journal size limit for the current database connection.
@@ -598,14 +558,7 @@ impl SqliteStore {
     /// this is larger than the journal size.
     // FIXME this method should be removed and this option should be configurable only during object construction
     pub async fn set_journal_size_limit(&mut self, size: Size) -> Result<(), SqliteError> {
-        let writer = self.writer.lock().await;
-
-        let mut modified_options = self.options.clone();
-        modified_options.journal_size_limit = size;
-        writer.apply_pragmas(&modified_options)?;
-        self.options = modified_options;
-
-        Ok(())
+        self.pool.set_journal_size_limit(size).await
     }
 }
 
@@ -626,16 +579,20 @@ impl PropertyStore for SqliteStore {
     type Err = SqliteError;
 
     async fn store_prop(&self, prop: StoredProp<&str, &AstarteData>) -> Result<(), Self::Err> {
-        debug!(
-            "Storing property {} {} in db ({:?})",
-            prop.interface, prop.path, prop.value
+        trace!(
+            interface = prop.interface,
+            path = prop.path,
+            "storing property",
         );
 
         let buf = Payload::new(prop.value)
             .to_vec()
             .map_err(ValueError::Encode)?;
 
-        self.writer.lock().await.store_prop(prop, &buf)?;
+        let prop = StoredProp::<String, AstarteData>::from(prop);
+        self.pool
+            .acquire_writer(move |writer| writer.store_prop((&prop).into(), &buf))
+            .await?;
 
         Ok(())
     }
@@ -644,16 +601,20 @@ impl PropertyStore for SqliteStore {
         &self,
         property: &PropertyMapping<'_>,
     ) -> Result<Option<AstarteData>, Self::Err> {
+        let interface_name = property.interface_name().to_string();
+        let path = property.path().to_string();
+
         let opt_record = self
-            .with_reader(|reader| reader.load_prop(property.interface_name(), property.path()))?;
+            .pool
+            .acquire_reader(move |reader| reader.load_prop(&interface_name, &path))
+            .await?;
 
         match opt_record {
             Some(record) => {
                 trace!(
-                    "Loaded property {} {} in db {:?}",
-                    property.interface_name(),
-                    property.path(),
-                    record
+                    interface = property.interface_name(),
+                    path = property.path(),
+                    "loaded property",
                 );
 
                 // if version mismatch, delete
@@ -678,84 +639,65 @@ impl PropertyStore for SqliteStore {
     }
 
     async fn unset_prop(&self, property: &PropertyMapping<'_>) -> Result<(), Self::Err> {
-        self.writer
-            .lock()
+        let interface_name = property.interface_name().to_string();
+        let path = property.path().to_string();
+        self.pool
+            .acquire_writer(move |writer| writer.unset_prop(&interface_name, &path))
             .await
-            .unset_prop(property.interface_name(), property.path())?;
-
-        Ok(())
     }
 
     async fn delete_prop(&self, property: &PropertyMapping<'_>) -> Result<(), Self::Err> {
-        self.writer
-            .lock()
+        let interface_name = property.interface_name().to_string();
+        let path = property.path().to_string();
+        self.pool
+            .acquire_writer(move |writer| writer.delete_prop(&interface_name, &path))
             .await
-            .delete_prop(property.interface_name(), property.path())?;
-
-        Ok(())
     }
 
     async fn clear(&self) -> Result<(), Self::Err> {
-        self.writer.lock().await.clear_props()?;
-
-        Ok(())
+        self.pool
+            .acquire_writer(|writer| writer.clear_props())
+            .await
     }
 
     async fn load_all_props(&self) -> Result<Vec<StoredProp>, Self::Err> {
-        self.with_reader(|reader| reader.load_all_props())
+        self.pool
+            .acquire_reader(|reader| reader.load_all_props())
+            .await
     }
 
     async fn device_props(&self) -> Result<Vec<StoredProp>, Self::Err> {
-        self.with_reader(|reader| reader.props_with_ownership(Ownership::Device))
+        self.pool
+            .acquire_reader(|reader| reader.props_with_ownership(Ownership::Device))
+            .await
     }
 
     async fn server_props(&self) -> Result<Vec<StoredProp>, Self::Err> {
-        self.with_reader(|reader| reader.props_with_ownership(Ownership::Server))
+        self.pool
+            .acquire_reader(|reader| reader.props_with_ownership(Ownership::Server))
+            .await
     }
 
     async fn interface_props(&self, interface: &Properties) -> Result<Vec<StoredProp>, Self::Err> {
-        self.with_reader(|reader| reader.interface_props(interface.name()))
+        let interface_name = interface.name().to_string();
+
+        self.pool
+            .acquire_reader(move |reader| reader.interface_props(&interface_name))
+            .await
     }
 
     async fn delete_interface(&self, interface: &Properties) -> Result<(), Self::Err> {
-        self.writer
-            .lock()
-            .await
-            .delete_interface_props(interface.name())?;
+        let interface_name = interface.name().to_string();
 
-        Ok(())
+        self.pool
+            .acquire_writer(move |writer| writer.delete_interface_props(&interface_name))
+            .await
     }
 
     async fn device_props_with_unset(&self) -> Result<Vec<OptStoredProp>, Self::Err> {
-        self.with_reader(|reader| reader.props_with_unset(Ownership::Device))
-    }
-}
-
-#[cfg(not(feature = "tokio-multi-thread"))]
-/// Functions to wrap the sync calls to the database and not starve the other tasks.
-pub(crate) fn wrap_sync_call<F, O>(f: F) -> O
-where
-    F: FnOnce() -> O,
-{
-    (f)()
-}
-
-#[cfg(feature = "tokio-multi-thread")]
-/// Functions to wrap the sync calls to the database and not starve the other tasks.
-pub(crate) fn wrap_sync_call<F, O>(f: F) -> O
-where
-    F: FnOnce() -> O,
-{
-    let Ok(current) = tokio::runtime::Handle::try_current() else {
-        return (f)();
-    };
-
-    match current.runtime_flavor() {
-        // We cannot block in place, so we execute the call directly
-        tokio::runtime::RuntimeFlavor::CurrentThread => (f)(),
-        tokio::runtime::RuntimeFlavor::MultiThread => tokio::task::block_in_place(f),
-        // Matches tokio-unstable MultiThreadAlt
-        _ => tokio::task::block_in_place(f),
+        self.pool
+            .acquire_reader(|reader| reader.props_with_unset(Ownership::Device))
+            .await
     }
 }
 
@@ -769,17 +711,10 @@ fn deserialize_prop(stored_type: u8, buf: &[u8]) -> Result<AstarteData, ValueErr
     value.try_into().map_err(ValueError::from)
 }
 
-/// Necessary for rust 1.78 const compatibility
-const fn const_non_zero(v: u64) -> NonZeroU64 {
-    let Some(v) = NonZeroU64::new(v) else {
-        panic!("value cannot be zero");
-    };
-
-    v
-}
-
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
     use crate::store::tests::test_property_store;
 
@@ -829,31 +764,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_max_pages_invalid_size() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut db = SqliteStore::connect(dir.path()).await.unwrap();
-
-        let err = db.set_max_pages(0).await.unwrap_err();
-
-        assert!(matches!(
-            err,
-            SqliteError::InvalidMaxSize {
-                ctx,
-            } if ctx == "max page count cannot be 0"
-        ));
-    }
-
-    #[tokio::test]
     async fn skip_set_max_pages() {
         let dir = tempfile::tempdir().unwrap();
         let mut db = SqliteStore::connect(dir.path()).await.unwrap();
 
-        {
-            let connection = db.writer.lock().await;
-            set_pragma(&connection, "max_page_count", 1000).unwrap();
-        }
+        db.pool
+            .acquire_writer(|writer| writer.set_pragma("max_page_count", &1000))
+            .await
+            .unwrap();
 
-        assert!(db.set_max_pages(1000).await.is_ok());
+        let res = db.set_max_pages(NonZeroU32::new(1000).unwrap()).await;
+
+        assert!(res.is_ok());
     }
 
     #[tokio::test]
@@ -861,10 +783,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut db = SqliteStore::connect(dir.path()).await.unwrap();
 
-        let page_size: usize = {
-            let connection = db.writer.lock().await;
-            get_pragma(&connection, "page_size").unwrap()
-        };
+        let page_size: usize = db
+            .pool
+            .acquire_writer(|writer| writer.get_pragma("page_size"))
+            .await
+            .unwrap();
 
         db.store_prop(StoredProp {
             interface: "interface",
@@ -876,7 +799,10 @@ mod tests {
         .await
         .unwrap();
 
-        let err = db.set_max_pages(1).await.unwrap_err();
+        let err = db
+            .set_max_pages(NonZeroU32::new(1).unwrap())
+            .await
+            .unwrap_err();
 
         assert!(matches!(
             err,
@@ -891,15 +817,19 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut db = SqliteStore::connect(dir.path()).await.unwrap();
 
-        let (page_size, page_count): (u32, u32) = {
-            let connection = db.writer.lock().await;
-            (
-                get_pragma(&connection, "page_size").unwrap(),
-                get_pragma(&connection, "page_count").unwrap(),
-            )
-        };
+        let (page_size, page_count): (u32, u32) = db
+            .pool
+            .acquire_writer(|writer| -> Result<_, SqliteError> {
+                let size = writer.get_pragma("page_size")?;
+                let count = writer.get_pragma("page_count")?;
+                Ok((size, count))
+            })
+            .await
+            .unwrap();
 
-        db.set_max_pages(page_count).await.unwrap();
+        db.set_max_pages(NonZeroU32::new(page_count).unwrap())
+            .await
+            .unwrap();
 
         let size = (page_size * page_count + 1) as usize;
 
@@ -925,10 +855,16 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut db = SqliteStore::connect(dir.path()).await.unwrap();
 
-        assert!(db.set_max_pages(10).await.is_ok());
+        let res = db.set_max_pages(NonZeroU32::new(10).unwrap()).await;
 
-        let lock = db.writer.lock().await;
-        let page_count: u32 = get_pragma(&lock, "max_page_count").unwrap();
+        assert!(res.is_ok());
+
+        let page_count: u32 = db
+            .pool
+            .acquire_writer(|writer| writer.get_pragma("max_page_count"))
+            .await
+            .unwrap();
+
         let exp_count = 10;
 
         assert_eq!(page_count, exp_count);
@@ -944,11 +880,13 @@ mod tests {
         // set the max size considering the default page size of 4096 bytes
         db.set_db_max_size(size).await.unwrap();
 
-        let lock = db.writer.lock().await;
-        let page_count: u32 = get_pragma(&lock, "max_page_count").unwrap();
-        let exp_count = 1024; // 4MiB / 4096B = 1024 pages
+        let max_page_count: u32 = db
+            .pool
+            .acquire_writer(|writer| writer.get_pragma("max_page_count"))
+            .await
+            .unwrap();
 
-        assert_eq!(page_count, exp_count);
+        assert_eq!(max_page_count, 1024);
     }
 
     #[tokio::test]
@@ -983,16 +921,25 @@ mod tests {
         // set the max size considering the default page size of 4096 bytes
         assert!(db.set_journal_size_limit(size).await.is_ok());
 
-        let lock = db.writer.lock().await;
-        let journal_size: u32 = get_pragma(&lock, "journal_size_limit").unwrap();
-        let exp_size: u32 = size.to_bytes().try_into().unwrap();
-        assert_eq!(journal_size, exp_size);
+        let journal_size: u64 = db
+            .pool
+            .acquire_writer(|writer| writer.get_pragma("journal_size_limit"))
+            .await
+            .unwrap();
+        assert_eq!(journal_size, 1024 * 1024);
 
-        let wal_autocheckpoint: u32 = get_pragma(&lock, "wal_autocheckpoint").unwrap();
+        let wal_autocheckpoint: u32 = db
+            .pool
+            .acquire_writer(|writer| writer.get_pragma("wal_autocheckpoint"))
+            .await
+            .unwrap();
+
         // autocheckpoin is set to a fraction of the journal_size in pages (pages / 10)
-        // in this case 1MiB / 4096 / 10 = 25
-        let exp_autocheckpoint = 25;
-        assert_eq!(wal_autocheckpoint, exp_autocheckpoint);
+        // in this case
+        //
+        // 1MiB / 4096 = 256
+        // 256 / 10 = 25
+        assert_eq!(wal_autocheckpoint, 25);
     }
 
     #[tokio::test]
@@ -1005,46 +952,49 @@ mod tests {
         // set the max size considering the default page size of 4096 bytes
         assert!(db.set_journal_size_limit(size).await.is_ok());
 
-        let lock = db.writer.lock().await;
-        let journal_size: u32 = get_pragma(&lock, "journal_size_limit").unwrap();
-        let exp_size: u32 = size.to_bytes().try_into().unwrap();
-        assert_eq!(journal_size, exp_size);
+        let journal_size: u32 = db
+            .pool
+            .acquire_writer(|writer| writer.get_pragma("journal_size_limit"))
+            .await
+            .unwrap();
 
-        let wal_autocheckpoint: u32 = get_pragma(&lock, "wal_autocheckpoint").unwrap();
+        assert_eq!(journal_size, 1000);
+
+        let wal_autocheckpoint: u32 = db
+            .pool
+            .acquire_writer(|writer| writer.get_pragma("wal_autocheckpoint"))
+            .await
+            .unwrap();
+
         // autocheckpoin is set to a fraction of the journal_size in pages
-        // in this case the size in pages is 0 (1KB / 4096 = 0) but the minimum we allow is 1
-        let exp_autocheckpoint = 1;
-        assert_eq!(wal_autocheckpoint, exp_autocheckpoint);
+        // in this case the size in pages is 0
+        //
+        // (1KB / 4096 = 0) but the minimum we allow is 1
+        assert_eq!(wal_autocheckpoint, 1);
     }
 
     #[test]
     fn size_to_bytes() {
         let size = Size::Kb(NonZeroU64::new(1).unwrap());
-        assert_eq!(size.to_bytes(), 1000);
+        assert_eq!(size.to_bytes().get(), 1000);
 
         let size = Size::Mb(NonZeroU64::new(1).unwrap());
-        assert_eq!(size.to_bytes(), 1000 * 1000);
+        assert_eq!(size.to_bytes().get(), 1000 * 1000);
 
         let size = Size::Gb(NonZeroU64::new(1).unwrap());
-        assert_eq!(size.to_bytes(), 1000 * 1000 * 1000);
+        assert_eq!(size.to_bytes().get(), 1000 * 1000 * 1000);
     }
 
     #[test]
     fn size_to_kib() {
         let size = Size::KiB(NonZeroU64::new(1).unwrap());
-        assert_eq!(size.to_bytes(), 1024);
+        assert_eq!(size.to_bytes().get(), 1024);
 
         let size = Size::MiB(NonZeroU64::new(1).unwrap());
-        assert_eq!(size.to_bytes(), 1024 * 1024);
+        assert_eq!(size.to_bytes().get(), 1024 * 1024);
 
         let size = Size::GiB(NonZeroU64::new(1).unwrap());
-        assert_eq!(size.to_bytes(), 1024 * 1024 * 1024);
-    }
-
-    #[test]
-    #[should_panic(expected = "value cannot be zero")]
-    fn const_non_zero_should_panic() {
-        const_non_zero(0);
+        assert_eq!(size.to_bytes().get(), 1024 * 1024 * 1024);
     }
 
     #[test]

--- a/src/store/sqlite/pool.rs
+++ b/src/store/sqlite/pool.rs
@@ -1,0 +1,327 @@
+// This file is part of Astarte.
+//
+// Copyright 2025 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::VecDeque;
+use std::num::NonZeroU32;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, RwLock, Semaphore};
+use tracing::{debug, error, instrument, trace, warn};
+
+use crate::error::Report;
+use crate::store::sqlite::connection::SqliteConnection;
+
+use super::connection::{ReadConnection, WriteConnection};
+use super::options::SqliteOptions;
+use super::{Size, SqliteError};
+
+type HandleResult<C, O, E> = Result<(C, Result<O, E>), E>;
+
+#[derive(Debug)]
+pub(crate) struct Connections {
+    db_file: Arc<Path>,
+    options: RwLock<SqliteOptions>,
+    writer: Mutex<Option<WriteConnection>>,
+    reader_sem: Semaphore,
+    /// Use a FIFO queue for the connections to cycle through them all.
+    readers: Mutex<VecDeque<ReadConnection>>,
+}
+
+impl Connections {
+    /// Create a new connection queue
+    pub(crate) fn new(db_file: PathBuf, options: SqliteOptions) -> Self {
+        let readers = options.max_readers();
+
+        Self {
+            db_file: db_file.into(),
+            options: RwLock::new(options),
+            writer: Mutex::new(None),
+            reader_sem: Semaphore::new(readers.get()),
+            readers: Mutex::new(VecDeque::with_capacity(readers.get())),
+        }
+    }
+
+    /// Acquire the write connection to the database.
+    ///
+    /// It will call the closure in a [`tokio::task::spawn_blocking`] so all the SQLite operation
+    /// will not block the runtime.
+    #[instrument(skip_all, fields(db = %self.db_file.display()))]
+    pub(crate) async fn acquire_writer<F, O, E>(&self, f: F) -> Result<O, E>
+    where
+        F: FnOnce(&mut WriteConnection) -> Result<O, E> + Send + 'static,
+        O: Send + 'static,
+        E: From<SqliteError> + Send + 'static,
+    {
+        trace!("locking writer connection");
+
+        let mut writer_g = self.writer.lock().await;
+
+        trace!("writer connection acquired");
+
+        let writer = writer_g.take();
+        let db_file = Arc::clone(&self.db_file);
+        let options = { *self.options.read().await };
+
+        // this need to be a spawn blocking to both support single and multi threaded runtimes
+        let (writer, out) =
+            tokio::task::spawn_blocking(move || -> HandleResult<WriteConnection, O, E> {
+                let mut writer = WriteConnection::lazy(writer, &db_file, &options)?;
+
+                let out = (f)(&mut writer);
+
+                Ok((writer, out))
+            })
+            .await
+            .map_err(|err| {
+                error!(error = %Report::new(err), "couldn't join sqlite task");
+
+                SqliteError::Join
+            })??;
+
+        trace!("restoring writer connection");
+
+        writer_g.replace(writer);
+
+        out
+    }
+
+    /// Acquire one of the reader connection to the database.
+    ///
+    /// It will call the closure in a [`tokio::task::spawn_blocking`] so all the SQLite operation
+    /// will not block the runtime.
+    #[instrument(skip_all, fields(db = %self.db_file.display()))]
+    pub(crate) async fn acquire_reader<F, O, E>(&self, f: F) -> Result<O, E>
+    where
+        F: FnOnce(&mut ReadConnection) -> Result<O, E> + Send + 'static,
+        O: Send + 'static,
+        E: From<SqliteError> + Send + 'static,
+    {
+        trace!("acquiring reader permit");
+
+        let _permit = self
+            .reader_sem
+            .acquire()
+            .await
+            .map_err(|_| SqliteError::Reader)?;
+
+        trace!("reader permit acquired");
+
+        // The number of connection is less than or equal to the number of permits. We pop the
+        // interface and if the collection is empty, we need to add another one.
+        let reader = { self.readers.lock().await.pop_front() };
+        let db_file = Arc::clone(&self.db_file);
+        let options = { *self.options.read().await };
+
+        // this need to be a spawn blocking to both support single and multi threaded runtimes
+        let (reader, out) =
+            tokio::task::spawn_blocking(move || -> HandleResult<ReadConnection, O, E> {
+                let mut reader = ReadConnection::lazy(reader, &db_file, &options)?;
+
+                let out = (f)(&mut reader);
+
+                Ok((reader, out))
+            })
+            .await
+            .map_err(|err| {
+                error!(error = %Report::new(err), "couldn't join sqlite task");
+
+                SqliteError::Join
+            })??;
+
+        {
+            self.readers.lock().await.push_back(reader)
+        }
+
+        out
+    }
+
+    // FIXME: remove in next release.
+    pub(crate) async fn set_max_page_count(&self, count: NonZeroU32) -> Result<(), SqliteError> {
+        let mut writer_g = self.writer.lock().await;
+        let mut readers_g = self.readers.lock().await;
+
+        let mut options_g = self.options.write().await;
+        let mut options = *options_g;
+
+        options.set_max_page_count(count);
+
+        apply_options(&mut writer_g, &mut readers_g, options).await?;
+
+        *options_g = options;
+
+        Ok(())
+    }
+
+    // FIXME: remove in next release.
+    pub(crate) async fn set_db_max_size(&self, size: Size) -> Result<(), SqliteError> {
+        let mut writer_g = self.writer.lock().await;
+        let mut readers_g = self.readers.lock().await;
+
+        let mut options_g = self.options.write().await;
+        let mut options = *options_g;
+
+        options.set_db_max_size(size);
+
+        apply_options(&mut writer_g, &mut readers_g, options).await?;
+
+        *options_g = options;
+
+        Ok(())
+    }
+
+    // FIXME: remove in next release.
+    pub(crate) async fn set_journal_size_limit(&self, size: Size) -> Result<(), SqliteError> {
+        let mut writer_g = self.writer.lock().await;
+        let mut readers_g = self.readers.lock().await;
+
+        let mut options_g = self.options.write().await;
+        let mut options = *options_g;
+
+        options.set_journal_size_limit(size);
+
+        apply_options(&mut writer_g, &mut readers_g, options).await?;
+
+        *options_g = options;
+
+        Ok(())
+    }
+}
+
+#[instrument(skip(writer_g, readers_g))]
+async fn apply_options(
+    writer_g: &mut Option<WriteConnection>,
+    readers_g: &mut VecDeque<ReadConnection>,
+    options: SqliteOptions,
+) -> Result<(), SqliteError> {
+    trace!("applyign options");
+
+    if let Some(writer) = writer_g.take() {
+        let writer =
+            tokio::task::spawn_blocking(move || -> Result<WriteConnection, SqliteError> {
+                writer.apply_pragmas(&options)?;
+
+                Ok(writer)
+            })
+            .await
+            .map_err(|err| {
+                error!(error = %Report::new(err), "couldn't join sqlite task");
+
+                SqliteError::Join
+            })??;
+
+        writer_g.replace(writer);
+
+        debug!("writer options applyed");
+    } else {
+        trace!("writer not connectd");
+    }
+
+    let len = readers_g.len();
+    for i in 0..len {
+        trace!(i, "applying to reader");
+
+        let Some(reader) = readers_g.pop_front() else {
+            warn!(i, "no more readers");
+
+            break;
+        };
+
+        let reader = tokio::task::spawn_blocking(move || -> Result<ReadConnection, SqliteError> {
+            reader.apply_pragmas(&options)?;
+
+            Ok(reader)
+        })
+        .await
+        .map_err(|err| {
+            error!(error = %Report::new(err), "couldn't join sqlite task");
+
+            SqliteError::Join
+        })??;
+
+        readers_g.push_back(reader);
+
+        debug!(i, "reader options applyed");
+    }
+
+    Ok(())
+}
+
+// Drop to manually close all the readers before the writer.
+impl Drop for Connections {
+    #[instrument(skip_all, fields(db = %self.db_file.display()))]
+    fn drop(&mut self) {
+        trace!("pool dropped, closing the connections");
+
+        let readers = std::mem::take(self.readers.get_mut());
+        let writer = self.writer.get_mut().take();
+
+        tokio::task::spawn_blocking(move || {
+            for reader in readers {
+                reader.close();
+            }
+
+            if let Some(writer) = writer {
+                writer.close();
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn should_survice_panic() {
+        let tpm = TempDir::new().unwrap();
+
+        let pool = Connections::new(tpm.path().join("sdk.db"), SqliteOptions::default());
+
+        let res: Result<(), SqliteError> = pool.acquire_writer(|_writer| panic!()).await;
+
+        assert!(matches!(res.unwrap_err(), SqliteError::Join));
+
+        let pool = Connections::new(tpm.path().join("sdk.db"), SqliteOptions::default());
+
+        let res: Result<(), SqliteError> = pool.acquire_reader(|_reader| panic!()).await;
+
+        assert!(matches!(res.unwrap_err(), SqliteError::Join));
+    }
+
+    #[tokio::test]
+    async fn apply_options() {
+        let tpm = TempDir::new().unwrap();
+
+        let pool = Connections::new(tpm.path().join("sdk.db"), SqliteOptions::default());
+
+        // create connections
+        pool.acquire_writer::<_, _, SqliteError>(|_writer| Ok(()))
+            .await
+            .unwrap();
+        pool.acquire_reader::<_, _, SqliteError>(|_reader| Ok(()))
+            .await
+            .unwrap();
+
+        pool.set_max_page_count(NonZeroU32::new(42).unwrap())
+            .await
+            .unwrap();
+    }
+}

--- a/src/utils/const_conv.rs
+++ b/src/utils/const_conv.rs
@@ -1,0 +1,70 @@
+// This file is part of Astarte.
+//
+// Copyright 2025 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Conversions for const context
+//!
+//! Necessary for rust 1.78 const compatibility
+
+use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
+
+pub(crate) const fn const_non_zero_usize(v: usize) -> NonZeroUsize {
+    let Some(v) = NonZeroUsize::new(v) else {
+        panic!("value cannot be zero");
+    };
+
+    v
+}
+
+pub(crate) const fn const_non_zero_u64(v: u64) -> NonZeroU64 {
+    let Some(v) = NonZeroU64::new(v) else {
+        panic!("value cannot be zero");
+    };
+
+    v
+}
+
+pub(crate) const fn const_non_zero_u32(v: u32) -> NonZeroU32 {
+    let Some(v) = NonZeroU32::new(v) else {
+        panic!("value cannot be zero");
+    };
+
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "value cannot be zero")]
+    fn const_non_zero_usize_should_panic() {
+        const_non_zero_usize(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "value cannot be zero")]
+    fn const_non_zero_u64_should_panic() {
+        const_non_zero_u64(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "value cannot be zero")]
+    fn const_non_zero_u32_should_panic() {
+        const_non_zero_u32(0);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,23 @@
+// This file is part of Astarte.
+//
+// Copyright 2025 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Crate to place util functions reused in the crate.
+//!
+//! This MUST be pub(crate) and with a module for each util.
+
+pub(crate) mod const_conv;


### PR DESCRIPTION
Do not use the thread locals for the sqlite connections, but a pool that will be dropped when the program exits.


## Tested

If you test the e2e on the release-0.10 branch the following file will remain after it finishes:

```
prop-cache.db-shm
prop-cache.db-wal
```

On the current branch when the pool is dropped all the files are cleaned up.