### PR TITLE
feat(pairing): add method to check whether the device is paired

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -373,9 +373,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-fips-sys"
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -1014,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1075,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1362,9 +1362,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1539,9 +1539,9 @@ checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1584,9 +1584,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1948,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2021,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "matchers"
@@ -2052,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -2171,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2667,9 +2667,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2720,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "rsqlite-vfs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
@@ -3220,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
 dependencies = [
  "bindgen",
  "cc",
@@ -3576,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3863,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3876,9 +3876,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3886,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3896,9 +3896,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3909,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3952,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4207,9 +4207,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,8 +234,8 @@ rcgen = { version = "0.14.0", default-features = false }
 regex = "1.11.0"
 reqwest = { version = "0.13.0", default-features = false }
 rumqttc = { package = "rumqttc-dev-patched", version = "0.24.9-ack-notify" }
-# for last diesel release compatibility
-rusqlite = ">=0.35.0"
+# for last diesel release compatibility and MSRV
+rusqlite = ">=0.35.0, <0.40.0"
 rstest = "0.26.1"
 rustls = "0.23.39"
 rustls-native-certs = "0.8.1"

--- a/astarte-device-sdk-mock/src/lib.rs
+++ b/astarte-device-sdk-mock/src/lib.rs
@@ -22,7 +22,7 @@ use std::{future::Future, path::Path};
 
 use astarte_device_sdk::aggregate::AstarteObject;
 use astarte_device_sdk::astarte_interfaces::Interface;
-use astarte_device_sdk::client::{ClientDisconnect, RecvError};
+use astarte_device_sdk::client::{ClientConnection, RecvError};
 use astarte_device_sdk::properties::PropAccess;
 use astarte_device_sdk::store::StoredProp;
 use astarte_device_sdk::transport::Connection;
@@ -164,8 +164,10 @@ mock! {
         async fn server_props(&self) -> Result<Vec<StoredProp>, Error>;
     }
 
-    impl<C: Connection> ClientDisconnect for DeviceClient<C> {
+    impl<C: Connection> ClientConnection for DeviceClient<C> {
         async fn disconnect(&mut self) -> Result<(), Error>;
+
+        fn is_paired(&self) -> bool;
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -123,6 +123,9 @@ pub enum BuilderError {
     /// Couldn't set the maximum number of items in the store
     #[error("couldn't set the maximum number of items in the store")]
     Retention(#[from] RetentionError),
+    /// Couldn't set the maximum number of items in the store
+    #[error("couldn't check if the device is already paired")]
+    PairingStatus(#[from] std::io::Error),
 }
 
 /// Configuration options and parameters for the connection.
@@ -470,6 +473,15 @@ where
             store,
         } = self.connection_config.connect(config).await?;
 
+        let paired = connection
+            .is_paired()
+            .await
+            .map_err(BuilderError::PairingStatus)?;
+
+        debug!(paired, "device pairing status");
+
+        state.set_device_status(paired);
+
         let (client_state, connection_state) = state.split();
 
         let client = DeviceClient::new(
@@ -562,6 +574,7 @@ where
 mod test {
     use std::time::Duration;
 
+    use futures::FutureExt;
     use mockall::Sequence;
     use tempfile::TempDir;
 
@@ -632,8 +645,12 @@ mod test {
                 let mut seq = Sequence::new();
                 sender.expect_clone().once().in_sequence(&mut seq).returning(MockSender::new);
 
+                let mut connection = MockCon::new();
+
+                connection.expect_is_paired().with().returning(|| futures::future::ok(true).boxed());
+
                 Ok(DeviceTransport {
-                    connection: MockCon::new(),
+                    connection,
                     sender,
                     store: StoreWrapper::new(config.store),
                 })

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -342,10 +342,15 @@ pub trait Client: Clone {
     fn recv(&self) -> impl Future<Output = Result<DeviceEvent, RecvError>> + Send;
 }
 
-/// A trait representing the behavior of an Astarte device client to disconnect itself from Astarte.
-pub trait ClientDisconnect {
+/// Connection of the Client.
+///
+/// Manages introspects the connection and device status.
+pub trait ClientConnection {
     /// Cleanly disconnects the client consuming it.
     fn disconnect(&mut self) -> impl Future<Output = Result<(), Error>> + Send;
+
+    /// Check if the client is already paired.
+    fn is_paired(&self) -> bool;
 }
 
 /// Client to send and receive message to and form Astarte or access the Device properties.
@@ -654,7 +659,7 @@ where
     }
 }
 
-impl<C> ClientDisconnect for DeviceClient<C>
+impl<C> ClientConnection for DeviceClient<C>
 where
     C: Connection,
     C::Sender: Disconnect,
@@ -675,6 +680,10 @@ where
         }
 
         Ok(())
+    }
+
+    fn is_paired(&self) -> bool {
+        self.state.is_device_paired()
     }
 }
 

--- a/src/pairing/api/mod.rs
+++ b/src/pairing/api/mod.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 
 use reqwest::StatusCode;
 use tokio::fs;
-use tracing::{debug, info};
+use tracing::{debug, error, info, instrument};
 
 use self::client::{ApiClient, ClientArgs};
 
@@ -149,13 +149,8 @@ impl PairingApi {
             Credential::Secret { credentials_secret } => Ok(credentials_secret.clone()),
             Credential::ParingToken { pairing_token } => {
                 debug!("pairing token provided, retrieving credentials secret");
-                let Some(dir) = &ctx.state.config.writable_dir else {
-                    return Err(PairingError::NoStorePairingToken);
-                };
 
-                let secret = self
-                    .read_secret_or_register(ctx, dir, pairing_token)
-                    .await?;
+                let secret = self.read_secret_or_register(ctx, pairing_token).await?;
 
                 Ok(secret)
             }
@@ -166,10 +161,15 @@ impl PairingApi {
     async fn read_secret_or_register<S>(
         &self,
         ctx: &mut ConnCtx<'_, S>,
-        store_dir: &Path,
         pairing_token: &str,
     ) -> Result<String, PairingError> {
-        let credential_file = store_dir.join(CREDENTIAL_FILE);
+        let credential_file = ctx
+            .state
+            .config
+            .writable_dir
+            .as_ref()
+            .map(|dir| dir.join(CERTIFICATE_FILE))
+            .ok_or(PairingError::NoStorePairingToken)?;
 
         match fs::read_to_string(&credential_file).await {
             Ok(secret) => {
@@ -231,5 +231,28 @@ impl Pairing for PairingApi {
             keepalive: self.mqtt_config.keepalive,
             secret,
         })
+    }
+
+    #[instrument(skip(self), ret)]
+    async fn is_paired(&self, store_dir: Option<&Path>) -> std::io::Result<bool> {
+        if matches!(self.mqtt_config.credential, Credential::Secret { .. }) {
+            return Ok(true);
+        }
+
+        let credential_file = store_dir.map(|p| p.join(CREDENTIAL_FILE)).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "store directory not configured for pairing with token",
+            )
+        })?;
+
+        tokio::fs::try_exists(&credential_file)
+            .await
+            .inspect_err(|_| {
+                error!(
+                    path = %credential_file.display(),
+                    "couldn't read credentials file"
+                )
+            })
     }
 }

--- a/src/pairing/fdo/mod.rs
+++ b/src/pairing/fdo/mod.rs
@@ -263,6 +263,11 @@ where
     {
         self.register(ctx).await
     }
+
+    async fn is_paired(&self, _: Option<&Path>) -> Result<bool, std::io::Error> {
+        // the FDO has already finished the DeviceInitialization and has an ownership voucher
+        Ok(true)
+    }
 }
 
 impl<S, C> ConnectionConfig<S> for FdoConfig<C>

--- a/src/pairing/mod.rs
+++ b/src/pairing/mod.rs
@@ -18,6 +18,7 @@
 
 //! Module to pair a new device to the transport
 
+use std::path::Path;
 use std::time::Duration;
 
 use rumqttc::{MqttOptions, NetworkOptions, Transport};
@@ -44,6 +45,12 @@ pub trait Pairing: Send + Sync {
     ) -> impl Future<Output = Result<PairingConfig, Self::Error>> + Send
     where
         S: Send + Sync;
+
+    /// Check if the device is already paired.
+    fn is_paired(
+        &self,
+        store_dir: Option<&Path>,
+    ) -> impl Future<Output = Result<bool, std::io::Error>> + Send;
 }
 
 /// Device configuration after pairing.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 // This file is part of Astarte.
 //
-// Copyright 2023 - 2025 SECO Mind Srl
+// Copyright 2023-2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 pub mod device {
     pub use crate::FromEvent;
     pub use crate::client::Client;
-    pub use crate::client::ClientDisconnect;
+    pub use crate::client::ClientConnection;
     pub use crate::connection::EventLoop;
     pub use crate::introspection::{DeviceIntrospection, DynamicIntrospection};
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,6 +18,8 @@
 
 use std::fmt::Display;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
 
 use chrono::DateTime;
 use chrono::Utc;
@@ -39,6 +41,8 @@ pub struct SharedState {
     pub(crate) retention_ctx: retention::Context,
     pub(crate) status: RwLock<ConnStatus>,
     pub(crate) cert_expiry: RwLock<Option<DateTime<Utc>>>,
+    /// Status of the device, whether it's paired to Astarte
+    pub(crate) device_status: AtomicU8,
 }
 
 impl SharedState {
@@ -54,6 +58,7 @@ impl SharedState {
             retention_ctx: retention::Context::new(),
             status: RwLock::new(ConnStatus::default()),
             cert_expiry: RwLock::new(None),
+            device_status: AtomicU8::new(DeviceStatus::Unknown.into()),
         }
     }
 
@@ -67,6 +72,16 @@ impl SharedState {
     /// Gets the config for the retention
     pub fn config(&self) -> &Config {
         &self.config
+    }
+
+    pub(crate) fn set_device_status(&self, paired: bool) {
+        let status = if paired {
+            DeviceStatus::Paired
+        } else {
+            DeviceStatus::Unpaired
+        };
+
+        self.device_status.store(status.into(), Ordering::Release);
     }
 }
 
@@ -97,6 +112,21 @@ impl ClientState {
 
     pub(crate) async fn cert_expiry(&self) -> Option<DateTime<Utc>> {
         *self.0.cert_expiry.read().await
+    }
+
+    pub(crate) fn is_device_paired(&self) -> bool {
+        let value = DeviceStatus::from(self.0.device_status.load(Ordering::Acquire));
+
+        debug_assert_ne!(
+            value,
+            DeviceStatus::Unknown,
+            "the unknown status should be set only in the builder"
+        );
+
+        match value {
+            DeviceStatus::Unknown | DeviceStatus::Unpaired => false,
+            DeviceStatus::Paired => true,
+        }
     }
 }
 
@@ -152,11 +182,46 @@ impl Display for ConnStatus {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub(crate) enum DeviceStatus {
+    Unknown = 0,
+    Unpaired = 1,
+    Paired = 2,
+}
+
+impl Display for DeviceStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeviceStatus::Unknown => write!(f, "Unknown"),
+            DeviceStatus::Unpaired => write!(f, "Unpaired"),
+            DeviceStatus::Paired => write!(f, "Paired"),
+        }
+    }
+}
+
+impl From<u8> for DeviceStatus {
+    fn from(value: u8) -> Self {
+        match value {
+            0 | 3.. => DeviceStatus::Unknown,
+            1 => DeviceStatus::Unpaired,
+            2 => DeviceStatus::Paired,
+        }
+    }
+}
+
+impl From<DeviceStatus> for u8 {
+    fn from(value: DeviceStatus) -> Self {
+        value as u8
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use pretty_assertions::assert_eq;
+    use rstest::rstest;
 
     impl ConnectionState {
         pub(crate) fn retention_ctx(&self) -> &retention::Context {
@@ -168,5 +233,26 @@ mod tests {
     fn default_connection_state() {
         // Must start disconnected
         assert_eq!(ConnStatus::default(), ConnStatus::Disconnected)
+    }
+
+    #[rstest]
+    #[case(0, DeviceStatus::Unknown)]
+    #[case(3, DeviceStatus::Unknown)]
+    #[case(1, DeviceStatus::Unpaired)]
+    #[case(2, DeviceStatus::Paired)]
+    fn device_status_from_u8(#[case] value: u8, #[case] exp: DeviceStatus) {
+        let res = DeviceStatus::from(value);
+
+        assert_eq!(res, exp);
+    }
+
+    #[rstest]
+    #[case(DeviceStatus::Unknown, 0)]
+    #[case(DeviceStatus::Unpaired, 1)]
+    #[case(DeviceStatus::Paired, 2)]
+    fn device_status_into_u8(#[case] value: DeviceStatus, #[case] exp: u8) {
+        let res = u8::from(value);
+
+        assert_eq!(res, exp);
     }
 }

--- a/src/transport/grpc/mod.rs
+++ b/src/transport/grpc/mod.rs
@@ -596,6 +596,11 @@ where
     type Sender = GrpcClient<GrpcStore<S>>;
 
     type Store = GrpcStore<S>;
+
+    async fn is_paired(&self) -> Result<bool, std::io::Error> {
+        // The device never pairs with the message-hub
+        Ok(false)
+    }
 }
 
 /// Internal struct holding the received grpc message

--- a/src/transport/mock.rs
+++ b/src/transport/mock.rs
@@ -54,6 +54,9 @@ mock! {
     impl<S: StoreCapabilities> Connection for Con<S> {
         type Sender = MockSender;
         type Store = S;
+
+        fn is_paired(&self) -> impl Future<Output = Result<bool, std::io::Error>> + Send {
+        }
     }
 
     impl<S: StoreCapabilities> Receive for Con<S> {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -80,6 +80,11 @@ pub trait Connection: Send + Sync {
     /// This reduces the number of generics for connection, since a single client type is associated
     /// with a connection.
     type Store: StoreCapabilities;
+
+    /// Checks whether the device is paired.
+    ///
+    /// In case of the MQTT connection is when the device is paired on Astarte.
+    fn is_paired(&self) -> impl Future<Output = Result<bool, std::io::Error>> + Send;
 }
 
 /// Implement the publication for a connection.

--- a/src/transport/mqtt/connection/mod.rs
+++ b/src/transport/mqtt/connection/mod.rs
@@ -121,7 +121,7 @@ impl ConnError {
 #[derive(Debug)]
 pub(crate) struct MqttState<P> {
     /// The device is disconnected from Astarte, it will need to recreate the connection.
-    pairing: P,
+    pub(crate) pairing: P,
     state: State,
 }
 
@@ -210,6 +210,9 @@ impl<P> MqttState<P> {
 
             ConnError::Pairing
         })?;
+
+        // FIXME: Not sure if this is the best place to do it
+        ctx.state.set_device_status(true);
 
         let connection = disconnected.connect(ctx, &cfg).await?;
 

--- a/src/transport/mqtt/mod.rs
+++ b/src/transport/mqtt/mod.rs
@@ -47,7 +47,7 @@ use bytes::Bytes;
 use futures::{TryFutureExt, future::Either};
 use itertools::Itertools;
 use rumqttc::{AckOfPub, ClientError, QoS, Token, TokenError};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, instrument, trace};
 
 use super::{
     Connection, Disconnect, Publish, Receive, ReceivedEvent, Register, TransportError,
@@ -865,6 +865,14 @@ where
 {
     type Sender = MqttClient<S>;
     type Store = S;
+
+    #[instrument(skip(self), ret)]
+    async fn is_paired(&self) -> Result<bool, std::io::Error> {
+        self.connection
+            .pairing
+            .is_paired(self.state.config.writable_dir.as_deref())
+            .await
+    }
 }
 
 /// Wrapper structs that holds data used when connecting/reconnecting


### PR DESCRIPTION
Add a method to the connection to check at runtime whether the device is
binded to a cloud. If a device is bindend the device id, realm and
pairing url cannot be reconfigured. This methods allows user to check
for this case externally.