### PR TITLE
feat(tls): add crate to configure tls on the device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "astarte-device-tls"
+version = "0.13.0"
+dependencies = [
+ "aws-lc-rs",
+ "cfg-if",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier 0.6.2",
+ "tracing",
+ "webpki-roots",
+]
+
+[[package]]
 name = "astarte-fdo-protocol"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ resolver = "3"
 members = [
   "astarte-device-sdk-derive",
   "astarte-device-sdk-mock",
+  "astarte-device-tls",
   "astarte-test-utils",
   "e2e-test",
 ]
@@ -196,13 +197,14 @@ all-features = true
 rustdoc-args = ["--cfg=astarte_device_sdk_docsrs"]
 
 [workspace.dependencies]
-astarte-test-utils = { path = "./astarte-test-utils", version = "=0.13.0" }
 astarte-device-fdo = "1.0.1"
 astarte-device-sdk = { path = "./", version = "=0.13.0" }
 astarte-device-sdk-derive = { version = "=0.13.0", path = "./astarte-device-sdk-derive" }
+astarte-device-tls = { path = "./astarte-device-tls", version = "=0.13.0" }
 astarte-interfaces = "1.0.0"
 astarte-message-hub-proto = "0.10.1"
 astarte-message-hub-proto-mock = "0.10.1"
+astarte-test-utils = { path = "./astarte-test-utils", version = "=0.13.0" }
 async-channel = "2.0.0"
 aws-lc-rs = "1.14.0"
 base64 = "0.22.1"

--- a/astarte-device-tls/Cargo.toml
+++ b/astarte-device-tls/Cargo.toml
@@ -1,0 +1,44 @@
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "astarte-device-tls"
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+categories = ["cryptography"]
+description = "TLS configuration for the Astarte device"
+
+[features]
+default = ["platform-verifier"]
+# Preferred, use the platform certificate and TLS verifier.
+platform-verifier = ["dep:rustls-platform-verifier"]
+# Compiled in copy of the root certificate trusted by Mozilla.
+webpki-roots = ["dep:webpki-roots"]
+
+[dependencies]
+aws-lc-rs.workspace = true
+cfg-if.workspace = true
+rustls-native-certs.workspace = true
+rustls.workspace = true
+tracing.workspace = true
+rustls-platform-verifier = { workspace = true, optional = true }
+webpki-roots = { workspace = true, optional = true }

--- a/astarte-device-tls/src/insecure.rs
+++ b/astarte-device-tls/src/insecure.rs
@@ -1,0 +1,100 @@
+// This file is part of Astarte.
+//
+// Copyright 2026 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Insecure verifier that accepts all certificates as valid.
+
+use std::sync::Arc;
+
+use rustls::client::WantsClientCert;
+use rustls::crypto::CryptoProvider;
+use rustls::{ClientConfig, ConfigBuilder, Error};
+use tracing::instrument;
+
+/// Insecure configuration builder.
+///
+/// This disables TLS verification.
+///
+/// # Errors
+///
+/// If we cannot configure the verifier.
+#[instrument]
+pub fn builder() -> Result<ConfigBuilder<ClientConfig, WantsClientCert>, Error> {
+    let provider = CryptoProvider::get_default()
+        .cloned()
+        .unwrap_or_else(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
+
+    let builder = rustls::ClientConfig::builder_with_provider(provider)
+        .with_protocol_versions(rustls::ALL_VERSIONS)?
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerifier {}));
+
+    Ok(builder)
+}
+
+/// Verifier that doesn't verify the certificate
+#[derive(Debug)]
+struct NoVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for NoVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        vec![
+            rustls::SignatureScheme::RSA_PKCS1_SHA1,
+            rustls::SignatureScheme::ECDSA_SHA1_Legacy,
+            rustls::SignatureScheme::RSA_PKCS1_SHA256,
+            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+            rustls::SignatureScheme::RSA_PKCS1_SHA384,
+            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+            rustls::SignatureScheme::RSA_PKCS1_SHA512,
+            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+            rustls::SignatureScheme::RSA_PSS_SHA256,
+            rustls::SignatureScheme::RSA_PSS_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA512,
+            rustls::SignatureScheme::ED25519,
+            rustls::SignatureScheme::ED448,
+        ]
+    }
+}

--- a/astarte-device-tls/src/lib.rs
+++ b/astarte-device-tls/src/lib.rs
@@ -1,0 +1,176 @@
+// This file is part of Astarte.
+//
+// Copyright 2026 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use rustls::client::WantsClientCert;
+use rustls::crypto::CryptoProvider;
+use rustls::{ClientConfig, ConfigBuilder, Error, RootCertStore};
+use rustls_native_certs::load_native_certs;
+use tracing::instrument;
+use tracing::{error, info};
+
+// re-export
+pub use rustls;
+
+pub mod insecure;
+
+/// Returns a configured TLS client.
+///
+/// # Errors
+///
+/// If we cannot configure the verifier or read the root CAs.
+#[instrument]
+pub fn config() -> Result<ClientConfig, Error> {
+    builder().map(ConfigBuilder::<ClientConfig, WantsClientCert>::with_no_client_auth)
+}
+
+/// Returns a configured builder.
+///
+/// This builder can be used for client authentication.
+///
+/// # Errors
+///
+/// If we cannot configure the verifier or read the root CAs.
+#[instrument]
+pub fn builder() -> Result<ConfigBuilder<ClientConfig, WantsClientCert>, Error> {
+    // This step is to ensure a CryptoProvider is configured also in the tests.
+    let provider = CryptoProvider::get_default().map_or_else(
+        || Arc::new(rustls::crypto::aws_lc_rs::default_provider()),
+        Arc::clone,
+    );
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "platform-verifier")] {
+            platform_verifier(provider)
+        } else if #[cfg(feature = "webpki-roots")]{
+            webpki(provider)
+        } else {
+            _default(provider)
+        }
+    }
+}
+
+#[cfg(feature = "platform-verifier")]
+#[instrument(skip(provider))]
+fn platform_verifier(
+    provider: Arc<CryptoProvider>,
+) -> Result<ConfigBuilder<ClientConfig, WantsClientCert>, Error> {
+    use rustls_platform_verifier::BuilderVerifierExt;
+
+    let config = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()?
+        .with_platform_verifier()?;
+
+    info!("tls client configured with platform verifier");
+
+    Ok(config)
+}
+
+/// Uses the CA bundled at compile time.
+///
+/// # Errors
+///
+/// If we cannot configure the verifier or read the root CAs.
+#[instrument(skip(provider))]
+#[cfg(feature = "webpki-roots")]
+pub fn webpki(provider: Arc<CryptoProvider>) -> Result<ClientConfig, Error> {
+    static ROOTS: std::sync::OnceLock<Arc<RootCertStore>> = std::sync::OnceLock::new();
+
+    let roots = ROOTS.get_or_init(|| {
+        let roots = RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+        };
+
+        Arc::new(roots)
+    });
+
+    let config = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()?
+        .with_root_certificates(Arc::clone(roots))
+        .with_no_client_auth();
+
+    info!("tls client configured with webpki roots");
+
+    Ok(config)
+}
+
+// NOTE: the `_` in the name is to prevent a dead_code warning when the other features are enabled
+#[instrument(skip(provider))]
+fn _default(
+    provider: Arc<CryptoProvider>,
+) -> Result<ConfigBuilder<ClientConfig, WantsClientCert>, Error> {
+    static ROOTS: std::sync::OnceLock<Arc<RootCertStore>> = std::sync::OnceLock::new();
+
+    let roots = ROOTS.get_or_init(|| {
+        let res = load_native_certs();
+
+        for error in res.errors {
+            error!(%error, "couldn't load native certificate");
+        }
+
+        let mut roots = RootCertStore::empty();
+
+        let (added, ignored) = roots.add_parsable_certificates(res.certs);
+
+        info!(added, ignored, "native certificates loaded");
+
+        Arc::new(roots)
+    });
+
+    let config = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()?
+        .with_root_certificates(Arc::clone(roots));
+
+    info!("tls client configured with native roots");
+
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configure() {
+        config().unwrap();
+    }
+
+    #[test]
+    fn configure_default() {
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+
+        _default(Arc::new(provider)).unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "platform-verifier")]
+    fn configure_platform_verifier() {
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+
+        platform_verifier(Arc::new(provider)).unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "webpki-roots")]
+    fn configure_webpki_roots() {
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+
+        webpki(Arc::new(provider)).unwrap();
+    }
+}

--- a/scripts/ci/check-for-publish.sh
+++ b/scripts/ci/check-for-publish.sh
@@ -31,6 +31,7 @@ pkgsFiles=$(
     cat <(cargo package --allow-dirty -l -p "astarte-device-sdk") \
         <(listPackage "astarte-device-sdk-derive") \
         <(listPackage "astarte-device-sdk-mock") \
+        <(listPackage "astarte-device-tls") \
         <(listPackage "astarte-test-utils") \
         <(listPackage "e2e-test") |
         sort


### PR DESCRIPTION
Add a new crate to configure TLS on both the message-hub and edgehog-device-runtime.