### PR TITLE
feat(derive)!: add the required object attribute

### DIFF
--- a/astarte-device-error/src/lib.rs
+++ b/astarte-device-error/src/lib.rs
@@ -111,6 +111,11 @@ impl<K> Error<K> {
         }
     }
 
+    /// Sets a static message for the error.
+    pub fn set_message(&mut self, message: &'static str) {
+        self.message = Some(message);
+    }
+
     /// Sets the message for the error
     pub fn set_ctx<T>(mut self, message: T) -> Self
     where

--- a/astarte-device-sdk-derive/src/event.rs
+++ b/astarte-device-sdk-derive/src/event.rs
@@ -152,27 +152,49 @@ impl FromEventDerive {
         let fields = fields
             .iter()
             .filter_map(|field| {
+                let required = field.required.unwrap_or_default();
                 errors.handle_in(|| {
-                    field.field_name(self.rename_all).ok_or_else(|| {
-                        darling::Error::custom("missing field names").with_span(&self.ident)
-                    })
+                    field
+                        .field_name(self.rename_all)
+                        .ok_or_else(|| {
+                            darling::Error::custom("missing field names").with_span(&self.ident)
+                        })
+                        .map(|(i, name)| (i, name, required))
                 })
             })
-            .collect::<Vec<(&syn::Ident, String)>>();
+            .collect::<Vec<(&syn::Ident, String, bool)>>();
 
-        let fields_val = fields.iter().map(|(i, name)| {
-            quote_spanned! {i.span() =>
-                let #i = object
-                    .remove(#name)
-                    .ok_or_else(||{
-                        Error::new(FromEventError::Interface(InterfaceError::MappingRequired))
-                            .set_ctx(format!("for interface {} endpoint {}{}", interface, base_path, #name))
-                    })?
-                    .try_into()
-                    .map_kind(FromEventError::Conversion)?;
+        let fields_val = fields.iter().map(|(i, name, required)| {
+            if *required {
+                quote_spanned! {i.span() =>
+                    let #i = object
+                        .remove(#name)
+                        .ok_or_else(||{
+                            Error::new(FromEventError::Interface(InterfaceError::MappingRequired))
+                                .set_ctx(format!("for interface {} endpoint {}{}", interface, base_path, #name))
+                        })?
+                        .try_into()
+                        .map_kind(FromEventError::Conversion)
+                        .map_err(|mut err| {
+                            err.set_message(concat!("for mapping ", #name));
+                            err
+                        })?;
+                }
+            } else {
+                quote_spanned! {i.span() =>
+                    let #i = object
+                        .remove(#name)
+                        .map(AstarteData::try_into)
+                        .transpose()
+                        .map_kind(FromEventError::Conversion)
+                        .map_err(|mut err| {
+                            err.set_message(concat!("for mapping ", #name));
+                            err
+                        })?;
+                }
             }
         });
-        let fields = fields.iter().map(|(i, _)| i);
+        let fields = fields.iter().map(|(i, _, _)| i);
         let interface = &self.interface;
         let st_name = &self.ident;
 
@@ -189,7 +211,7 @@ impl FromEventDerive {
                 type Err = astarte_device_sdk::astarte_device_error::Error<astarte_device_sdk::event::FromEventError>;
 
                 fn from_event(event: astarte_device_sdk::DeviceEvent) -> ::std::result::Result<Self, Self::Err> {
-                    use astarte_device_sdk::Value;
+                    use astarte_device_sdk::{Value, AstarteData};
                     use astarte_device_sdk::astarte_device_error::{Error, WrapError, ResultExt};
                     use astarte_device_sdk::error::InterfaceError;
                     use astarte_device_sdk::event::FromEventError;
@@ -521,6 +543,8 @@ impl FromEventDerive {
 pub(crate) struct FromEventField {
     /// Rename the filed or variant.
     rename: Option<String>,
+    /// The filed is for a required object mapping.
+    required: Option<bool>,
     /// Field name
     ident: Option<syn::Ident>,
 }

--- a/examples/object_datastream/main.rs
+++ b/examples/object_datastream/main.rs
@@ -118,7 +118,9 @@ where
     path = "/%{led_id}"
 )]
 struct ServerDatastream {
+    #[mapping(required)]
     enable: bool,
+    #[mapping(required)]
     intensity: f64,
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -238,14 +238,15 @@ mod tests {
         assert_eq!(val.clone().try_into_property(), Ok(prop));
     }
 
-    #[test]
     #[cfg(feature = "derive")]
-    fn should_derive_form_event_obj() {
-        use crate::aggregate::AstarteObject;
-        use crate::{DeviceEvent, FromEvent, Value};
+    mod derive {
+        use pretty_assertions::assert_eq;
 
+        use crate::{DeviceEvent, FromEvent, Value};
         // Alias the crate to the resulting macro
         use crate::{self as astarte_device_sdk};
+
+        use super::*;
 
         #[derive(Debug, FromEvent, PartialEq, Eq)]
         #[from_event(
@@ -254,92 +255,147 @@ mod tests {
             aggregation = "object"
         )]
         struct Sensor {
+            #[mapping(required)]
             name: String,
+            #[mapping(required)]
             value: i32,
         }
 
-        let mut data = AstarteObject::new();
-        data.insert("name".to_string(), "Foo".to_string().into());
-        data.insert("value".to_string(), 42i32.into());
+        #[test]
+        fn should_derive_form_event_obj() {
+            let mut data = AstarteObject::new();
+            data.insert("name".to_string(), "Foo".to_string().into());
+            data.insert("value".to_string(), 42i32.into());
 
-        let event = DeviceEvent {
-            interface: "com.example.Sensor".to_string(),
-            path: "/sensor".to_string(),
-            data: Value::Object {
-                data,
-                timestamp: Utc::now(),
-            },
-        };
+            let event = DeviceEvent {
+                interface: "com.example.Sensor".to_string(),
+                path: "/sensor".to_string(),
+                data: Value::Object {
+                    data,
+                    timestamp: Utc::now(),
+                },
+            };
 
-        let sensor = Sensor::from_event(event).expect("couldn't parse the event");
+            let sensor = Sensor::from_event(event).expect("couldn't parse the event");
 
-        let expected = Sensor {
-            name: "Foo".to_string(),
-            value: 42,
-        };
+            let expected = Sensor {
+                name: "Foo".to_string(),
+                value: 42,
+            };
 
-        assert_eq!(sensor, expected);
-    }
+            assert_eq!(sensor, expected);
+        }
 
-    #[test]
-    #[cfg(feature = "derive")]
-    fn should_derive_form_event_individual() {
-        use crate::{AstarteData, DeviceEvent, FromEvent, Value};
+        #[derive(Debug, FromEvent, PartialEq, Eq)]
+        #[from_event(
+            interface = "com.example.Sensor",
+            path = "/sensor",
+            aggregation = "object"
+        )]
+        struct SensorOpt {
+            name: Option<String>,
+            value: Option<i32>,
+        }
 
-        // Alias the crate to the resulting macro
-        use crate::{self as astarte_device_sdk};
+        #[rstest::rstest]
+        #[case(
+            AstarteObject::from_iter([
+                ("name".to_string(), AstarteData::String("Foo".to_string())),
+                ("value".to_string(), AstarteData::Integer(42))
+            ]),
+            SensorOpt {
+                name: Some("Foo".to_string()),
+                value: Some(42),
+            }
+        )]
+        #[case(
+            AstarteObject::from_iter([
+                ("name".to_string(), AstarteData::String("Foo".to_string())),
+            ]),
+            SensorOpt {
+                name: Some("Foo".to_string()),
+                value: None,
+            }
+        )]
+        #[case(
+            AstarteObject::from_iter([
+                ("value".to_string(), AstarteData::Integer(42))
+            ]),
+            SensorOpt {
+                name: None,
+                value:  Some(42),
+            }
+        )]
+        #[case(
+            AstarteObject::from_iter([]),
+            SensorOpt {
+                name: None,
+                value:  None,
+            }
+        )]
+        fn should_derive_form_event_obj_optional(
+            #[case] data: AstarteObject,
+            #[case] exp: SensorOpt,
+        ) {
+            let event = DeviceEvent {
+                interface: "com.example.Sensor".to_string(),
+                path: "/sensor".to_string(),
+                data: Value::Object {
+                    data,
+                    timestamp: Utc::now(),
+                },
+            };
+
+            let sensor = SensorOpt::from_event(event).expect("couldn't parse the event");
+
+            assert_eq!(sensor, exp);
+        }
 
         #[derive(Debug, FromEvent, PartialEq)]
         #[from_event(interface = "com.example.Sensor", aggregation = "individual")]
-        enum Sensor {
+        enum SensorInd {
             #[mapping(endpoint = "/%{param}/luminosity")]
             Luminosity(i32),
             #[mapping(endpoint = "/sensor/temperature")]
             Temperature(f64),
         }
 
-        let event = DeviceEvent {
-            interface: "com.example.Sensor".to_string(),
-            path: "/sensor/luminosity".to_string(),
-            data: Value::Individual {
-                data: 42i32.into(),
-                timestamp: Utc::now(),
-            },
-        };
+        #[test]
+        fn should_derive_form_event_individual() {
+            let event = DeviceEvent {
+                interface: "com.example.Sensor".to_string(),
+                path: "/sensor/luminosity".to_string(),
+                data: Value::Individual {
+                    data: 42i32.into(),
+                    timestamp: Utc::now(),
+                },
+            };
 
-        let luminosity = Sensor::from_event(event).expect("couldn't parse the event");
+            let luminosity = SensorInd::from_event(event).expect("couldn't parse the event");
 
-        let expected = Sensor::Luminosity(42);
+            let expected = SensorInd::Luminosity(42);
 
-        assert_eq!(luminosity, expected);
+            assert_eq!(luminosity, expected);
 
-        let event = DeviceEvent {
-            interface: "com.example.Sensor".to_string(),
-            path: "/sensor/temperature".to_string(),
-            data: Value::Individual {
-                data: AstarteData::try_from(3.0).unwrap(),
-                timestamp: Utc::now(),
-            },
-        };
+            let event = DeviceEvent {
+                interface: "com.example.Sensor".to_string(),
+                path: "/sensor/temperature".to_string(),
+                data: Value::Individual {
+                    data: AstarteData::try_from(3.0).unwrap(),
+                    timestamp: Utc::now(),
+                },
+            };
 
-        let temperature = Sensor::from_event(event).expect("couldn't parse the event");
+            let temperature = SensorInd::from_event(event).expect("couldn't parse the event");
 
-        let expected = Sensor::Temperature(3.);
+            let expected = SensorInd::Temperature(3.);
 
-        assert_eq!(temperature, expected);
-    }
-
-    #[test]
-    #[cfg(feature = "derive")]
-    fn should_derive_form_event_property() {
-        use crate::{AstarteData, DeviceEvent, FromEvent, Value};
-
-        // Alias the crate to the resulting macro
-        use crate::{self as astarte_device_sdk};
+            assert_eq!(temperature, expected);
+        }
 
         #[derive(Debug, FromEvent, PartialEq)]
         #[from_event(interface = "com.example.Sensor", interface_type = "properties")]
-        enum Sensor {
+        enum SensorProp {
             #[mapping(endpoint = "/%{param}/luminosity")]
             Luminosity(i32),
             #[mapping(endpoint = "/sensor/temperature")]
@@ -348,52 +404,29 @@ mod tests {
             Unsettable(Option<bool>),
         }
 
-        let event = DeviceEvent {
-            interface: "com.example.Sensor".to_string(),
-            path: "/sensor/luminosity".to_string(),
-            data: Value::Property(Some(42i32.into())),
-        };
+        #[rstest::rstest]
+        #[case("/sensor/luminosity", Some(42i32.into()), SensorProp::Luminosity(42))]
+        #[case("/sensor/temperature", Some(AstarteData::try_from(3.0).unwrap()), SensorProp::Temperature(3.0))]
+        #[case(
+            "/sensor/unsettable",
+            Some(AstarteData::Boolean(true)),
+            SensorProp::Unsettable(Some(true))
+        )]
+        #[case("/sensor/unsettable", None, SensorProp::Unsettable(None))]
+        fn should_derive_form_event_property(
+            #[case] path: &str,
+            #[case] value: Option<AstarteData>,
+            #[case] exp: SensorProp,
+        ) {
+            let event = DeviceEvent {
+                interface: "com.example.Sensor".to_string(),
+                path: path.to_string(),
+                data: Value::Property(value),
+            };
 
-        let luminosity = Sensor::from_event(event).expect("couldn't parse the event");
+            let sensor = SensorProp::from_event(event).expect("couldn't parse the event");
 
-        let expected = Sensor::Luminosity(42);
-
-        assert_eq!(luminosity, expected);
-
-        let event = DeviceEvent {
-            interface: "com.example.Sensor".to_string(),
-            path: "/sensor/temperature".to_string(),
-            data: Value::Property(Some(AstarteData::try_from(3.0).unwrap())),
-        };
-
-        let temperature = Sensor::from_event(event).expect("couldn't parse the event");
-
-        let expected = Sensor::Temperature(3.0);
-
-        assert_eq!(temperature, expected);
-
-        let event = DeviceEvent {
-            interface: "com.example.Sensor".to_string(),
-            path: "/sensor/unsettable".to_string(),
-            data: Value::Property(Some(AstarteData::Boolean(true))),
-        };
-
-        let temperature = Sensor::from_event(event).expect("couldn't parse the event");
-
-        let expected = Sensor::Unsettable(Some(true));
-
-        assert_eq!(temperature, expected);
-
-        let event = DeviceEvent {
-            interface: "com.example.Sensor".to_string(),
-            path: "/sensor/unsettable".to_string(),
-            data: Value::Property(None),
-        };
-
-        let temperature = Sensor::from_event(event).expect("couldn't parse the event");
-
-        let expected = Sensor::Unsettable(None);
-
-        assert_eq!(temperature, expected);
+            assert_eq!(sensor, exp);
+        }
     }
 }


### PR DESCRIPTION
Make all the object fields `Option` by default in the FromEvent macro, and add the `#[mapping(required)]` attribute to mark them as required.

This change better reflects the behavior of the Astarte Interface schema.