### PR TITLE
feat(sqlite): run PRAGMA optimize at startup

### DIFF
--- a/src/store/sqlite/connection.rs
+++ b/src/store/sqlite/connection.rs
@@ -204,6 +204,11 @@ impl SqliteConnection for WriteConnection {
 
         connection.apply_pragmas(options)?;
 
+        // See: https://sqlite.org/pragma.html#pragma_optimize
+        connection
+            .execute("PRAGMA optimize=0x10002", [])
+            .wrap_err_msg(SqliteError::Option, "running pragma optimize")?;
+
         Ok(connection)
     }
 


### PR DESCRIPTION
The first time we open a write connection we run PRAGMA optimize on the database. This will optimize the database and generate statistics on the tables with `ANALYZE`.

This runs only the first time during startup and will scan all the tables, another approach would be before closing the connection. But we don't know how lont that would take.

Another options is scan the tables after an interval (daily) to keep the statistics up to date.