### PR TITLE
refactor(tls): update the insecure tls verifier

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -21,7 +21,7 @@ description: "Install dependencies needed to run the jobs"
 inputs:
   for-image:
     description: Image the job is running on
-    default: "ubuntu-24.04"
+    default: "ubuntu-26.04"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
   multi-platform:
     uses: ./.github/workflows/multi-platform.yaml
   check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -30,7 +30,7 @@ env:
 jobs:
   check-copyright:
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       BASE_REF: ${{ github.event.pull_request.base.sha }}
       HEAD_REF: ${{ github.event.pull_request.head.sha }}
@@ -43,7 +43,7 @@ jobs:
           ./scripts/ci/add-copyright-to-modified.sh "$BASE_REF" "$HEAD_REF"
           git diff --exit-code --name-only
   conventional-commit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -37,7 +37,7 @@ env:
   GH_TOKEN: ${{ github.token }}
 jobs:
   check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - run: echo 'Checking DCO status for PR \#'${{ inputs.pr }}''
       - name: check DCO passed

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,7 +1,6 @@
-#
 # This file is part of Astarte.
 #
-# Copyright 2025 SECO Mind Srl
+# Copyright 2025, 2026 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
 name: docs
 
@@ -36,7 +34,7 @@ concurrency:
 
 jobs:
   latest-release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       GH_TOKEN: ${{ github.token }}
       CURRENT_RELEASE: ${{ github.event.release.tag_name }}
@@ -55,12 +53,12 @@ jobs:
             echo "RESULT=FAILED" >> "$GITHUB_OUTPUT"
           fi
   push-get-started:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: latest-release
     if: needs.latest-release.outputs.RESULT == 'OK'
     env:
-      OUR_FILE: 'docs/get-started.md'
-      THEIR_FILE: './sdk-doc/source/get_started/rust.md'
+      OUR_FILE: "docs/get-started.md"
+      THEIR_FILE: "./sdk-doc/source/get_started/rust.md"
     steps:
       # clone the astarte-device-sdk repo
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -37,7 +37,7 @@ env:
   EXPORT_FOR_CI: "true"
 jobs:
   e2e-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,7 @@ jobs:
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: ${{ github.repository_owner == 'astarte-platform' }}
     permissions:
       contents: write
@@ -76,7 +76,7 @@ jobs:
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
     name: Release-plz PR
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: ${{ github.repository_owner == "astarte-platform" }}
     permissions:
       contents: write

--- a/astarte-device-tls/src/insecure.rs
+++ b/astarte-device-tls/src/insecure.rs
@@ -21,8 +21,10 @@
 use std::sync::Arc;
 
 use rustls::client::WantsClientCert;
-use rustls::crypto::CryptoProvider;
-use rustls::{ClientConfig, ConfigBuilder, Error};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::{CryptoProvider, verify_tls12_signature, verify_tls13_signature};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, ConfigBuilder, DigitallySignedStruct, Error, SignatureScheme};
 use tracing::instrument;
 
 /// Insecure configuration builder.
@@ -38,63 +40,76 @@ pub fn builder() -> Result<ConfigBuilder<ClientConfig, WantsClientCert>, Error> 
         .cloned()
         .unwrap_or_else(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
 
-    let builder = rustls::ClientConfig::builder_with_provider(provider)
-        .with_protocol_versions(rustls::ALL_VERSIONS)?
+    let builder = rustls::ClientConfig::builder()
         .dangerous()
-        .with_custom_certificate_verifier(Arc::new(NoVerifier {}));
+        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification(provider)));
 
     Ok(builder)
 }
 
-/// Verifier that doesn't verify the certificate
-#[derive(Debug)]
-struct NoVerifier;
+pub fn insecure() -> Result<ClientConfig, Error> {
+    // This step is to ensure a CryptoProvider is configured also in the tests.
+    let provider = CryptoProvider::get_default()
+        .map(Arc::clone)
+        .unwrap_or_else(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
 
-impl rustls::client::danger::ServerCertVerifier for NoVerifier {
+    Ok(ClientConfig::builder_with_provider(provider.clone())
+        .with_safe_default_protocol_versions()?
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification::new(provider)))
+        .with_no_client_auth())
+}
+
+#[derive(Debug)]
+pub struct NoCertificateVerification(Arc<CryptoProvider>);
+
+impl NoCertificateVerification {
+    pub fn new(provider: Arc<CryptoProvider>) -> Self {
+        Self(provider)
+    }
+}
+
+impl ServerCertVerifier for NoCertificateVerification {
     fn verify_server_cert(
         &self,
-        _end_entity: &rustls::pki_types::CertificateDer<'_>,
-        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
-        _server_name: &rustls::pki_types::ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: rustls::pki_types::UnixTime,
-    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        Ok(rustls::client::danger::ServerCertVerified::assertion())
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, Error> {
+        Ok(ServerCertVerified::assertion())
     }
 
     fn verify_tls12_signature(
         &self,
-        _message: &[u8],
-        _cert: &rustls::pki_types::CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
     }
 
     fn verify_tls13_signature(
         &self,
-        _message: &[u8],
-        _cert: &rustls::pki_types::CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
     }
 
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        vec![
-            rustls::SignatureScheme::RSA_PKCS1_SHA1,
-            rustls::SignatureScheme::ECDSA_SHA1_Legacy,
-            rustls::SignatureScheme::RSA_PKCS1_SHA256,
-            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
-            rustls::SignatureScheme::RSA_PKCS1_SHA384,
-            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
-            rustls::SignatureScheme::RSA_PKCS1_SHA512,
-            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
-            rustls::SignatureScheme::RSA_PSS_SHA256,
-            rustls::SignatureScheme::RSA_PSS_SHA384,
-            rustls::SignatureScheme::RSA_PSS_SHA512,
-            rustls::SignatureScheme::ED25519,
-            rustls::SignatureScheme::ED448,
-        ]
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
     }
 }

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -74,7 +74,12 @@ gethtml_wrapper() {
 
 crate="astarte-device-sdk"
 
+# Clean up old coverage artifacts
+rm -rf "$CARGO_TARGET_DIR/lcov" || true
+cargo llvm-cov clean || true
+
 if [[ -n "${EXPORT_FOR_CI:-}" ]]; then
+    rm "$PWD/coverage-$crate.info" || true
     out_path="$PWD/coverage-$crate.info"
 else
     mkdir -p "$CARGO_TARGET_DIR/lcov"


### PR DESCRIPTION
Port the example from the rustls repository for the insecure tls verifier.

This verifier will accept any certificate, but actualy check the other parts of the TLS protocol. Instead of returning an assert directly.