### PR TITLE
feat(derive): add required to IntoAstarteObject

### DIFF
--- a/astarte-device-sdk-derive/src/lib.rs
+++ b/astarte-device-sdk-derive/src/lib.rs
@@ -70,7 +70,7 @@ impl ObjectDerive {
                 "enum",
                 &"object must be astruct",
             )
-            .with_span(&self.ident));
+                .with_span(&self.ident));
         };
 
         let mut errors = darling::Error::accumulator();
@@ -84,20 +84,41 @@ impl ObjectDerive {
                             .with_span(&self.ident)
                     ))
                     .map(|(field_i, field_n)| {
-                        if field.fallible {
+                        // Value comes from the other quotes
+                        let conversion = if field.fallible {
                             quote_spanned! {field_i.span() =>
-                                let v: astarte_device_sdk::types::AstarteData = ::std::convert::TryInto::try_into(value.#field_i)?;
-                                object.insert(#field_n.to_string(), v);
+                                { 
+                                    let res: Result<
+                                        astarte_device_sdk::types::AstarteData,
+                                        astarte_device_sdk::astarte_device_error::Error<astarte_device_sdk::types::TypeError>
+                                    > = ::std::convert::TryInto::try_into(value); 
+
+                                    res?
+                                }
                             }
                         } else {
                             quote_spanned! {field_i.span() =>
-                                let v: astarte_device_sdk::types::AstarteData = ::std::convert::Into::into(value.#field_i);
-                                object.insert(#field_n.to_string(), v);
+                                ::std::convert::Into::<astarte_device_sdk::types::AstarteData>::into(value)
+                            }
+                        };
+
+                        if field.required {
+                            quote_spanned! {field_i.span() =>
+                                object.insert(#field_n.to_string(), {
+                                    let value = value.#field_i;
+
+                                    #conversion
+                                });
+                            }
+                        } else {
+                            quote_spanned! {field_i.span() => 
+                                if let Some(value) = value.#field_i {
+                                    object.insert(#field_n.to_string(), #conversion);
+                                }
                             }
                         }
-
                     })
-            }).collect::<Vec<_>>();
+            }).collect::<Vec<proc_macro2::TokenStream>>();
 
         errors.finish()?;
 
@@ -141,6 +162,9 @@ struct ObjectField {
     /// Use a fallible conversion.
     #[darling(default)]
     fallible: bool,
+    /// Use a fallible conversion.
+    #[darling(default = || true)]
+    required: bool,
     /// Name of the field
     ident: Option<syn::Ident>,
 }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -238,32 +238,48 @@ mod tests {
     }
 
     #[cfg(feature = "derive")]
-    #[test]
-    fn should_implement() {
+    mod derive {
         use crate as astarte_device_sdk;
+        use crate::AstarteData;
+        use crate::aggregate::AstarteObject;
         use astarte_device_sdk_derive::IntoAstarteObject;
+        use pretty_assertions::assert_eq;
 
-        #[derive(IntoAstarteObject)]
-        #[astarte_object(rename_all = "camelCase")]
-        struct Foo {
-            #[astarte_object(rename = "some")]
-            bar: String,
-            #[astarte_object(fallible)]
-            try_from: f64,
+        #[test]
+        fn should_implement() {
+            #[derive(IntoAstarteObject)]
+            #[astarte_object(rename_all = "camelCase")]
+            struct Foo {
+                #[astarte_object(rename = "some")]
+                bar: String,
+                #[astarte_object(fallible)]
+                try_from: f64,
+                #[astarte_object(required = false)]
+                optional: Option<i32>,
+                #[astarte_object(fallible, required = false)]
+                optional_fallible: Option<f64>,
+            }
+
+            let val = Foo {
+                bar: "some".to_string(),
+                try_from: 42.,
+                optional: Some(42),
+                optional_fallible: Some(42.0),
+            };
+
+            let res = AstarteObject::try_from(val).unwrap();
+
+            let obj = AstarteObject::from_iter([
+                ("some".to_string(), AstarteData::String("some".to_string())),
+                ("tryFrom".to_string(), AstarteData::try_from(42f64).unwrap()),
+                ("optional".to_string(), AstarteData::Integer(42)),
+                (
+                    "optionalFallible".to_string(),
+                    AstarteData::try_from(42.0).unwrap(),
+                ),
+            ]);
+
+            assert_eq!(res, obj)
         }
-
-        let val = Foo {
-            bar: "some".to_string(),
-            try_from: 42.,
-        };
-
-        let res = AstarteObject::try_from(val).unwrap();
-
-        let obj = AstarteObject::from_iter([
-            ("some".to_string(), AstarteData::String("some".to_string())),
-            ("tryFrom".to_string(), AstarteData::try_from(42f64).unwrap()),
-        ]);
-
-        assert_eq!(res, obj)
     }
 }


### PR DESCRIPTION
Make it possibile to pass optional values to the derive macro.