### PR TITLE
ci(publish): fix if condition for job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -51,7 +51,7 @@ jobs:
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-26.04
-    if: ${{ github.repository_owner == 'astarte-platform' }}
+    if: github.repository_owner == 'astarte-platform'
     permissions:
       contents: write
       id-token: write
@@ -77,7 +77,7 @@ jobs:
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-26.04
-    if: ${{ github.repository_owner == "astarte-platform" }}
+    if: github.repository_owner == 'astarte-platform'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Re-reading the workflows syntax the if condition doesn't require template substitiution and uses `'` and not `"`. So we copied their example since the action has been failing.